### PR TITLE
Upgrade prompt_toolkit to 0.52.

### DIFF
--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -14,6 +14,8 @@ def mycli_bindings(get_key_bindings, set_key_bindings):
     key_binding_manager = KeyBindingManager(
             enable_open_in_editor=True,
             enable_system_bindings=True,
+            enable_search=True,
+            enable_abort_and_exit_bindings=True,
             enable_vi_mode=Condition(lambda cli: get_key_bindings() == 'vi'))
 
     @key_binding_manager.registry.add_binding(Keys.F2)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -362,7 +362,7 @@ class MyCli(object):
                                   key_bindings_registry=key_binding_manager.registry,
                                   on_exit=AbortAction.RAISE_EXCEPTION,
                                   on_abort=AbortAction.RETRY,
-                                  mouse_support=True,
+                                  mouse_support=False,
                                   ignore_case=True)
         cli = CommandLineInterface(application=application, eventloop=create_eventloop())
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -16,8 +16,10 @@ import sqlparse
 from prompt_toolkit import CommandLineInterface, Application, AbortAction
 from prompt_toolkit.enums import DEFAULT_BUFFER
 from prompt_toolkit.shortcuts import create_default_layout, create_eventloop
+from prompt_toolkit.buffer import AcceptAction
 from prompt_toolkit.document import Document
 from prompt_toolkit.filters import Always, HasFocus, IsDone
+from prompt_toolkit.layout.lexers import PygmentsLexer
 from prompt_toolkit.layout.processors import (HighlightMatchingBracketProcessor,
                                               ConditionalProcessor)
 from prompt_toolkit.history import FileHistory
@@ -339,7 +341,7 @@ class MyCli(object):
             return [(Token.Prompt, self.get_prompt(self.prompt_format))]
 
         get_toolbar_tokens = create_toolbar_tokens_func(lambda: self.key_bindings)
-        layout = create_default_layout(lexer=MyCliLexer,
+        layout = create_default_layout(lexer=PygmentsLexer(MyCliLexer),
                                        reserve_space_for_menu=True,
                                        multiline=True,
                                        get_prompt_tokens=prompt_tokens,
@@ -352,12 +354,15 @@ class MyCli(object):
                                        ])
         buf = CLIBuffer(always_multiline=self.multi_line, completer=completer,
                 history=FileHistory(os.path.expanduser('~/.mycli-history')),
-                complete_while_typing=Always())
+                complete_while_typing=Always(),
+                accept_action=AcceptAction.RETURN_DOCUMENT)
 
         application = Application(style=style_factory(self.syntax_style, self.cli_style),
                                   layout=layout, buffer=buf,
                                   key_bindings_registry=key_binding_manager.registry,
                                   on_exit=AbortAction.RAISE_EXCEPTION,
+                                  on_abort=AbortAction.RETRY,
+                                  mouse_support=True,
                                   ignore_case=True)
         cli = CommandLineInterface(application=application, eventloop=create_eventloop())
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         install_requires=[
             'click >= 4.1',
             'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
-            'prompt_toolkit==0.46',
+            'prompt_toolkit==0.52',
             'PyMySQL >= 0.6.2',
             'sqlparse >= 0.1.16',
             'configobj >= 5.0.6',


### PR DESCRIPTION
@tsroten Can you please review and merge? 

There is no hurry. I understand you're moving this weekend so no need to rush this, take your time. 

One new feature is the enabling of mouse support. You can now click on the query to move the cursor there. So if you're writing a long multi-line query you can click anywhere in the query to jump to that position.

Click and drag will select portions of the query, but they're a bit laggy.

My suggestion is to install this branch and try a lot of the features, such as keybindings (F3, F2 etc), check syntax coloring, try out the multi-line mode, prompts, different color schemes etc.

If you have access to a windows machine try it there, otherwise I'll try to get a Windows VM running today. 

/cc @jonathanslenders 