### PR TITLE
Add --auto-vertical-output option.

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -81,11 +81,12 @@ class MyCli(object):
 
     def __init__(self, sqlexecute=None, prompt=None,
             logfile=None, defaults_suffix=None, defaults_file=None,
-            login_path=None):
+            login_path=None, auto_vertical_output=False):
         self.sqlexecute = sqlexecute
         self.logfile = logfile
         self.defaults_suffix = defaults_suffix
         self.login_path = login_path
+        self.auto_vertical_output = auto_vertical_output
 
         # self.cnf_files is a class variable that stores the list of mysql
         # config files to read in at launch.
@@ -466,8 +467,17 @@ class MyCli(object):
                             if not click.confirm('Do you want to continue?'):
                                 self.output("Aborted!", err=True, fg='red')
                                 break
-                        output.extend(format_output(title, cur, headers,
-                            status, self.table_format))
+
+                        if self.auto_vertical_output:
+                            max_width = self.cli.output.get_size().columns
+                        else:
+                            max_width = None
+
+                        formatted = format_output(title, cur, headers,
+                            status, self.table_format,
+                            special.is_expanded_output(), max_width)
+
+                        output.extend(formatted)
                         end = time()
                         total += end - start
                         mutating = mutating or is_mutating(status)
@@ -607,6 +617,7 @@ class MyCli(object):
 
 @click.command()
 @click.option('-h', '--host', envvar='MYSQL_HOST', help='Host address of the database.')
+@click.option('--auto-vertical-output', is_flag=True, help='Automatically switch to vertical output mode if the result is wider than the terminal width.')
 @click.option('-P', '--port', envvar='MYSQL_TCP_PORT', type=int, help='Port number to use for connection. Honors '
               '$MYSQL_TCP_PORT')
 @click.option('-u', '--user', help='User name to connect to the database.')
@@ -631,14 +642,15 @@ class MyCli(object):
 @click.argument('database', default='', nargs=1)
 def cli(database, user, host, port, socket, password, dbname,
         version, prompt, logfile, defaults_group_suffix, defaults_file,
-        login_path):
+        login_path, auto_vertical_output):
     if version:
         print('Version:', __version__)
         sys.exit(0)
 
     mycli = MyCli(prompt=prompt, logfile=logfile,
                   defaults_suffix=defaults_group_suffix,
-                  defaults_file=defaults_file, login_path=login_path)
+                  defaults_file=defaults_file, login_path=login_path,
+                  auto_vertical_output=auto_vertical_output)
 
     # Choose which ever one has a valid value.
     database = database or dbname
@@ -656,20 +668,33 @@ def cli(database, user, host, port, socket, password, dbname,
 
     mycli.run_cli()
 
-def format_output(title, cur, headers, status, table_format):
+def format_output(title, cur, headers, status, table_format, expanded=False, max_width=None):
     output = []
     if title:  # Only print the title if it's not None.
         output.append(title)
     if cur:
         headers = [utf8tounicode(x) for x in headers]
-        if special.is_expanded_output():
+        if expanded:
             output.append(expanded_table(cur, headers))
         else:
-            output.append(tabulate(cur, headers, tablefmt=table_format,
-                missingval='<null>'))
+            tabulated, rows = tabulate(cur, headers, tablefmt=table_format,
+                missingval='<null>')
+            if (max_width and rows and
+                    content_exceeds_width(rows[0], max_width) and
+                    headers):
+                output.append(expanded_table(rows, headers))
+            else:
+                output.append(tabulated)
     if status:  # Only print the status if it's not None.
         output.append(status)
     return output
+
+def content_exceeds_width(row, width):
+    # Account for 3 characters between each column
+    separator_space = (len(row)*3)
+    # Add 2 columns for a bit of buffer
+    line_len = sum([len(str(x)) for x in row]) + separator_space + 2
+    return line_len > width
 
 def need_completion_refresh(queries):
     """Determines if the completion needs a refresh by checking if the sql

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -617,7 +617,6 @@ class MyCli(object):
 
 @click.command()
 @click.option('-h', '--host', envvar='MYSQL_HOST', help='Host address of the database.')
-@click.option('--auto-vertical-output', is_flag=True, help='Automatically switch to vertical output mode if the result is wider than the terminal width.')
 @click.option('-P', '--port', envvar='MYSQL_TCP_PORT', type=int, help='Port number to use for connection. Honors '
               '$MYSQL_TCP_PORT')
 @click.option('-u', '--user', help='User name to connect to the database.')
@@ -637,6 +636,8 @@ class MyCli(object):
               help='Read config group with the specified suffix.')
 @click.option('--defaults-file', type=click.Path(),
               help='Only read default options from the given file')
+@click.option('--auto-vertical-output', is_flag=True,
+              help='Automatically switch to vertical output mode if the result is wider than the terminal width.')
 @click.option('--login-path', type=str,
               help='Read this path from the login file.')
 @click.argument('database', default='', nargs=1)

--- a/mycli/packages/tabulate.py
+++ b/mycli/packages/tabulate.py
@@ -881,6 +881,8 @@ def tabulate(tabular_data, headers=[], tablefmt="simple",
      eggs & 451      \\\\
     \\bottomrule
     \end{tabular}
+
+    Also returns a tuple of the raw rows pulled from tabular_data
     """
     if tabular_data is None:
         tabular_data = []
@@ -923,7 +925,7 @@ def tabulate(tabular_data, headers=[], tablefmt="simple",
     if not isinstance(tablefmt, TableFormat):
         tablefmt = _table_formats.get(tablefmt, _table_formats["simple"])
 
-    return _format_table(tablefmt, headers, rows, minwidths, aligns)
+    return _format_table(tablefmt, headers, rows, minwidths, aligns), rows
 
 
 def _build_simple_row(padded_cells, rowfmt):

--- a/tests/test_expanded.py
+++ b/tests/test_expanded.py
@@ -11,4 +11,3 @@ name | world
 age  | 456
 """
     assert expected == expanded_table(input, ["name", "age"])
-

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,21 @@
+import pytest
+from mycli.main import format_output
+
+def test_format_output():
+    results = format_output('Title', [('abc', 'def')], ['head1', 'head2'],
+                            'test status', 'psql')
+    expected = ['Title', '+---------+---------+\n| head1   | head2   |\n|---------+---------|\n| abc     | def     |\n+---------+---------+', 'test status']
+    assert results == expected
+
+def test_format_output_auto_expand():
+    table_results = format_output('Title', [('abc', 'def')],
+                                  ['head1', 'head2'], 'test status', 'psql',
+                                  max_width=100)
+    table = ['Title', '+---------+---------+\n| head1   | head2   |\n|---------+---------|\n| abc     | def     |\n+---------+---------+', 'test status']
+    assert table_results == table
+
+    expanded_results = format_output('Title', [('abc', 'def')],
+                                     ['head1', 'head2'], 'test status', 'psql',
+                                     max_width=1)
+    expanded = ['Title', u'***************************[ 1. row ]***************************\nhead1 | abc    \nhead2 | def    \n', 'test status']
+    assert expanded_results == expanded

--- a/tests/test_tabulate.py
+++ b/tests/test_tabulate.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 def test_dont_strip_leading_whitespace():
     data = [['    abc']]
     headers = ['xyz']
-    tbl = tabulate(data, headers, tablefmt='psql')
+    tbl, _ = tabulate(data, headers, tablefmt='psql')
     assert tbl == dedent('''
         +---------+
         | xyz     |

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -35,7 +35,7 @@ def run(executor, sql, join=False):
     " Return string output for the sql to be run "
     result = []
     for title, rows, headers, status in executor.run(sql):
-        result.extend(format_output(title, rows, headers, status, 'psql'))
+        result.extend(format_output(title, rows, headers, status, 'psql', special.is_expanded_output()))
     if join:
         result = '\n'.join(result)
     return result


### PR DESCRIPTION
Reviewer: @tsroten 

This PR adds support for `--auto-vertical-output` option to the command line. This option will automatically switch the output to the vertical mode (or expanded mode in mycli terminology) when the width of the formatted table doesn't fit the screen. 

This PR addresses #195. 

