### PR TITLE
Fix #203 - Support \G terminator for \f queries

### DIFF
--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -98,15 +98,14 @@ class SQLExecute(object):
             # and then proceed to execute the sql as normal.
             if sql.endswith('\\G'):
                 special.set_expanded_output(True)
-                yield self.execute_normal_sql(sql.rsplit('\\G', 1)[0])
-            else:
-                try:   # Special command
-                    _logger.debug('Trying a dbspecial command. sql: %r', sql)
-                    cur = self.conn.cursor()
-                    for result in special.execute(cur, sql):
-                        yield result
-                except special.CommandNotFound:  # Regular SQL
-                    yield self.execute_normal_sql(sql)
+                sql = sql[:-2].strip()
+            try:   # Special command
+                _logger.debug('Trying a dbspecial command. sql: %r', sql)
+                cur = self.conn.cursor()
+                for result in special.execute(cur, sql):
+                    yield result
+            except special.CommandNotFound:  # Regular SQL
+                yield self.execute_normal_sql(sql)
 
     def execute_normal_sql(self, split_sql):
         _logger.debug('Regular sql statement. sql: %r', split_sql)

--- a/tests/test_sqlexecute.py
+++ b/tests/test_sqlexecute.py
@@ -176,6 +176,36 @@ def test_favorite_query_multiple_statement(executor):
     assert results == ['test-ad: Deleted']
 
 @dbtest
+def test_favorite_query_expanded_output(executor):
+    set_expanded_output(False)
+    run(executor, '''create table test(a text)''')
+    run(executor, '''insert into test values('abc')''')
+
+    results = run(executor, "\\fs test-ae select * from test")
+    assert results == ['Saved.']
+
+    results = run(executor, "\\f test-ae \G", join=True)
+
+    expected_results = set([
+        dedent("""\
+        > select * from test
+        -[ RECORD 0 ]
+        a | abc
+        """),
+        dedent("""\
+        > select * from test
+        ***************************[ 1. row ]***************************
+        a | abc
+        """),
+    ])
+    set_expanded_output(False)
+
+    assert results in expected_results
+
+    results = run(executor, "\\fd test-ae")
+    assert results == ['test-ae: Deleted']
+
+@dbtest
 def test_special_command(executor):
     results = run(executor, '\\?')
     expected_line = u'| help      | \\?               | Show this help.                              |\n'


### PR DESCRIPTION
Try to fix the issue #203 by adding support for the syntax `\f favorite_query \G`.

I think this is a better feature than saving favorites queries with `\G` since it have the flexibility to execute a favorite query with or without `\G`.