### PR TITLE
Add testing option for doctest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,2 @@
+# https://pytest.org/latest/example/pythoncollection.html
+collect_ignore = ["setup.py"]

--- a/mycli/packages/counter.py
+++ b/mycli/packages/counter.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from operator import itemgetter
 from heapq import nlargest
 from itertools import repeat, ifilter
@@ -186,4 +187,4 @@ class Counter(dict):
 
 if __name__ == '__main__':
     import doctest
-    print doctest.testmod()
+    print(doctest.testmod())

--- a/mycli/packages/parseutils.py
+++ b/mycli/packages/parseutils.py
@@ -7,10 +7,10 @@ from sqlparse.tokens import Keyword, DML, Punctuation
 cleanup_regex = {
         # This matches only alphanumerics and underscores.
         'alphanum_underscore': re.compile(r'(\w+)$'),
-        # This matches everything except spaces, parens, and comma
-        'many_punctuations': re.compile(r'([^(),\s]+)$'),
-        # This matches everything except spaces, parens, comma, and period
-        'most_punctuations': re.compile(r'([^\.(),\s]+)$'),
+        # This matches everything except spaces, parens, colon, and comma
+        'many_punctuations': re.compile(r'([^():,\s]+)$'),
+        # This matches everything except spaces, parens, colon, comma, and period
+        'most_punctuations': re.compile(r'([^\.():,\s]+)$'),
         # This matches everything except a space.
         'all_punctuations': re.compile('([^\s]+)$'),
         }
@@ -37,12 +37,14 @@ def last_word(text, include='alphanum_underscore'):
     ''
     >>> last_word('bac $def')
     'def'
-    >>> last_word('bac $def', True)
+    >>> last_word('bac $def', include='most_punctuations')
     '$def'
-    >>> last_word('bac \def', True)
+    >>> last_word('bac \def', include='most_punctuations')
     '\\\\def'
-    >>> last_word('bac \def;', True)
+    >>> last_word('bac \def;', include='most_punctuations')
     '\\\\def;'
+    >>> last_word('bac::def', include='most_punctuations')
+    'def'
     """
 
     if not text:   # Empty string

--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,4 @@ envlist = py26, py27, py33, py34
 [testenv]
 deps = pytest
     mock
-commands = py.test
+commands = py.test --doctest-modules --doctest-ignore-import-errors


### PR DESCRIPTION
## current (without doctest options)
```
 % py.test
collected 147 items
...
145 passed, 1 xfailed, 1 xpassed in 0.38 seconds
```

## with doctest options
```
% py.test --doctest-modules --doctest-ignore-import-errors
collected 160 items / 2 skipped
...
158 passed, 2 skipped, 1 xfailed, 1 xpassed in 0.40 seconds
```