### PR TITLE
command line host or port have priority over socket

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -175,10 +175,13 @@ class MyCli(object):
         # Fall back to config values only if user did not specify a value.
 
         database = database or c_database
+        if port or host:
+            socket = ''
+        else:
+            socket = socket or c_socket
         user = user or c_user or os.getenv('USER')
         host = host or c_host or 'localhost'
         port = int(port or c_port or os.getenv('MYSQL_TCP_PORT') or 3306)
-        socket = socket or c_socket
         passwd = passwd or c_password
         charset = charset or c_charset or 'utf8'
 


### PR DESCRIPTION
Need to remove socket setting because PyMysql will prefer socket if specified. If we specify host or port then we mean tcp right?

closes #63
