### PR TITLE
Add error message for auditlog's validation

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -431,10 +431,12 @@ class MyCli(object):
 
                 try:
                     logger.debug('sql: %r', document.text)
-                    if self.logfile:
+                    if self.logfile is not False:
                         self.logfile.write('\n# %s\n' % datetime.now())
                         self.logfile.write(document.text)
                         self.logfile.write('\n')
+                    else:
+                        self.output("Error: Unable to load the audit log file.", err=True, fg='red')
                     successful = False
                     start = time()
                     res = sqlexecute.run(document.text)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -437,8 +437,6 @@ class MyCli(object):
                         self.logfile.write('\n# %s\n' % datetime.now())
                         self.logfile.write(document.text)
                         self.logfile.write('\n')
-                    elif self.logfile is False:
-                        self.output("Error: Unable to write to the audit log file.", err=True, fg='red')
 
                     successful = False
                     start = time()
@@ -517,7 +515,9 @@ class MyCli(object):
                     if need_completion_refresh(document.text):
                         self.refresh_completions(
                                 reset=need_completion_reset(document.text))
-
+                finally:
+                    if self.logfile is False:
+                        self.output("Warning: This query was not logged.", err=True, fg='red')
                 query = Query(document.text, successful, mutating)
                 self.query_history.append(query)
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -105,6 +105,7 @@ class MyCli(object):
             try:
                 self.logfile = open(os.path.expanduser(c['main']['audit_log']), 'a')
             except (IOError, OSError) as e:
+                self.output('Error: Unable to open the audit log file.', err=True, fg='red')
                 self.logfile = False
 
         self.completion_refresher = CompletionRefresher()

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -102,7 +102,10 @@ class MyCli(object):
 
         # audit log
         if self.logfile is None and 'audit_log' in c['main']:
-            self.logfile = open(os.path.expanduser(c['main']['audit_log']), 'a')
+            try:
+                self.logfile = open(os.path.expanduser(c['main']['audit_log']), 'a')
+            except (IOError, OSError) as e:
+                self.logfile = False
 
         self.completion_refresher = CompletionRefresher()
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -432,12 +432,14 @@ class MyCli(object):
 
                 try:
                     logger.debug('sql: %r', document.text)
-                    if self.logfile is not False:
+
+                    if self.logfile:
                         self.logfile.write('\n# %s\n' % datetime.now())
                         self.logfile.write(document.text)
                         self.logfile.write('\n')
-                    else:
-                        self.output("Error: Unable to load the audit log file.", err=True, fg='red')
+                    elif self.logfile is False:
+                        self.output("Error: Unable to write to the audit log file.", err=True, fg='red')
+
                     successful = False
                     start = time()
                     res = sqlexecute.run(document.text)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -105,7 +105,7 @@ class MyCli(object):
             try:
                 self.logfile = open(os.path.expanduser(c['main']['audit_log']), 'a')
             except (IOError, OSError) as e:
-                self.output('Error: Unable to open the audit log file.', err=True, fg='red')
+                self.output('Error: Unable to open the audit log file. Your queries will not be logged.', err=True, fg='red')
                 self.logfile = False
 
         self.completion_refresher = CompletionRefresher()


### PR DESCRIPTION
As discussed in #185. This PR add the error message for the `audit_log` config file validation.

The error message will only show up if the user enabled the `audit_log` config but added a invalid path to the audit log file. So in order to help the user fix the path, the error message will show up after each query is executed.

This PR is related to the issue #75.

Please, can one of you review this?
cc/ @amjith @tsroten 

:wink: 