### PR TITLE
upgrade prompt_toolkit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         install_requires=[
             'click >= 4.1',
             'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
-            'prompt_toolkit==0.38',
+            'prompt_toolkit==0.42',
             'PyMySQL >= 0.6.6',
             'sqlparse == 0.1.14',
             'six >= 1.8',


### PR DESCRIPTION
If installed pgcli, mycli doesn't work because the version of prompt_toolkit is older than pgcli's one.