### PR TITLE
New debian release (1.5.2)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,30 @@
+mycli (1.5.2) unstable; urgency=low
+
+  * Protect against port number being None when no port is specified in command line.
+  * Cast the value of port read from my.cnf to int.
+  * Make a config option to enable `audit_log`. (Thanks: [Matheus Rosa]).
+  * Add support for reading .mylogin.cnf to get user credentials. (Thanks: [Thomas Roten]).
+  * Register the special command `prompt` with the `\R` as alias. (Thanks: [Matheus Rosa]).
+  * Perform completion refresh in a background thread. Now mycli can handle
+  * Add support for `system` command. (Thanks: [Matheus Rosa]).
+  * Caught and hexed binary fields in MySQL. (Thanks: [Daniel West]).
+  * Treat enter key as tab when the suggestion menu is open. (Thanks: [Matheus Rosa])
+  * Add "delete" and "truncate" as destructive commands. (Thanks: [Martijn Engler]).
+  * Change \dt syntax to add an optional table name. (Thanks: [Shoma Suzuki]).
+  * Add TRANSACTION related keywords.
+  * Treat DESC and EXPLAIN as DESCRIBE. (Thanks: [spacewander]).
+  * Fix the removal of whitespace from table output.
+  * Add ability to make suggestions for compound join clauses. (Thanks: [Matheus Rosa]).
+  * Fix the incorrect reporting of command time.
+  * Add type validation for port argument. (Thanks [Matheus Rosa])
+  * Make pycrypto optional and only install it in \*nix systems. (Thanks: [Iryna Cherniavska]).
+  * Add badge for PyPI version to README. (Thanks: [Shoma Suzuki]).
+  * Updated release script with a --dry-run and --confirm-steps option. (Thanks: [Iryna Cherniavska]).
+  * Adds support for PyMySQL 0.6.2 and above. This is useful for debian package builders. (Thanks: [Thomas Roten]).
+  * Disable click warning.
+
+ -- Casper Langemeijer <casper@langemeijer.eu>  Sun, 15 Nov 2015 10:26:24 +0100
+
 mycli (1.4.0) unstable; urgency=low
 
   * Add `source` command. This allows running sql statement from a file. 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: mycli
 Section: python
 Priority: extra
 Maintainer: Amjith Ramanujam <amjith.r@gmail.com>
-Build-Depends: debhelper (>= 9), python, dh-virtualenv (>= 0.7)
+Build-Depends: debhelper (>= 9), python, dh-virtualenv (>= 0.7), python-setuptools, python-dev
 Standards-Version: 3.9.5
 
 Package: mycli


### PR DESCRIPTION
Updated the changelog to create a 1.5.2 version package.

Built & mycli tested on ubuntu wily and debian wheezy.

To build on wheezy I used the dh-virtualenv package from wheezy-backports-sloppy:
 https://packages.debian.org/wheezy-backports-sloppy/dh-virtualenv