### PR TITLE
Adds support for alternate login path file names

### DIFF
--- a/mycli/config.py
+++ b/mycli/config.py
@@ -74,7 +74,7 @@ def write_default_config(source, destination, overwrite=False):
     shutil.copyfile(source, destination)
 
 def get_mylogin_cnf_path():
-    """Return the path to the .mylogin.cnf file or None if doesn't exist."""
+    """Return the path to the login path file or None if it doesn't exist."""
     mylogin_cnf_path = os.getenv('MYSQL_TEST_LOGIN_FILE')
 
     if mylogin_cnf_path is None:

--- a/mycli/config.py
+++ b/mycli/config.py
@@ -75,14 +75,14 @@ def write_default_config(source, destination, overwrite=False):
 
 def get_mylogin_cnf_path():
     """Return the path to the .mylogin.cnf file or None if doesn't exist."""
-    app_data = os.getenv('APPDATA')
-    if app_data is None:
-        mylogin_cnf_dir = os.path.expanduser('~')
-    else:
-        mylogin_cnf_dir = os.path.join(app_data, 'MySQL')
+    mylogin_cnf_path = os.getenv('MYSQL_TEST_LOGIN_FILE')
 
-    mylogin_cnf_dir = os.path.abspath(mylogin_cnf_dir)
-    mylogin_cnf_path = os.path.join(mylogin_cnf_dir, '.mylogin.cnf')
+    if mylogin_cnf_path is None:
+        app_data = os.getenv('APPDATA')
+        default_dir = os.path.join(app_data, 'MySQL') if app_data else '~'
+        mylogin_cnf_path = os.path.join(default_dir, '.mylogin.cnf')
+
+    mylogin_cnf_path = os.path.expanduser(mylogin_cnf_path)
 
     if exists(mylogin_cnf_path):
         logger.debug("Found login path file at '{0}'".format(mylogin_cnf_path))

--- a/tests/test_login_path.py
+++ b/tests/test_login_path.py
@@ -96,11 +96,15 @@ def test_corrupted_pad():
 
 def test_get_mylogin_cnf_path():
     """Tests that the path for .mylogin.cnf is detected."""
+    original_env = None
     if 'MYSQL_TEST_LOGIN_FILE' in os.environ:
-        del os.environ['MYSQL_TEST_LOGIN_FILE']
+        original_env = os.environ.pop('MYSQL_TEST_LOGIN_FILE')
     is_windows = sys.platform == 'win32'
 
     login_cnf_path = get_mylogin_cnf_path()
+
+    if original_env is not None:
+        os.environ['MYSQL_TEST_LOGIN_FILE'] = original_env
 
     if login_cnf_path is not None:
         assert login_cnf_path.endswith('.mylogin.cnf')
@@ -114,9 +118,16 @@ def test_get_mylogin_cnf_path():
 
 def test_alternate_get_mylogin_cnf_path():
     """Tests that the alternate path for .mylogin.cnf is detected."""
+    original_env = None
+    if 'MYSQL_TEST_LOGIN_FILE' in os.environ:
+        original_env = os.environ.pop('MYSQL_TEST_LOGIN_FILE')
+
     temp_fh, temp_path = tempfile.mkstemp()
     os.environ['MYSQL_TEST_LOGIN_FILE'] = temp_path
 
     login_cnf_path = get_mylogin_cnf_path()
+
+    if original_env is not None:
+        os.environ['MYSQL_TEST_LOGIN_FILE'] = original_env
 
     assert temp_path == login_cnf_path

--- a/tests/test_login_path.py
+++ b/tests/test_login_path.py
@@ -122,7 +122,7 @@ def test_alternate_get_mylogin_cnf_path():
     if 'MYSQL_TEST_LOGIN_FILE' in os.environ:
         original_env = os.environ.pop('MYSQL_TEST_LOGIN_FILE')
 
-    temp_fh, temp_path = tempfile.mkstemp()
+    temp_path = tempfile.mkstemp()[1]
     os.environ['MYSQL_TEST_LOGIN_FILE'] = temp_path
 
     login_cnf_path = get_mylogin_cnf_path()

--- a/tests/test_login_path.py
+++ b/tests/test_login_path.py
@@ -96,7 +96,8 @@ def test_corrupted_pad():
 
 def test_get_mylogin_cnf_path():
     """Tests that the path for .mylogin.cnf is detected."""
-    del os.environ['MYSQL_TEST_LOGIN_FILE']
+    if 'MYSQL_TEST_LOGIN_FILE' in os.environ:
+        del os.environ['MYSQL_TEST_LOGIN_FILE']
     is_windows = sys.platform == 'win32'
 
     login_cnf_path = get_mylogin_cnf_path()

--- a/tests/test_login_path.py
+++ b/tests/test_login_path.py
@@ -122,7 +122,7 @@ def test_alternate_get_mylogin_cnf_path():
     if 'MYSQL_TEST_LOGIN_FILE' in os.environ:
         original_env = os.environ.pop('MYSQL_TEST_LOGIN_FILE')
 
-    temp_path = tempfile.mkstemp()[1]
+    _, temp_path = tempfile.mkstemp()
     os.environ['MYSQL_TEST_LOGIN_FILE'] = temp_path
 
     login_cnf_path = get_mylogin_cnf_path()

--- a/tests/test_login_path.py
+++ b/tests/test_login_path.py
@@ -3,10 +3,12 @@ from io import BytesIO, TextIOWrapper
 import os
 import pip
 import struct
+import sys
+import tempfile
 import pytest
 
-from mycli.config import open_mylogin_cnf, read_and_decrypt_mylogin_cnf, \
-    CryptoError
+from mycli.config import (CryptoError, get_mylogin_cnf_path,
+                          open_mylogin_cnf, read_and_decrypt_mylogin_cnf)
 
 with_pycrypto = ['pycrypto' in set([package.project_name for package in
                                     pip.get_installed_distributions()])]
@@ -90,3 +92,30 @@ def test_corrupted_pad():
     for word in ('[test]', 'password', 'host', 'port'):
         assert word in contents
     assert 'user' not in contents
+
+
+def test_get_mylogin_cnf_path():
+    """Tests that the path for .mylogin.cnf is detected."""
+    del os.environ['MYSQL_TEST_LOGIN_FILE']
+    is_windows = sys.platform == 'win32'
+
+    login_cnf_path = get_mylogin_cnf_path()
+
+    if login_cnf_path is not None:
+        assert login_cnf_path.endswith('.mylogin.cnf')
+
+        if is_windows is True:
+            assert 'MySQL' in login_cnf_path
+        else:
+            home_dir = os.path.expanduser('~')
+            assert login_cnf_path.startswith(home_dir)
+
+
+def test_alternate_get_mylogin_cnf_path():
+    """Tests that the alternate path for .mylogin.cnf is detected."""
+    temp_fh, temp_path = tempfile.mkstemp()
+    os.environ['MYSQL_TEST_LOGIN_FILE'] = temp_path
+
+    login_cnf_path = get_mylogin_cnf_path()
+
+    assert temp_path == login_cnf_path


### PR DESCRIPTION
This pull request adds support for the environment variable `MYSQL_TEST_LOGIN_FILE`. The MySQL docs [say this about it](http://dev.mysql.com/doc/refman/5.7/en/mysql-config-editor.html):

> To specify an alternate login path file name, set the `MYSQL_TEST_LOGIN_FILE` environment variable. This variable is recognized by **mysql_config_editor**, by standard MySQL clients (**mysql**, **mysqladmin**, and so forth), and by the **mysql-test-run.pl** testing utility.

Basically, it's a way to customize where the login path file is stored. By default, it is `%APPDATA%\MySQL\.mylogin.cnf` on Windows and `~/.mylogin.cnf` on Unix/Linux/OS X.

This pull request also adds tests for detecting both standard and alternate login path files.