### PR TITLE
Add ability to make suggestions for compound join clauses

### DIFF
--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -270,7 +270,7 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
         return [{'type': 'database'}]
     elif token_v == 'tableformat':
         return [{'type': 'table_format'}]
-    elif token_v.endswith(',') or token_v == '=':
+    elif token_v.endswith(',') or token_v in ['=', 'and', 'or']:
         prev_keyword, text_before_cursor = find_prev_keyword(text_before_cursor)
         if prev_keyword:
             return suggest_based_on_last_token(

--- a/tests/test_completion_engine.py
+++ b/tests/test_completion_engine.py
@@ -268,46 +268,60 @@ def test_join_suggests_tables_and_schemas(tbl_alias, join_type):
         {'type': 'view', 'schema': []},
         {'type': 'schema'}])
 
-def test_join_alias_dot_suggests_cols1():
-    suggestions = suggest_type('SELECT * FROM abc a JOIN def d ON a.',
-            'SELECT * FROM abc a JOIN def d ON a.')
+@pytest.mark.parametrize('sql', [
+    'SELECT * FROM abc a JOIN def d ON a.',
+    'SELECT * FROM abc a JOIN def d ON a.id = d.id AND a.',
+])
+def test_join_alias_dot_suggests_cols1(sql):
+    suggestions = suggest_type(sql, sql)
     assert sorted_dicts(suggestions) == sorted_dicts([
         {'type': 'column', 'tables': [(None, 'abc', 'a')]},
         {'type': 'table', 'schema': 'a'},
         {'type': 'view', 'schema': 'a'},
         {'type': 'function', 'schema': 'a'}])
 
-def test_join_alias_dot_suggests_cols2():
-    suggestion = suggest_type('SELECT * FROM abc a JOIN def d ON a.',
-            'SELECT * FROM abc a JOIN def d ON a.id = d.')
-    assert sorted_dicts(suggestion) == sorted_dicts([
+@pytest.mark.parametrize('sql', [
+    'SELECT * FROM abc a JOIN def d ON a.id = d.',
+    'SELECT * FROM abc a JOIN def d ON a.id = d.id AND a.id2 = d.',
+])
+def test_join_alias_dot_suggests_cols2(sql):
+    suggestions = suggest_type(sql, sql)
+    assert sorted_dicts(suggestions) == sorted_dicts([
         {'type': 'column', 'tables': [(None, 'def', 'd')]},
         {'type': 'table', 'schema': 'd'},
         {'type': 'view', 'schema': 'd'},
         {'type': 'function', 'schema': 'd'}])
 
-def test_on_suggests_aliases():
-    suggestions = suggest_type(
-        'select a.x, b.y from abc a join bcd b on ',
-        'select a.x, b.y from abc a join bcd b on ')
+@pytest.mark.parametrize('sql', [
+    'select a.x, b.y from abc a join bcd b on ',
+    'select a.x, b.y from abc a join bcd b on a.id = b.id OR ',
+])
+def test_on_suggests_aliases(sql):
+    suggestions = suggest_type(sql, sql)
     assert suggestions == [{'type': 'alias', 'aliases': ['a', 'b']}]
 
-def test_on_suggests_tables():
-    suggestions = suggest_type(
-        'select abc.x, bcd.y from abc join bcd on ',
-        'select abc.x, bcd.y from abc join bcd on ')
+@pytest.mark.parametrize('sql', [
+    'select abc.x, bcd.y from abc join bcd on ',
+    'select abc.x, bcd.y from abc join bcd on abc.id = bcd.id AND ',
+])
+def test_on_suggests_tables(sql):
+    suggestions = suggest_type(sql, sql)
     assert suggestions == [{'type': 'alias', 'aliases': ['abc', 'bcd']}]
 
-def test_on_suggests_aliases_right_side():
-    suggestions = suggest_type(
-        'select a.x, b.y from abc a join bcd b on a.id = ',
-        'select a.x, b.y from abc a join bcd b on a.id = ')
+@pytest.mark.parametrize('sql', [
+    'select a.x, b.y from abc a join bcd b on a.id = ',
+    'select a.x, b.y from abc a join bcd b on a.id = b.id AND a.id2 = ',
+])
+def test_on_suggests_aliases_right_side(sql):
+    suggestions = suggest_type(sql, sql)
     assert suggestions == [{'type': 'alias', 'aliases': ['a', 'b']}]
 
-def test_on_suggests_tables_right_side():
-    suggestions = suggest_type(
-        'select abc.x, bcd.y from abc join bcd on ',
-        'select abc.x, bcd.y from abc join bcd on ')
+@pytest.mark.parametrize('sql', [
+    'select abc.x, bcd.y from abc join bcd on ',
+    'select abc.x, bcd.y from abc join bcd on abc.id = bcd.id and ',
+])
+def test_on_suggests_tables_right_side(sql):
+    suggestions = suggest_type(sql, sql)
     assert suggestions == [{'type': 'alias', 'aliases': ['abc', 'bcd']}]
 
 


### PR DESCRIPTION
This is a feature ported from **pgcli**. https://github.com/dbcli/pgcli/pull/371

It adds the ability to make alias suggestions for `AND`/`OR` in an `ON` clause.

From the PR:
Previously, this worked correctly, suggesting columns etc. from a
`SELECT * FROM abc a JOIN def d ON a.`
But this suggested only keywords:
`SELECT * FROM abc a JOIN def d ON a.id = d.id AND a.`

Thank you @darikg! :)