### PR TITLE
Sets click minimum version to 4.1. Fixes #34.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         description=description,
         long_description=open('README.md').read(),
         install_requires=[
-            'click >= 3.2',
+            'click >= 4.1',
             'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
             'prompt_toolkit==0.38',
             'PyMySQL',


### PR DESCRIPTION
This fixes issue #34. It looks like click recently released version 4.1 to PyPi, so the bug should be fixed.
