### PR TITLE
Fixes file() overwrite

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -145,13 +145,12 @@ class MyCli(object):
         values.
         """
         cnf = ConfigObj()
-        for file in files:
+        for _file in files:
             try:
-                cnf.merge(ConfigObj(os.path.expanduser(file),
+                cnf.merge(ConfigObj(os.path.expanduser(_file),
                     interpolation=False))
             except ConfigObjError as e:
-                self.logger.error('Error parsing %r.',
-                        file)
+                self.logger.error('Error parsing %r.', _file)
                 self.logger.error('Recovering partially parsed config values.')
                 cnf.merge(e.config)
                 pass


### PR DESCRIPTION
In `main.py` there is a for loop that goes like this:

``` python
for file in files:
    [...]
```

While it doesn't affect mycli, the `file` variable is overwriting the [built-in `file()` function](https://docs.python.org/2/library/functions.html?highlight=file#file). This pull request changes it to `_file`.
