### PR TITLE
Update changelog for version 1.5.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+1.5.1:
+======
+
+Bug Fixes:
+----------
+
+* Cast the value of port read from my.cnf to int. 
+
 1.5.0:
 ======
 


### PR DESCRIPTION
This is a patch release to fix a corner case bug in reading port values from my.cnf file. The reason to release it so quickly after 1.5.0 is because this breaks an existing feature (reading my.cnf file) in a critical way.

Can I get approval from @dbcli/mycli-core so I can release a new version? 