### PR TITLE
Fixes #23 -- Makes "enter" key function as the "tab" key only when the completion menu is displayed.

### DIFF
--- a/mycli/filters.py
+++ b/mycli/filters.py
@@ -1,0 +1,12 @@
+from prompt_toolkit.filters import Filter
+
+class HasSelectedCompletion(Filter):
+    """Enable when the current buffer has a selected completion."""
+
+    def __call__(self, cli):
+        complete_state = cli.current_buffer.complete_state
+        return (complete_state is not None and
+                 complete_state.current_completion is not None)
+
+    def __repr__(self):
+        return "HasSelectedCompletion()"

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -75,4 +75,19 @@ def mycli_bindings(get_key_bindings, set_key_bindings):
         else:
             event.cli.start_completion(select_first=False)
 
+
+    @key_binding_manager.registry.add_binding(Keys.ControlJ)
+    def _(event):
+        """
+        This sould only be activated if the config 'use_enter_key_as_tab'
+        is activated. The enter key's behaviour should be attributed to another
+        key, for example: C-M.
+        """
+        _logger.debug('Detected <C-J> key.')
+        b = event.cli.current_buffer
+        if b.complete_state:
+            b.complete_next()
+        else:
+            event.cli.start_completion(select_first=True)
+
     return key_binding_manager

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -1,9 +1,11 @@
 import logging
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.key_binding.manager import KeyBindingManager
-from prompt_toolkit.filters import Condition, HasCompletions
+from prompt_toolkit.filters import Condition
+from .filters import HasSelectedCompletion
 
 _logger = logging.getLogger(__name__)
+
 
 def mycli_bindings(get_key_bindings, set_key_bindings):
     """
@@ -11,6 +13,7 @@ def mycli_bindings(get_key_bindings, set_key_bindings):
     """
     assert callable(get_key_bindings)
     assert callable(set_key_bindings)
+
     key_binding_manager = KeyBindingManager(
             enable_open_in_editor=True,
             enable_system_bindings=True,
@@ -75,12 +78,13 @@ def mycli_bindings(get_key_bindings, set_key_bindings):
         else:
             event.cli.start_completion(select_first=False)
 
-    @key_binding_manager.registry.add_binding(Keys.ControlJ, filter=HasCompletions())
+    @key_binding_manager.registry.add_binding(Keys.ControlJ, filter=HasSelectedCompletion())
     def _(event):
         """
         Makes the enter key work as the tab key only when showing the menu.
         """
         _logger.debug('Detected <C-J> key.')
+
         event.current_buffer.complete_state = None
         b = event.cli.current_buffer
         b.complete_state = None

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -78,9 +78,7 @@ def mycli_bindings(get_key_bindings, set_key_bindings):
     @key_binding_manager.registry.add_binding(Keys.ControlJ, filter=HasCompletions())
     def _(event):
         """
-        This sould only be activated if the config 'use_enter_key_as_tab'
-        is activated. The enter key's behaviour should be attributed to another
-        key, for example: C-M.
+        Makes the enter key work as the tab key only when showing the menu.
         """
         _logger.debug('Detected <C-J> key.')
         event.current_buffer.complete_state = None

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -41,11 +41,8 @@ syntax_style = default
 # When Vi mode is enabled you can use modal editing features offered by Vi in the REPL.
 key_bindings = emacs
 
-# Enabling this option will show the suggestions in a wider menu. Thus more items are suggested. 
+# Enabling this option will show the suggestions in a wider menu. Thus more items are suggested.
 wider_completion_menu = False
-
-# Enabling this option will make the `enter key` behave like the `tab key`. Default: False.
-use_enter_key_as_tab = False
 
 # MySQL prompt
 # \t - Product type (Percona, MySQL, Mariadb)
@@ -55,7 +52,7 @@ use_enter_key_as_tab = False
 # \n - Newline
 prompt = '\t \u@\h:\d> '
 
-# Custom colors for the completion menu, toolbar, etc. 
+# Custom colors for the completion menu, toolbar, etc.
 [colors]
 # Completion menus.
 Token.Menu.Completions.Completion.Current = 'bg:#00aaaa #000000'

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -44,6 +44,9 @@ key_bindings = emacs
 # Enabling this option will show the suggestions in a wider menu. Thus more items are suggested. 
 wider_completion_menu = False
 
+# Enabling this option will make the `enter key` behave like the `tab key`. Default: False.
+use_enter_key_as_tab = False
+
 # MySQL prompt
 # \t - Product type (Percona, MySQL, Mariadb)
 # \u - Username


### PR DESCRIPTION
New users get frustrated when they select a SQL command, press `Enter` and the command gets executed. So this PR makes the enter key work like the tab, but only when the completion menu is visible.

Fixes #23. 