### PR TITLE
Capture warnings to log file

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -237,6 +237,8 @@ class MyCli(object):
         root_logger.addHandler(handler)
         root_logger.setLevel(level_map[log_level.upper()])
 
+        logging.captureWarnings(True)
+
         root_logger.debug('Initializing mycli logging.')
         root_logger.debug('Log file %r.', log_file)
 


### PR DESCRIPTION
Prevents runtime warnings in pymysql from littering terminal output.

Example (warnings appear after completions are updated):
```
Version: 1.5.2
Chat: https://gitter.im/dbcli/mycli
Mail: https://groups.google.com/forum/#!forum/mycli-users
Home: http://mycli.net
Thanks to the contributor - Tech Blue Software
mysql root@localhost:******> /home/borman/.local/lib/python2.7/site-packages/pymysql/cursors.py:146: Warning: View `******`.`ResourceView1001` has no creatiot
  result = self._query(query)
/home/borman/.local/lib/python2.7/site-packages/pymysql/cursors.py:146: Warning: View `******`.`ResourceView1002` has no creation context
  result = self._query(query)
/home/borman/.local/lib/python2.7/site-packages/pymysql/cursors.py:146: Warning: View `******`.`ResourceView1003` has no creation context
  result = self._query(query)
/home/borman/.local/lib/python2.7/site-packages/pymysql/cursors.py:146: Warning: View `******`.`ResourceView1004` has no creation context
  result = self._query(query)
/home/borman/.local/lib/python2.7/site-packages/pymysql/cursors.py:146: Warning: View `******`.`ResourceView1005` has no creation context
  result = self._query(query)
```