### PR TITLE
Add "delete" and "truncate" as destructive commands

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -660,7 +660,7 @@ def confirm_destructive_query(queries):
     True if the query is destructive and the user wants to proceed.
     False if the query is destructive and the user doesn't want to proceed.
     """
-    destructive = set(['drop', 'shutdown'])
+    destructive = set(['drop', 'shutdown', 'delete', 'truncate'])
     queries = queries.strip()
     for query in sqlparse.split(queries):
         try:


### PR DESCRIPTION
After doing a DELETE without a WHERE (I *thought* multiline was on, but my quick glance at the bottom of the screen was wrong) I thought it might actually be nice to have DELETE and TRUNCATE give a warning.