### PR TITLE
Adds nopager command and skip-pager config option.

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -525,7 +525,10 @@ class MyCli(object):
                     self.output(str(e), err=True, fg='red')
                 else:
                     try:
-                        self.output_via_pager('\n'.join(output))
+                        if special.is_pager_enabled():
+                            self.output_via_pager('\n'.join(output))
+                        else:
+                            self.output('\n'.join(output))
                     except KeyboardInterrupt:
                         pass
                     if special.is_timing_enabled():
@@ -568,9 +571,11 @@ class MyCli(object):
         return less_opts
 
     def set_pager_from_config(self):
-        cnf = self.read_my_cnf_files(self.cnf_files, ['pager'])
+        cnf = self.read_my_cnf_files(self.cnf_files, ['pager', 'skip-pager'])
         if cnf['pager']:
             special.set_pager(cnf['pager'])
+        if cnf['skip-pager']:
+            special.disable_pager()
 
     def refresh_completions(self, reset=False):
         if reset:

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -15,11 +15,21 @@ from .utils import handle_cd_command
 TIMING_ENABLED = False
 use_expanded_output = False
 ORIGINAL_PAGER = os.environ.get('PAGER', '')
+PAGER_ENABLED = True
 
 @export
 def set_timing_enabled(val):
     global TIMING_ENABLED
     TIMING_ENABLED = val
+
+@export
+def set_pager_enabled(val):
+    global PAGER_ENABLED
+    PAGER_ENABLED = val
+
+@export
+def is_pager_enabled():
+    return PAGER_ENABLED
 
 @export
 def get_original_pager():
@@ -32,14 +42,28 @@ def set_pager(arg, **_):
         if not ORIGINAL_PAGER:
             os.environ.pop('PAGER', None)
             msg = 'Reset pager.'
+            set_pager_enabled(False)
         else:
             os.environ['PAGER'] = ORIGINAL_PAGER
             msg = 'Reset pager back to default. Default: %s' % ORIGINAL_PAGER
+            set_pager_enabled(True)
     else:
         os.environ['PAGER'] = arg
         msg = 'PAGER set to %s.' % arg
+        set_pager_enabled(True)
 
     return [(None, None, None, msg)]
+
+@special_command('nopager', '\\n', 'Disable pager, print to stdout.',
+        arg_type=NO_QUERY, aliases=('\\n', ), case_sensitive=True)
+def disable_pager():
+    set_pager_enabled(False)
+    return [(None, None, None, 'Pager disabled.')]
+
+@export
+def is_pager_enabled():
+    return PAGER_ENABLED
+
 
 @special_command('\\timing', '\\t', 'Toggle timing of commands.', arg_type=NO_QUERY, aliases=('\\t', ), case_sensitive=True)
 def toggle_timing():

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -54,16 +54,12 @@ def set_pager(arg, **_):
 
     return [(None, None, None, msg)]
 
+@export
 @special_command('nopager', '\\n', 'Disable pager, print to stdout.',
-        arg_type=NO_QUERY, aliases=('\\n', ), case_sensitive=True)
+                 arg_type=NO_QUERY, aliases=('\\n', ), case_sensitive=True)
 def disable_pager():
     set_pager_enabled(False)
     return [(None, None, None, 'Pager disabled.')]
-
-@export
-def is_pager_enabled():
-    return PAGER_ENABLED
-
 
 @special_command('\\timing', '\\t', 'Toggle timing of commands.', arg_type=NO_QUERY, aliases=('\\t', ), case_sensitive=True)
 def toggle_timing():


### PR DESCRIPTION
This pull request adds support for the `nopager` and `\n` commands (that mimic MySQL's client). Issuing either of those commands will disable the pager until the pager is set again with the `pager` or `\P` command.

It also adds support for the `skip-pager` config option in user's `.my.cnf` file. Like expected, this must be specified in the `[client]` section of the file. If `skip-pager` is set, regardless of the value, the pager will be disabled. This mimics MySQL's behavior.