### PR TITLE
Make `audit_log` config optional

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -101,7 +101,7 @@ class MyCli(object):
         self.wider_completion_menu = c['main'].as_bool('wider_completion_menu')
 
         # audit log
-        if self.logfile is None:
+        if self.logfile is None and 'audit_log' in c['main']:
             self.logfile = open(os.path.expanduser(c['main']['audit_log']), 'a')
 
         self.completion_refresher = CompletionRefresher()

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -23,8 +23,9 @@ log_file = ~/.mycli.log
 # and "DEBUG".
 log_level = INFO
 
-# Log every query and its results to a file.
-audit_log = ~/.mycli-audit.log
+# Log every query and its results to a file. Enable this by uncommenting the
+# line below.
+# audit_log = ~/.mycli-audit.log
 
 # Timing of sql statments and table rendering.
 timing = True


### PR DESCRIPTION
Since not everyone wants to make an audit log this PR makes the `audit_log` optional. 

I was thinking about writing some tests for this feature. What do you guys think?

cc/ @amjith 