### PR TITLE
Amjith/background completion

### DIFF
--- a/mycli/clitoolbar.py
+++ b/mycli/clitoolbar.py
@@ -1,12 +1,12 @@
 from pygments.token import Token
 
-def create_toolbar_tokens_func(get_key_bindings, token=None):
+def create_toolbar_tokens_func(get_key_bindings, get_is_refreshing):
     """
     Return a function that generates the toolbar tokens.
     """
     assert callable(get_key_bindings)
 
-    token = token or Token.Toolbar
+    token = Token.Toolbar
 
     def get_toolbar_tokens(cli):
         result = []
@@ -30,6 +30,9 @@ def create_toolbar_tokens_func(get_key_bindings, token=None):
             result.append((token.On, '[F4] Vi-mode'))
         else:
             result.append((token.On, '[F4] Emacs-mode'))
+
+        if get_is_refreshing():
+            result.append((token, '     Refreshing completions...'))
 
         return result
     return get_toolbar_tokens

--- a/mycli/completion_refresher.py
+++ b/mycli/completion_refresher.py
@@ -1,0 +1,119 @@
+import threading
+from .packages.special.main import COMMANDS
+try:
+    from collections import OrderedDict
+except ImportError:
+    from .packages.ordereddict import OrderedDict
+
+from .sqlcompleter import SQLCompleter
+from .sqlexecute import SQLExecute
+
+class CompletionRefresher(object):
+
+    refreshers = OrderedDict()
+
+    def __init__(self):
+        self._completer_thread = None
+        self._restart_refresh = threading.Event()
+
+    def refresh(self, executor, callbacks):
+        """
+        Creates a SQLCompleter object and populates it with the relevant
+        completion suggestions in a background thread.
+
+        executor - SQLExecute object, used to extract the credentials to connect
+                   to the database.
+        callbacks - A function or a list of functions to call after the thread
+                    has completed the refresh. The newly created completion
+                    object will be passed in as an argument to each callback.
+        """
+        if self.is_refreshing():
+            self._restart_refresh.set()
+            return [(None, None, None, 'Auto-completion refresh restarted.')]
+        else:
+            self._completer_thread = threading.Thread(target=self._bg_refresh,
+                                                      args=(executor, callbacks),
+                                                      name='completion_refresh')
+            self._completer_thread.setDaemon(True)
+            self._completer_thread.start()
+            return [(None, None, None,
+                     'Auto-completion refresh started in the background.')]
+
+    def is_refreshing(self):
+        return self._completer_thread and self._completer_thread.is_alive()
+
+    def _bg_refresh(self, sqlexecute, callbacks):
+        completer = SQLCompleter(smart_completion=True)
+
+        # Create a new pgexecute method to popoulate the completions.
+        e = sqlexecute
+        executor = SQLExecute(e.dbname, e.user, e.password, e.host, e.port,
+                              e.socket, e.charset)
+
+        # If callbacks is a single function then push it into a list.
+        if callable(callbacks):
+            callbacks = [callbacks]
+
+        while 1:
+            for refresher in self.refreshers.values():
+                refresher(completer, executor)
+                if self._restart_refresh.is_set():
+                    self._restart_refresh.clear()
+                    break
+            else:
+                # Break out of while loop if the for loop finishes natually
+                # without hitting the break statement.
+                break
+
+            # Start over the refresh from the beginning if the for loop hit the
+            # break statement.
+            continue
+
+        for callback in callbacks:
+            callback(completer)
+
+def refresher(name, refreshers=CompletionRefresher.refreshers):
+    """Decorator to add the decorated function to the dictionary of
+    refreshers. Any function decorated with a @refresher will be executed as
+    part of the completion refresh routine."""
+    def wrapper(wrapped):
+        refreshers[name] = wrapped
+        return wrapped
+    return wrapper
+
+@refresher('databases')
+def refresh_databases(completer, executor):
+    completer.extend_database_names(executor.databases())
+
+@refresher('schemata')
+def refresh_schemata(completer, executor):
+    # schemata - In MySQL Schema is the same as database. But for mycli
+    # schemata will be the name of the current database.
+    completer.extend_schemata(executor.dbname)
+    completer.set_dbname(executor.dbname)
+
+@refresher('tables')
+def refresh_tables(completer, executor):
+    completer.extend_relations(executor.tables(), kind='tables')
+    completer.extend_columns(executor.table_columns(), kind='tables')
+
+@refresher('users')
+def refresh_users(completer, executor):
+    completer.extend_users(executor.users())
+
+# @refresher('views')
+# def refresh_views(completer, executor):
+#     completer.extend_relations(executor.views(), kind='views')
+#     completer.extend_columns(executor.view_columns(), kind='views')
+
+@refresher('functions')
+def refresh_functions(completer, executor):
+    completer.extend_functions(executor.functions())
+
+@refresher('special_commands')
+def refresh_special(completer, executor):
+    completer.extend_special_commands(COMMANDS.keys())
+
+@refresher('show_commands')
+def refresh_show_commands(completer, executor):
+    completer.extend_show_items(executor.show_candidates())

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -482,9 +482,10 @@ class MyCli(object):
                     if special.is_timing_enabled():
                         self.output('Time: %0.03fs' % total)
 
-                # Refresh the table names and column names if necessary.
-                if need_completion_refresh(document.text):
-                    self.refresh_completions(reset=need_completion_reset(document.text))
+                    # Refresh the table names and column names if necessary.
+                    if need_completion_refresh(document.text):
+                        self.refresh_completions(
+                                reset=need_completion_reset(document.text))
 
                 query = Query(document.text, successful, mutating)
                 self.query_history.append(query)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -635,9 +635,9 @@ def need_completion_refresh(queries):
     for query in sqlparse.split(queries):
         try:
             first_token = query.split()[0]
-            res = first_token.lower() in ('alter', 'create', 'use', '\\r',
-                    '\\u', 'connect', 'drop')
-            return res
+            if first_token.lower() in ('alter', 'create', 'use', '\\r',
+                    '\\u', 'connect', 'drop'):
+                return True
         except Exception:
             return False
 
@@ -649,7 +649,8 @@ def need_completion_reset(queries):
     for query in sqlparse.split(queries):
         try:
             first_token = query.split()[0]
-            return first_token.lower() in ('use', '\\u')
+            if first_token.lower() in ('use', '\\u'):
+                return True
         except Exception:
             return False
 

--- a/mycli/packages/ordereddict.py
+++ b/mycli/packages/ordereddict.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2009 Raymond Hettinger
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+
+from UserDict import DictMixin
+
+class OrderedDict(dict, DictMixin):
+
+    def __init__(self, *args, **kwds):
+        if len(args) > 1:
+            raise TypeError('expected at most 1 arguments, got %d' % len(args))
+        try:
+            self.__end
+        except AttributeError:
+            self.clear()
+        self.update(*args, **kwds)
+
+    def clear(self):
+        self.__end = end = []
+        end += [None, end, end]         # sentinel node for doubly linked list
+        self.__map = {}                 # key --> [key, prev, next]
+        dict.clear(self)
+
+    def __setitem__(self, key, value):
+        if key not in self:
+            end = self.__end
+            curr = end[1]
+            curr[2] = end[1] = self.__map[key] = [key, curr, end]
+        dict.__setitem__(self, key, value)
+
+    def __delitem__(self, key):
+        dict.__delitem__(self, key)
+        key, prev, next = self.__map.pop(key)
+        prev[2] = next
+        next[1] = prev
+
+    def __iter__(self):
+        end = self.__end
+        curr = end[2]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[2]
+
+    def __reversed__(self):
+        end = self.__end
+        curr = end[1]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[1]
+
+    def popitem(self, last=True):
+        if not self:
+            raise KeyError('dictionary is empty')
+        if last:
+            key = reversed(self).next()
+        else:
+            key = iter(self).next()
+        value = self.pop(key)
+        return key, value
+
+    def __reduce__(self):
+        items = [[k, self[k]] for k in self]
+        tmp = self.__map, self.__end
+        del self.__map, self.__end
+        inst_dict = vars(self).copy()
+        self.__map, self.__end = tmp
+        if inst_dict:
+            return (self.__class__, (items,), inst_dict)
+        return self.__class__, (items,)
+
+    def keys(self):
+        return list(self)
+
+    setdefault = DictMixin.setdefault
+    update = DictMixin.update
+    pop = DictMixin.pop
+    values = DictMixin.values
+    items = DictMixin.items
+    iterkeys = DictMixin.iterkeys
+    itervalues = DictMixin.itervalues
+    iteritems = DictMixin.iteritems
+
+    def __repr__(self):
+        if not self:
+            return '%s()' % (self.__class__.__name__,)
+        return '%s(%r)' % (self.__class__.__name__, self.items())
+
+    def copy(self):
+        return self.__class__(self)
+
+    @classmethod
+    def fromkeys(cls, iterable, value=None):
+        d = cls()
+        for key in iterable:
+            d[key] = value
+        return d
+
+    def __eq__(self, other):
+        if isinstance(other, OrderedDict):
+            if len(self) != len(other):
+                return False
+            for p, q in  zip(self.items(), other.items()):
+                if p != q:
+                    return False
+            return True
+        return dict.__eq__(self, other)
+
+    def __ne__(self, other):
+        return not self == other

--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -150,7 +150,7 @@ class SQLCompleter(Completer):
         for relname in data:
             try:
                 metadata[self.dbname][relname[0]] = ['*']
-            except AttributeError:
+            except KeyError:
                 _logger.error('%r %r listed in unrecognized schema %r',
                               kind, relname[0], self.dbname)
             self.all_completions.add(relname[0])

--- a/tests/test_completion_refresher.py
+++ b/tests/test_completion_refresher.py
@@ -1,0 +1,85 @@
+import time
+import pytest
+from mock import Mock, patch
+
+
+@pytest.fixture
+def refresher():
+    from mycli.completion_refresher import CompletionRefresher
+    return CompletionRefresher()
+
+
+def test_ctor(refresher):
+    """
+    Refresher object should contain a few handlers
+    :param refresher:
+    :return:
+    """
+    assert len(refresher.refreshers) > 0
+    actual_handlers = list(refresher.refreshers.keys())
+    expected_handlers = ['databases', 'schemata', 'tables', 'users', 'functions',
+                         'special_commands', 'show_commands']
+    assert expected_handlers == actual_handlers
+
+
+def test_refresh_called_once(refresher):
+    """
+
+    :param refresher:
+    :return:
+    """
+    callbacks = Mock()
+    sqlexecute = Mock()
+
+    with patch.object(refresher, '_bg_refresh') as bg_refresh:
+        actual = refresher.refresh(sqlexecute, callbacks)
+        time.sleep(1)  # Wait for the thread to work.
+        assert len(actual) == 1
+        assert len(actual[0]) == 4
+        assert actual[0][3] == 'Auto-completion refresh started in the background.'
+        bg_refresh.assert_called_with(sqlexecute, callbacks)
+
+
+def test_refresh_called_twice(refresher):
+    """
+    If refresh is called a second time, it should be restarted
+    :param refresher:
+    :return:
+    """
+    callbacks = Mock()
+
+    sqlexecute = Mock()
+
+    def dummy_bg_refresh(*args):
+        time.sleep(3)  # seconds
+
+    refresher._bg_refresh = dummy_bg_refresh
+
+    actual1 = refresher.refresh(sqlexecute, callbacks)
+    time.sleep(1)  # Wait for the thread to work.
+    assert len(actual1) == 1
+    assert len(actual1[0]) == 4
+    assert actual1[0][3] == 'Auto-completion refresh started in the background.'
+
+    actual2 = refresher.refresh(sqlexecute, callbacks)
+    time.sleep(1)  # Wait for the thread to work.
+    assert len(actual2) == 1
+    assert len(actual2[0]) == 4
+    assert actual2[0][3] == 'Auto-completion refresh restarted.'
+
+
+def test_refresh_with_callbacks(refresher):
+    """
+    Callbacks must be called
+    :param refresher:
+    """
+    callbacks = [Mock()]
+    sqlexecute_class = Mock()
+    sqlexecute = Mock()
+
+    with patch('mycli.completion_refresher.SQLExecute', sqlexecute_class):
+        # Set refreshers to 0: we're not testing refresh logic here
+        refresher.refreshers = {}
+        refresher.refresh(sqlexecute, callbacks)
+        time.sleep(1)  # Wait for the thread to work.
+        assert (callbacks[0].call_count == 1)


### PR DESCRIPTION
Reviewer: @tsroten

The completion data-structures are populated at the startup time and then refreshed every time we ALTER, DROP, CREATE or change the database. But this completion refresh happens synchronously which could tie up the REPL for a while if the database is huge (with hundreds of thousands of tables). So instead of refreshing the completions synchronously this PR will make it asynchronous by kicking off a background thread. 

This is a copy of the feature that was implemented in pgcli a little while back. 

See this PR for discussion: https://github.com/dbcli/pgcli/pull/345