### PR TITLE
Prompt Customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Options:
   --pass TEXT          Password to connect to the database
   -v, --version        Version of mycli.
   -D, --database TEXT  Database to use.
-  -R, --prompt TEXT    Prompt format (Default: "\u@\h:\d> ")
+  -R, --prompt TEXT    Prompt format (Default: "\t \u@\h:\d> ")
   --help               Show this message and exit.
 ```
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -411,6 +411,7 @@ class MyCli(object):
         string = string.replace('\\u', sqlexecute.user or '(none)')
         string = string.replace('\\h', sqlexecute.host or '(none)')
         string = string.replace('\\d', sqlexecute.dbname or '(none)')
+        string = string.replace('\\t', sqlexecute.server_type()[0] or 'mycli')
         return string
 
 @click.command()
@@ -426,7 +427,7 @@ class MyCli(object):
         help='Password to connect to the database')
 @click.option('-v', '--version', is_flag=True, help='Version of mycli.')
 @click.option('-D', '--database', 'dbname', help='Database to use.')
-@click.option('-R', '--prompt', 'prompt', help='Prompt format (Default: "\\u@\\h:\\d> ")', default='\\u@\\h:\\d> ')
+@click.option('-R', '--prompt', 'prompt', help='Prompt format (Default: "\\t \\u@\\h:\\d> ")', default='\\t \\u@\\h:\\d> ')
 @click.argument('database', default='', nargs=1)
 def cli(database, user, host, port, socket, password, prompt_passwd, dbname,
         version, prompt):


### PR DESCRIPTION
This is my attempt at implementing #48.  I'm very new to python so please critique.

![image](http://i.imgur.com/6XpOuej.png)

The prompt by default is `user@host [dbname]>`, but you can create your own PS1 using the `--prompt` option.

What's still missing is changing the prompt during runtime.  I'm not sure how to add commands nor what the best practice is here.  Timing uses a global variable so I suppose that would be the way to do it.
