### PR TITLE
case-insensitive fuzzy autocomplete

### DIFF
--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -211,7 +211,7 @@ class SQLCompleter(Completer):
             regex = '.*?'.join(map(escape, text))
             pat = compile('(%s)' % regex)
             for item in sorted(collection):
-                r = pat.search(item)
+                r = pat.search(item.lower())
                 if r:
                     completions.append((len(r.group()), r.start(), item))
         else:


### PR DESCRIPTION
Fuzzy autocomplete was not working for objects with capitalized names. Converting the collection item (e.g. db name or table name) to lower case allows case-insensitive regex matching.