### PR TITLE
Adds support for system-wide config file.

### DIFF
--- a/mycli/config.py
+++ b/mycli/config.py
@@ -27,7 +27,8 @@ def read_config_file(f):
     try:
         config = ConfigObj(f, interpolation=False)
     except ConfigObjError as e:
-        print("Error parsing config file '{0}'.".format(f), file=sys.stderr)
+        print("Error parsing line {0} of config file '{1}'.".format(
+              e.line_number, f), file=sys.stderr)
         print('Recovering partially parsed config values.', file=sys.stderr)
         return e.config
     except (IOError, OSError) as e:

--- a/mycli/config.py
+++ b/mycli/config.py
@@ -19,36 +19,32 @@ class CryptoError(Exception):
 
 logger = logging.getLogger(__name__)
 
-def read_config_file(f, base_config=None):
-    """Read and merge a config file.
+def read_config_file(f):
+    """Read a config file."""
 
-    If the file is read successfully, the config object takes
-    on that filename.
-    """
-
-    config = ConfigObj() if base_config is None else base_config
     try:
-        _config = ConfigObj(f, interpolation=False)
-        config.merge(_config)
-        if bool(_config) is True:
-            config.filename = f
+        config = ConfigObj(f, interpolation=False)
     except ConfigObjError as e:
         logger.error("Error parsing config file '{0}'.".format(f))
         logger.error('Recovering partially parsed config values.')
-        config.merge(e.config)
-    except (IOError, PermissionError) as e:
+        return e.config
+    except (IOError, OSError) as e:
         logger.warning("You don't have permission to read config "
                        "file '{0}'.".format(e.filename))
+        return None
 
     return config
 
-def read_config_files(files, base_config=None):
+def read_config_files(files):
     """Read and merge a list of config files."""
 
-    config = ConfigObj() if base_config is None else base_config
+    config = ConfigObj()
 
     for _file in files:
-        read_config_file(_file, base_config=config)
+        _config = read_config_file(_file)
+        if bool(_config) is True:
+            config.merge(_config)
+            config.filename = _file
 
     return config
 

--- a/mycli/config.py
+++ b/mycli/config.py
@@ -21,19 +21,27 @@ class CryptoError(Exception):
 
 logger = logging.getLogger(__name__)
 
+def log(logger, level, message):
+    """Logs message to stderr if logging isn't initialized."""
+
+    if logger.parent.name != 'root':
+        logger.log(level, message)
+    else:
+        print(message, file=sys.stderr)
+
 def read_config_file(f):
     """Read a config file."""
 
     try:
         config = ConfigObj(f, interpolation=False)
     except ConfigObjError as e:
-        print("Error parsing line {0} of config file '{1}'.".format(
-              e.line_number, f), file=sys.stderr)
-        print('Recovering partially parsed config values.', file=sys.stderr)
+        log(logger, logging.ERROR, "Unable to parse line {0} of config file "
+            "'{1}'.".format(e.line_number, f))
+        log(logger, logging.ERROR, "Using successfully parsed config values.")
         return e.config
     except (IOError, OSError) as e:
-        print("You don't have permission to read config file "
-              "'{0}'.".format(e.filename), file=sys.stderr)
+        log(logger, logging.WARNING, "You don't have permission to read "
+            "config file '{0}'.".format(e.filename))
         return None
 
     return config

--- a/mycli/config.py
+++ b/mycli/config.py
@@ -8,6 +8,10 @@ import struct
 import sys
 from configobj import ConfigObj, ConfigObjError
 try:
+    basestring
+except NameError:
+    basestring = str
+try:
     from Crypto.Cipher import AES
 except ImportError:
     AES = None
@@ -32,6 +36,9 @@ def log(logger, level, message):
 def read_config_file(f):
     """Read a config file."""
 
+    if isinstance(f, basestring):
+        f = os.path.expanduser(f)
+
     try:
         config = ConfigObj(f, interpolation=False)
     except ConfigObjError as e:
@@ -55,11 +62,12 @@ def read_config_files(files):
         _config = read_config_file(_file)
         if bool(_config) is True:
             config.merge(_config)
-            config.filename = _file
+            config.filename = _config.filename
 
     return config
 
 def write_default_config(source, destination, overwrite=False):
+    destination = os.path.expanduser(destination)
     if not overwrite and exists(destination):
         return
 

--- a/mycli/config.py
+++ b/mycli/config.py
@@ -1,9 +1,11 @@
+from __future__ import print_function
 import shutil
 from io import BytesIO, TextIOWrapper
 import logging
 import os
 from os.path import exists
 import struct
+import sys
 from configobj import ConfigObj, ConfigObjError
 try:
     from Crypto.Cipher import AES
@@ -25,12 +27,12 @@ def read_config_file(f):
     try:
         config = ConfigObj(f, interpolation=False)
     except ConfigObjError as e:
-        logger.error("Error parsing config file '{0}'.".format(f))
-        logger.error('Recovering partially parsed config values.')
+        print("Error parsing config file '{0}'.".format(f), file=sys.stderr)
+        print('Recovering partially parsed config values.', file=sys.stderr)
         return e.config
     except (IOError, OSError) as e:
-        logger.warning("You don't have permission to read config "
-                       "file '{0}'.".format(e.filename))
+        print("You don't have permission to read config file "
+              "'{0}'.".format(e.filename), file=sys.stderr)
         return None
 
     return config

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -251,15 +251,7 @@ class MyCli(object):
         :param keys: list of keys to retrieve
         :returns: tuple, with None for missing keys.
         """
-        cnf = ConfigObj()
-        for _file in files:
-            try:
-                cnf.merge(ConfigObj(_file, interpolation=False))
-            except ConfigObjError as e:
-                self.logger.error('Error parsing %r.', _file)
-                self.logger.error('Recovering partially parsed config values.')
-                cnf.merge(e.config)
-                pass
+        cnf = read_config_files(files)
 
         sections = ['client']
         if self.login_path and self.login_path != 'client':

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -95,9 +95,9 @@ class MyCli(object):
             self.cnf_files = [defaults_file]
 
         # Load config.
-        c = self.config = read_config_file(self.default_config_file)
-        read_config_files(self.system_config_files, base_config=c)
-        read_config_file(self.user_config_file, base_config=c)
+        config_files = ([self.default_config_file] + self.system_config_files +
+                        [self.user_config_file])
+        c = self.config = read_config_files(config_files)
         self.multi_line = c['main'].as_bool('multi_line')
         self.destructive_warning = c['main'].as_bool('destructive_warning')
         self.key_bindings = c['main']['key_bindings']

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -36,7 +36,8 @@ from .sqlexecute import SQLExecute
 from .clibuffer import CLIBuffer
 from .completion_refresher import CompletionRefresher
 from .config import (write_default_config, get_mylogin_cnf_path,
-                     open_mylogin_cnf, CryptoError, read_config_files)
+                     open_mylogin_cnf, CryptoError, read_config_file,
+                     read_config_files)
 from .key_bindings import mycli_bindings
 from .encodingutils import utf8tounicode
 from .lexer import MyCliLexer
@@ -96,7 +97,7 @@ class MyCli(object):
         # Load config.
         c = self.config = ConfigObj(self.default_config_file)
         read_config_files(self.system_config_files, base_config=c)
-        read_config_files(self.user_config_file, base_config=c)
+        read_config_file(self.user_config_file, base_config=c)
         self.multi_line = c['main'].as_bool('multi_line')
         self.destructive_warning = c['main'].as_bool('destructive_warning')
         self.key_bindings = c['main']['key_bindings']

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -68,7 +68,7 @@ class MyCli(object):
         '/etc/my.cnf',
         '/etc/mysql/my.cnf',
         '/usr/local/etc/my.cnf',
-        os.path.expanduser('~/.my.cnf')
+        '~/.my.cnf'
     ]
 
     system_config_files = [
@@ -76,7 +76,7 @@ class MyCli(object):
     ]
 
     default_config_file = os.path.join(PACKAGE_ROOT, 'myclirc')
-    user_config_file = os.path.expanduser('~/.myclirc')
+    user_config_file = '~/.myclirc'
 
 
     def __init__(self, sqlexecute=None, prompt=None,

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -95,7 +95,7 @@ class MyCli(object):
             self.cnf_files = [defaults_file]
 
         # Load config.
-        c = self.config = ConfigObj(self.default_config_file)
+        c = self.config = read_config_file(self.default_config_file)
         read_config_files(self.system_config_files, base_config=c)
         read_config_file(self.user_config_file, base_config=c)
         self.multi_line = c['main'].as_bool('multi_line')

--- a/mycli/packages/special/favoritequeries.py
+++ b/mycli/packages/special/favoritequeries.py
@@ -58,5 +58,5 @@ Examples:
         self.config.write()
         return '%s: Deleted' % name
 
-from ...config import read_config_files
-favoritequeries = FavoriteQueries(read_config_files(expanduser('~/.myclirc')))
+from ...config import read_config_file
+favoritequeries = FavoriteQueries(read_config_file(expanduser('~/.myclirc')))

--- a/mycli/packages/special/favoritequeries.py
+++ b/mycli/packages/special/favoritequeries.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from os.path import expanduser
 
 class FavoriteQueries(object):
 
@@ -57,5 +58,5 @@ Examples:
         self.config.write()
         return '%s: Deleted' % name
 
-from ...config import load_config
-favoritequeries = FavoriteQueries(load_config('~/.myclirc'))
+from ...config import read_config_files
+favoritequeries = FavoriteQueries(read_config_files(expanduser('~/.myclirc')))

--- a/mycli/packages/special/favoritequeries.py
+++ b/mycli/packages/special/favoritequeries.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from os.path import expanduser
 
 class FavoriteQueries(object):
 
@@ -59,4 +58,4 @@ Examples:
         return '%s: Deleted' % name
 
 from ...config import read_config_file
-favoritequeries = FavoriteQueries(read_config_file(expanduser('~/.myclirc')))
+favoritequeries = FavoriteQueries(read_config_file('~/.myclirc'))


### PR DESCRIPTION
This fixes #161 by introducing system-wide config files. Right now, only `'/etc/myclirc'` is checked, but adding other locations to the code is a simple as adding an item to a list. If the last successful file read is not a system-wide config file, then mycli checks to see if it should write the default user config file (by seeing if one exists). But, if the last successful file read was a system-wide config file, then no default user config file is created.

This cleans up and refactors some of the `ConfigObj()` code to use a generic function that handles two types of errors: config parsing errors and file permission errors.

Because logging isn't initialized before we read the config files, these two outputs are possible:
```
% mycli
You don't have permission to read config file '/etc/myclirc'.
Version: 1.5.2
Chat: https://gitter.im/dbcli/mycli
Mail: https://groups.google.com/forum/#!forum/mycli-users
Home: http://mycli.net
Thanks to the contributor - Foo
mysql dev@localhost:(none)>
```

And:
```
% mycli
Error parsing config file '/etc/myclirc'.
Recovering partially parsed config values.
Version: 1.5.2
Chat: https://gitter.im/dbcli/mycli
Mail: https://groups.google.com/forum/#!forum/mycli-users
Home: http://mycli.net
Thanks to the contributor - Foo
mysql dev@localhost:(none)>
```

I'm not sure if there is a better way to deal with those messages. They aren't printed by `mycli.py` so they don't know about `click.secho()`. They are basic logging calls to the default logging handler (stderr). Can anyone think of a better way to handle this? Or are we happy with it as it is?