### PR TITLE
Fix typo on the handler's name when registering the `rehash` special command

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -138,7 +138,7 @@ class MyCli(object):
         special.register_special_command(self.change_db, 'connect',
                 '\\r', 'Reconnect to the database. Optional database argument.',
                 aliases=('\\r', ), case_sensitive=True)
-        special.register_special_command(self.refresh_dynamic_completions, 'rehash',
+        special.register_special_command(self.refresh_completions, 'rehash',
                 '\\#', 'Refresh auto-completions.', arg_type=NO_QUERY, aliases=('\\#',))
         special.register_special_command(self.change_table_format, 'tableformat',
                 '\\T', 'Change Table Type.', aliases=('\\T',), case_sensitive=True)


### PR DESCRIPTION
Since there is no test for `rehash` command the travis-ci didn't get this typo. But when you run `mycli` you get a `AttributeError` exception.

I didn't find any method called `refresh_dynamic_completions`. So I've fixed the typo on the handler's name for the `rehash` command when registering it.