### PR TITLE
Add support for the system command

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -139,6 +139,8 @@ class MyCli(object):
                 '\\T', 'Change Table Type.', aliases=('\\T',), case_sensitive=True)
         special.register_special_command(self.execute_from_file, 'source', '\\. filename',
                               'Execute commands from file.', aliases=('\\.',))
+        special.register_special_command(self.execute_system_command, 'system',
+                    '\\s', 'Execute a system command.', aliases=('\\s',))
 
     def change_table_format(self, arg, **_):
         if not arg in table_formats():

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -6,6 +6,7 @@ import os
 import sys
 import traceback
 import logging
+import subprocess
 from time import time
 from datetime import datetime
 from random import choice
@@ -169,6 +170,12 @@ class MyCli(object):
             return [(None, None, None, str(e))]
 
         return self.sqlexecute.run(query)
+
+    def execute_system_command(self, arg, **_):
+          if not arg:
+              message = 'Missing required argument: command.'
+              yield(None, None, None, message)
+          yield(None, None, None, subprocess.call(arg, shell=True))
 
     def initialize_logging(self):
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -6,7 +6,6 @@ import os
 import sys
 import traceback
 import logging
-import subprocess
 from time import time
 from datetime import datetime
 from random import choice
@@ -139,8 +138,6 @@ class MyCli(object):
                 '\\T', 'Change Table Type.', aliases=('\\T',), case_sensitive=True)
         special.register_special_command(self.execute_from_file, 'source', '\\. filename',
                               'Execute commands from file.', aliases=('\\.',))
-        special.register_special_command(self.execute_system_command, 'system',
-                    '\\s', 'Execute a system command.', aliases=('\\s',))
 
     def change_table_format(self, arg, **_):
         if not arg in table_formats():
@@ -172,12 +169,6 @@ class MyCli(object):
             return [(None, None, None, str(e))]
 
         return self.sqlexecute.run(query)
-
-    def execute_system_command(self, arg, **_):
-          if not arg:
-              message = 'Missing required argument: command.'
-              yield(None, None, None, message)
-          yield(None, None, None, subprocess.call(arg, shell=True))
 
     def initialize_logging(self):
 

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -208,9 +208,10 @@ def execute_system_command(arg, **_):
     try:
         command = arg.strip()
         if command.startswith('cd'):
-            result, error_message = handle_cd_command(arg)
-            if not result:
+            ok, error_message = handle_cd_command(arg)
+            if not ok:
                 return [(None, None, None, error_message)]
+            return [(None, None, None, '')]
 
         args = arg.split(' ')
         process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -205,14 +205,18 @@ def execute_system_command(arg, **_):
     if not arg:
       return [(None, None, None, usage)]
 
-    output = ''
-
     try:
         command = arg.strip()
         if command.startswith('cd'):
-            output  = handle_cd_command(arg)
-        else:
-            output = subprocess.check_output(arg, stderr=subprocess.STDOUT, shell=True)
-        return [(None, None, None, output)]
-    except subprocess.CalledProcessError as e:
-        return [(None, None, None, e.output)]
+            result, error_message = handle_cd_command(arg)
+            if not result:
+                return [(None, None, None, error_message)]
+
+        args = arg.split(' ')
+        process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output, error = process.communicate()
+        response = output if not error else error
+
+        return [(None, None, None, response)]
+    except OSError as e:
+        return [(None, None, None, 'OSError: %s' % e.strerror)]

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -205,13 +205,12 @@ def execute_system_command(arg, **_):
     if not arg:
       return [(None, None, None, usage)]
 
-    CD_CMD = 'cd'
     output = ''
 
     try:
         command = arg.strip()
-        if command.startswith(CD_CMD):
-            output = handle_cd_command(arg)
+        if command.startswith('cd'):
+            output  = handle_cd_command(arg)
         else:
             output = subprocess.check_output(arg, stderr=subprocess.STDOUT, shell=True)
         return [(None, None, None, output)]

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -214,5 +214,5 @@ def execute_system_command(arg, **_):
         else:
             output = subprocess.check_output(arg, stderr=subprocess.STDOUT, shell=True)
         return [(None, None, None, output)]
-    except subprocess.CalledProcessError, e:
+    except subprocess.CalledProcessError as e:
         return [(None, None, None, e.output)]

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -1,6 +1,7 @@
 import os
 import re
 import logging
+import subprocess
 from io import open
 
 import click
@@ -193,3 +194,12 @@ def delete_favorite_query(arg, **_):
 
     return [(None, None, None, status)]
 
+@special_command('system', 'system [command]', 'Execute a system commmand.')
+def execute_system_command(arg, **_):
+    """
+    Execute a system command.
+    """
+    usage = "Syntax: system command.\n\n "
+    if not arg:
+      return [(None, None, None, usage)]
+    return [(None, None, None, subprocess.call(arg, shell=True))]

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -10,6 +10,7 @@ import sqlparse
 from . import export
 from .main import special_command, NO_QUERY, PARSED_QUERY
 from .favoritequeries import favoritequeries
+from .utils import handle_cd_command
 
 TIMING_ENABLED = False
 use_expanded_output = False
@@ -199,7 +200,20 @@ def execute_system_command(arg, **_):
     """
     Execute a system command.
     """
-    usage = "Syntax: system command.\n\n "
+    usage = "Syntax: system [command].\n"
+
     if not arg:
       return [(None, None, None, usage)]
-    return [(None, None, None, subprocess.call(arg, shell=True))]
+
+    CD_CMD = 'cd'
+    output = ''
+
+    try:
+        command = arg.strip()
+        if command.startswith(CD_CMD):
+            output = handle_cd_command(arg)
+        else:
+            output = subprocess.check_output(arg, stderr=subprocess.STDOUT, shell=True)
+        return [(None, None, None, output)]
+    except subprocess.CalledProcessError, e:
+        return [(None, None, None, e.output)]

--- a/mycli/packages/special/utils.py
+++ b/mycli/packages/special/utils.py
@@ -1,19 +1,26 @@
 import os
+import subprocess
 
 def handle_cd_command(arg):
     """Handles a `cd` shell command by calling python's os.chdir."""
     CD_CMD = 'cd'
     command = arg.strip()
     directory = ''
+    error = False
 
-    if command == CD_CMD:
-        # Treat `cd` as a change to the root directory.
-        # os.path.expanduser does this in a cross platform manner.
-        directory = os.path.expanduser('~')
-    else:
-        tokens = arg.split(CD_CMD + ' ')
-        directory = tokens[-1]
+    tokens = arg.split(CD_CMD + ' ')
+    directory = tokens[-1]
+
     try:
         os.chdir(directory)
+        output = subprocess.check_output('pwd', stderr=subprocess.STDOUT, shell=True)
     except OSError, e:
-        output = e.strerror
+        output, error = e.strerror, True
+
+    # formatting a nice output
+    if error:
+        output = "Error: {}".format(output)
+    else:
+        output = "Current directory: {}".format(output)
+
+    return output

--- a/mycli/packages/special/utils.py
+++ b/mycli/packages/special/utils.py
@@ -1,0 +1,19 @@
+import os
+
+def handle_cd_command(arg):
+    """Handles a `cd` shell command by calling python's os.chdir."""
+    CD_CMD = 'cd'
+    command = arg.strip()
+    directory = ''
+
+    if command == CD_CMD:
+        # Treat `cd` as a change to the root directory.
+        # os.path.expanduser does this in a cross platform manner.
+        directory = os.path.expanduser('~')
+    else:
+        tokens = arg.split(CD_CMD + ' ')
+        directory = tokens[-1]
+    try:
+        os.chdir(directory)
+    except OSError, e:
+        output = e.strerror

--- a/mycli/packages/special/utils.py
+++ b/mycli/packages/special/utils.py
@@ -4,7 +4,6 @@ import subprocess
 def handle_cd_command(arg):
     """Handles a `cd` shell command by calling python's os.chdir."""
     CD_CMD = 'cd'
-    command = arg.strip()
     directory = ''
     error = False
 

--- a/mycli/packages/special/utils.py
+++ b/mycli/packages/special/utils.py
@@ -12,6 +12,7 @@ def handle_cd_command(arg):
 
     try:
         os.chdir(directory)
-        output = subprocess.check_output('pwd', stderr=subprocess.STDOUT, shell=True)
+        subprocess.call(['pwd'])
+        return True, None
     except OSError as e:
         return False, e.strerror

--- a/mycli/packages/special/utils.py
+++ b/mycli/packages/special/utils.py
@@ -14,12 +14,4 @@ def handle_cd_command(arg):
         os.chdir(directory)
         output = subprocess.check_output('pwd', stderr=subprocess.STDOUT, shell=True)
     except OSError as e:
-        output, error = e.strerror, True
-
-    # formatting a nice output
-    if error:
-        output = "Error: {}".format(output)
-    else:
-        output = "Current directory: {}".format(output)
-
-    return output
+        return False, e.strerror

--- a/mycli/packages/special/utils.py
+++ b/mycli/packages/special/utils.py
@@ -4,12 +4,10 @@ import subprocess
 def handle_cd_command(arg):
     """Handles a `cd` shell command by calling python's os.chdir."""
     CD_CMD = 'cd'
-    directory = ''
-    error = False
-
     tokens = arg.split(CD_CMD + ' ')
-    directory = tokens[-1]
-
+    directory = tokens[-1] if len(tokens) > 1 else None
+    if not directory:
+        return False, "No folder name was provided."
     try:
         os.chdir(directory)
         subprocess.call(['pwd'])

--- a/mycli/packages/special/utils.py
+++ b/mycli/packages/special/utils.py
@@ -14,7 +14,7 @@ def handle_cd_command(arg):
     try:
         os.chdir(directory)
         output = subprocess.check_output('pwd', stderr=subprocess.STDOUT, shell=True)
-    except OSError, e:
+    except OSError as e:
         output, error = e.strerror, True
 
     # formatting a nice output

--- a/tests/test.txt
+++ b/tests/test.txt
@@ -1,0 +1,1 @@
+mycli rocks!

--- a/tests/test_sqlexecute.py
+++ b/tests/test_sqlexecute.py
@@ -153,7 +153,7 @@ def test_favorite_query_multiple_statement(executor):
 @dbtest
 def test_special_command(executor):
     results = run(executor, '\\?')
-    expected_line = u'| help      | \\?             | Show this help.                              |\n'
+    expected_line = u'| help      | \\?               | Show this help.                              |\n'
     assert len(results) == 1
     assert expected_line in results[0]
 

--- a/tests/test_sqlexecute.py
+++ b/tests/test_sqlexecute.py
@@ -2,6 +2,7 @@
 
 import pytest
 import pymysql
+import os
 from textwrap import dedent
 from utils import run, dbtest, set_expanded_output
 
@@ -156,6 +157,35 @@ def test_special_command(executor):
     expected_line = u'| help      | \\?               | Show this help.                              |\n'
     assert len(results) == 1
     assert expected_line in results[0]
+
+@dbtest
+def test_cd_command_without_a_folder_name(executor):
+    results = run(executor, 'system cd')
+    expected_line = 'No folder name was provided.'
+    assert len(results) == 1
+    assert expected_line in results[0]
+
+@dbtest
+def test_system_command_not_found(executor):
+    results = run(executor, 'system xyz')
+    assert len(results) == 1
+    expected_line = 'OSError:'
+    assert expected_line in results[0]
+
+@dbtest
+def test_system_command_output(executor):
+    test_file_path = os.path.join(os.path.abspath('.'), 'tests/test.txt')
+    results = run(executor, 'system cat {0}'.format(test_file_path))
+    assert len(results) == 1
+    expected_line = u'mycli rocks!\n'
+    result_str = results[0].decode('utf-8') # python3 returns a bytes-string
+    assert expected_line == result_str
+
+@dbtest
+def test_cd_command_current_dir(executor):
+    tests_path = os.path.join(os.path.abspath('.'), 'tests')
+    results = run(executor, 'system cd {0}'.format(tests_path))
+    assert os.getcwd() == tests_path
 
 @dbtest
 def test_unicode_support(executor):


### PR DESCRIPTION
Fixes #130.

The `system` command is very useful. So what I did was register a "special command" to execute system commands.