### PR TITLE
Upgrade to prompt_toolkit 0.56

### DIFF
--- a/mycli/clistyle.py
+++ b/mycli/clistyle.py
@@ -1,7 +1,7 @@
 from pygments.token import string_to_tokentype
 from pygments.style import Style
 from pygments.util import ClassNotFound
-from prompt_toolkit.styles import default_style_extensions
+from prompt_toolkit.styles import default_style_extensions, PygmentsStyle
 import pygments.styles
 
 
@@ -19,4 +19,4 @@ def style_factory(name, cli_style):
         custom_styles = dict([(string_to_tokentype(x), y) for x, y in cli_style.items()])
         styles.update(custom_styles)
 
-    return CLIStyle
+    return PygmentsStyle(CLIStyle)

--- a/mycli/clitoolbar.py
+++ b/mycli/clitoolbar.py
@@ -1,4 +1,5 @@
 from pygments.token import Token
+from prompt_toolkit.enums import DEFAULT_BUFFER
 
 def create_toolbar_tokens_func(get_key_bindings, get_is_refreshing):
     """
@@ -12,17 +13,17 @@ def create_toolbar_tokens_func(get_key_bindings, get_is_refreshing):
         result = []
         result.append((token, ' '))
 
-        if cli.buffers['default'].completer.smart_completion:
+        if cli.buffers[DEFAULT_BUFFER].completer.smart_completion:
             result.append((token.On, '[F2] Smart Completion: ON  '))
         else:
             result.append((token.Off, '[F2] Smart Completion: OFF  '))
 
-        if cli.buffers['default'].always_multiline:
+        if cli.buffers[DEFAULT_BUFFER].always_multiline:
             result.append((token.On, '[F3] Multiline: ON  '))
         else:
             result.append((token.Off, '[F3] Multiline: OFF  '))
 
-        if cli.buffers['default'].always_multiline:
+        if cli.buffers[DEFAULT_BUFFER].always_multiline:
             result.append((token,
                 ' (Semi-colon [;] will end the line)'))
 

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -17,6 +17,7 @@ def mycli_bindings(get_key_bindings, set_key_bindings):
     key_binding_manager = KeyBindingManager(
             enable_open_in_editor=True,
             enable_system_bindings=True,
+            enable_abort_and_exit_bindings=True,
             enable_vi_mode=Condition(lambda cli: get_key_bindings() == 'vi'))
 
     @key_binding_manager.registry.add_binding(Keys.F2)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -15,6 +15,7 @@ from io import open
 import click
 import sqlparse
 from prompt_toolkit import CommandLineInterface, Application, AbortAction
+from prompt_toolkit.interface import AcceptAction
 from prompt_toolkit.enums import DEFAULT_BUFFER
 from prompt_toolkit.shortcuts import create_default_layout, create_eventloop
 from prompt_toolkit.document import Document
@@ -396,12 +397,13 @@ class MyCli(object):
         with self._completer_lock:
             buf = CLIBuffer(always_multiline=self.multi_line, completer=self.completer,
                     history=FileHistory(os.path.expanduser('~/.mycli-history')),
-                    complete_while_typing=Always())
+                    complete_while_typing=Always(), accept_action=AcceptAction.RETURN_DOCUMENT)
 
             application = Application(style=style_factory(self.syntax_style, self.cli_style),
                                       layout=layout, buffer=buf,
                                       key_bindings_registry=key_binding_manager.registry,
                                       on_exit=AbortAction.RAISE_EXCEPTION,
+                                      on_abort=AbortAction.RETRY,
                                       ignore_case=True)
             self.cli = CommandLineInterface(application=application,
                                        eventloop=create_eventloop())

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -17,7 +17,7 @@ import sqlparse
 from prompt_toolkit import CommandLineInterface, Application, AbortAction
 from prompt_toolkit.interface import AcceptAction
 from prompt_toolkit.enums import DEFAULT_BUFFER
-from prompt_toolkit.shortcuts import create_default_layout, create_eventloop
+from prompt_toolkit.shortcuts import create_prompt_layout, create_eventloop
 from prompt_toolkit.document import Document
 from prompt_toolkit.filters import Always, HasFocus, IsDone
 from prompt_toolkit.layout.processors import (HighlightMatchingBracketProcessor,
@@ -383,17 +383,16 @@ class MyCli(object):
         get_toolbar_tokens = create_toolbar_tokens_func(lambda: self.key_bindings,
                                                         self.completion_refresher.is_refreshing)
 
-        layout = create_default_layout(lexer=MyCliLexer,
-                                       reserve_space_for_menu=True,
-                                       multiline=True,
-                                       get_prompt_tokens=prompt_tokens,
-                                       get_bottom_toolbar_tokens=get_toolbar_tokens,
-                                       display_completions_in_columns=self.wider_completion_menu,
-                                       extra_input_processors=[
-                                           ConditionalProcessor(
-                                               processor=HighlightMatchingBracketProcessor(chars='[](){}'),
-                                               filter=HasFocus(DEFAULT_BUFFER) & ~IsDone()),
-                                       ])
+        layout = create_prompt_layout(lexer=MyCliLexer,
+                                      multiline=True,
+                                      get_prompt_tokens=prompt_tokens,
+                                      get_bottom_toolbar_tokens=get_toolbar_tokens,
+                                      display_completions_in_columns=self.wider_completion_menu,
+                                      extra_input_processors=[
+                                          ConditionalProcessor(
+                                              processor=HighlightMatchingBracketProcessor(chars='[](){}'),
+                                              filter=HasFocus(DEFAULT_BUFFER) & ~IsDone()),
+                                      ])
         with self._completer_lock:
             buf = CLIBuffer(always_multiline=self.multi_line, completer=self.completer,
                     history=FileHistory(os.path.expanduser('~/.mycli-history')),

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ description = 'CLI for MySQL Database. With auto-completion and syntax highlight
 install_requirements = [
     'click >= 4.1',
     'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
-    'prompt_toolkit==0.46',
+    'prompt_toolkit==0.51',
     'PyMySQL >= 0.6.2',
     'sqlparse >= 0.1.16',
     'configobj >= 5.0.6',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ description = 'CLI for MySQL Database. With auto-completion and syntax highlight
 install_requirements = [
     'click >= 4.1',
     'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
-    'prompt_toolkit==0.51',
+    'prompt_toolkit==0.56',
     'PyMySQL >= 0.6.2',
     'sqlparse >= 0.1.16',
     'configobj >= 5.0.6',


### PR DESCRIPTION
Fix for backward-incompatible changes in prompt_toolkit v0.46..v0.56.
Based on a fix for v0.46..v0.51 from debian patches.

Allows mycli to be installed in the same environment with the latest ptpython.

fixes #204