### PR TITLE
Add a config option for always logging

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -71,10 +71,10 @@ class MyCli(object):
     ]
 
     def __init__(self, sqlexecute=None, prompt=None,
-            logfile=None, defaults_suffix=None, defaults_file=None,
+            auditlog=None, defaults_suffix=None, defaults_file=None,
             login_path=None):
         self.sqlexecute = sqlexecute
-        self.logfile = logfile
+        self.auditlog = auditlog
         self.defaults_suffix = defaults_suffix
         self.login_path = login_path
 
@@ -423,10 +423,10 @@ class MyCli(object):
 
                 try:
                     logger.debug('sql: %r', document.text)
-                    if self.logfile:
-                        self.logfile.write('\n# %s\n' % datetime.now())
-                        self.logfile.write(document.text)
-                        self.logfile.write('\n')
+                    if self.auditlog:
+                        self.auditlog.write('\n# %s\n' % datetime.now())
+                        self.auditlog.write(document.text)
+                        self.auditlog.write('\n')
                     successful = False
                     start = time()
                     res = sqlexecute.run(document.text)
@@ -516,15 +516,15 @@ class MyCli(object):
             os.environ['PAGER'] = special.get_original_pager()
 
     def output(self, text, **kwargs):
-        if self.logfile:
-            self.logfile.write(utf8tounicode(text))
-            self.logfile.write('\n')
+        if self.auditlog:
+            self.auditlog.write(utf8tounicode(text))
+            self.auditlog.write('\n')
         click.secho(text, **kwargs)
 
     def output_via_pager(self, text):
-        if self.logfile:
-            self.logfile.write(text)
-            self.logfile.write('\n')
+        if self.auditlog:
+            self.auditlog.write(text)
+            self.auditlog.write('\n')
         click.echo_via_pager(text)
 
     def adjust_less_opts(self):
@@ -597,7 +597,7 @@ class MyCli(object):
 @click.option('-R', '--prompt', 'prompt',
               help='Prompt format (Default: "{0}")'.format(
                   MyCli.default_prompt))
-@click.option('-l', '--logfile', type=click.File(mode='a', encoding='utf-8'),
+@click.option('-a', '--auditlog', type=click.File(mode='a', encoding='utf-8'),
               help='Log every query and its results to a file.')
 @click.option('--defaults-group-suffix', type=str,
               help='Read config group with the specified suffix.')
@@ -607,13 +607,13 @@ class MyCli(object):
               help='Read this path from the login file.')
 @click.argument('database', default='', nargs=1)
 def cli(database, user, host, port, socket, password, dbname,
-        version, prompt, logfile, defaults_group_suffix, defaults_file,
+        version, prompt, auditlog, defaults_group_suffix, defaults_file,
         login_path):
     if version:
         print('Version:', __version__)
         sys.exit(0)
 
-    mycli = MyCli(prompt=prompt, logfile=logfile,
+    mycli = MyCli(prompt=prompt, auditlog=auditlog,
                   defaults_suffix=defaults_group_suffix,
                   defaults_file=defaults_file, login_path=login_path)
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -71,10 +71,10 @@ class MyCli(object):
     ]
 
     def __init__(self, sqlexecute=None, prompt=None,
-            auditlog=None, defaults_suffix=None, defaults_file=None,
+            logfile=None, defaults_suffix=None, defaults_file=None,
             login_path=None):
         self.sqlexecute = sqlexecute
-        self.auditlog = auditlog
+        self.logfile = logfile
         self.defaults_suffix = defaults_suffix
         self.login_path = login_path
 
@@ -428,10 +428,10 @@ class MyCli(object):
 
                 try:
                     logger.debug('sql: %r', document.text)
-                    if self.auditlog:
-                        self.auditlog.write('\n# %s\n' % datetime.now())
-                        self.auditlog.write(document.text)
-                        self.auditlog.write('\n')
+                    if self.logfile:
+                        self.logfile.write('\n# %s\n' % datetime.now())
+                        self.logfile.write(document.text)
+                        self.logfile.write('\n')
                     successful = False
                     start = time()
                     res = sqlexecute.run(document.text)
@@ -521,15 +521,15 @@ class MyCli(object):
             os.environ['PAGER'] = special.get_original_pager()
 
     def output(self, text, **kwargs):
-        if self.auditlog:
-            self.auditlog.write(utf8tounicode(text))
-            self.auditlog.write('\n')
+        if self.logfile:
+            self.logfile.write(utf8tounicode(text))
+            self.logfile.write('\n')
         click.secho(text, **kwargs)
 
     def output_via_pager(self, text):
-        if self.auditlog:
-            self.auditlog.write(text)
-            self.auditlog.write('\n')
+        if self.logfile:
+            self.logfile.write(text)
+            self.logfile.write('\n')
         click.echo_via_pager(text)
 
     def adjust_less_opts(self):
@@ -602,7 +602,7 @@ class MyCli(object):
 @click.option('-R', '--prompt', 'prompt',
               help='Prompt format (Default: "{0}")'.format(
                   MyCli.default_prompt))
-@click.option('-a', '--auditlog', type=click.File(mode='a', encoding='utf-8'),
+@click.option('-l', '--logfile', type=click.File(mode='a', encoding='utf-8'),
               help='Log every query and its results to a file.')
 @click.option('--defaults-group-suffix', type=str,
               help='Read config group with the specified suffix.')
@@ -612,13 +612,13 @@ class MyCli(object):
               help='Read this path from the login file.')
 @click.argument('database', default='', nargs=1)
 def cli(database, user, host, port, socket, password, dbname,
-        version, prompt, auditlog, defaults_group_suffix, defaults_file,
+        version, prompt, logfile, defaults_group_suffix, defaults_file,
         login_path):
     if version:
         print('Version:', __version__)
         sys.exit(0)
 
-    mycli = MyCli(prompt=prompt, auditlog=auditlog,
+    mycli = MyCli(prompt=prompt, logfile=logfile,
                   defaults_suffix=defaults_group_suffix,
                   defaults_file=defaults_file, login_path=login_path)
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -88,6 +88,7 @@ class MyCli(object):
         default_config = os.path.join(PACKAGE_ROOT, 'myclirc')
         write_default_config(default_config, '~/.myclirc')
 
+
         # Load config.
         c = self.config = load_config('~/.myclirc', default_config)
         self.multi_line = c['main'].as_bool('multi_line')
@@ -98,6 +99,10 @@ class MyCli(object):
         self.syntax_style = c['main']['syntax_style']
         self.cli_style = c['colors']
         self.wider_completion_menu = c['main'].as_bool('wider_completion_menu')
+
+        # audit log
+        if self.auditlog is None:
+            self.auditlog = open(os.path.expanduser(c['main']['audit_log']), 'a')
 
         self.completion_refresher = CompletionRefresher()
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -101,8 +101,8 @@ class MyCli(object):
         self.wider_completion_menu = c['main'].as_bool('wider_completion_menu')
 
         # audit log
-        if self.auditlog is None:
-            self.auditlog = open(os.path.expanduser(c['main']['audit_log']), 'a')
+        if self.logfile is None:
+            self.logfile = open(os.path.expanduser(c['main']['audit_log']), 'a')
 
         self.completion_refresher = CompletionRefresher()
 

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -23,6 +23,9 @@ log_file = ~/.mycli.log
 # and "DEBUG".
 log_level = INFO
 
+# Log every query and its results to a file.
+audit_log = ~/.mycli-audit.log
+
 # Timing of sql statments and table rendering.
 timing = True
 


### PR DESCRIPTION
Addresses #75.

I added a new config in `myclirc` called `audit_log`. This is going to be used for always logging the queries. The user can still use the "new" `-a` or `--auditlog` argument when running `mycli`.

But since we've a new config option in `myclirc` I think we can drop the `--auditlog` argument. What do you guys think?

:)