### PR TITLE
mark connection as interactive

### DIFF
--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -56,7 +56,8 @@ class SQLExecute(object):
             '\tsocket: %r', database, user, host, port, socket)
         conn = pymysql.connect(database=db, user=user, password=password,
                 host=host, port=port, unix_socket=socket,
-                use_unicode=True, charset=charset, autocommit=True)
+                use_unicode=True, charset=charset, autocommit=True,
+                client_flag=pymysql.constants.CLIENT.INTERACTIVE)
         if hasattr(self, 'conn'):
             self.conn.close()
         self.conn = conn


### PR DESCRIPTION
probably the reason so many disconnects are happening is that the connection isn't marked as interactive.

A different wait_timeout applies on interactive sessions
https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_wait_timeout
