### PR TITLE
Refactors pager code

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -368,8 +368,7 @@ class MyCli(object):
     def run_cli(self):
         sqlexecute = self.sqlexecute
         logger = self.logger
-        original_less_opts = self.adjust_less_opts()
-        self.set_pager_from_config()
+        self.configure_pager()
 
         self.refresh_completions()
 
@@ -560,10 +559,6 @@ class MyCli(object):
 
         except EOFError:
             self.output('Goodbye!')
-        finally:  # Reset the less opts back to original.
-            logger.debug('Restoring env var LESS to %r.', original_less_opts)
-            os.environ['LESS'] = original_less_opts
-            os.environ['PAGER'] = special.get_original_pager()
 
     def output(self, text, **kwargs):
         if self.logfile:
@@ -577,14 +572,10 @@ class MyCli(object):
             self.logfile.write('\n')
         click.echo_via_pager(text)
 
-    def adjust_less_opts(self):
-        less_opts = os.environ.get('LESS', '')
-        self.logger.debug('Original value for LESS env var: %r', less_opts)
+    def configure_pager(self):
+        # Provide sane defaults for less.
         os.environ['LESS'] = '-SRXF'
 
-        return less_opts
-
-    def set_pager_from_config(self):
         cnf = self.read_my_cnf_files(self.cnf_files, ['pager', 'skip-pager'])
         if cnf['pager']:
             special.set_pager(cnf['pager'])

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -14,7 +14,6 @@ from .utils import handle_cd_command
 
 TIMING_ENABLED = False
 use_expanded_output = False
-ORIGINAL_PAGER = os.environ.get('PAGER', '')
 PAGER_ENABLED = True
 
 @export
@@ -32,24 +31,18 @@ def is_pager_enabled():
     return PAGER_ENABLED
 
 @export
-def get_original_pager():
-    return ORIGINAL_PAGER
-
-@export
 @special_command('pager', '\\P [command]', 'Set PAGER. Print the query results via PAGER', arg_type=PARSED_QUERY, aliases=('\\P', ), case_sensitive=True)
 def set_pager(arg, **_):
-    if not arg:
-        if not ORIGINAL_PAGER:
-            os.environ.pop('PAGER', None)
-            msg = 'Reset pager.'
-            set_pager_enabled(False)
-        else:
-            os.environ['PAGER'] = ORIGINAL_PAGER
-            msg = 'Reset pager back to default. Default: %s' % ORIGINAL_PAGER
-            set_pager_enabled(True)
-    else:
+    if arg:
         os.environ['PAGER'] = arg
         msg = 'PAGER set to %s.' % arg
+        set_pager_enabled(True)
+    else:
+        if 'PAGER' in os.environ:
+            msg = 'PAGER set to %s.' % os.environ['PAGER']
+        else:
+            # This uses click's default per echo_via_pager.
+            msg = 'Pager enabled.'
         set_pager_enabled(True)
 
     return [(None, None, None, msg)]


### PR DESCRIPTION
This pull request removes some unneeded code and makes the pager functionality a bit more intuitive.

First, it removes code that "resets" the environment variables `PAGER` and `LESS`. This is not needed because Python's environment variable changes do not affect the global environment.

Second, it adjusts the behavior of the `pager` command to respect the `pager` config once started up. Imagine a `my.cnf` set to use pager `less` and an environment variable `PAGER` set to `more`.

* mycli starts up with `PAGER` set to `less`.
* User runs `nopager`, executes commands, then runs `pager`.
* `PAGER` is now set to `more`.
* User runs `pager less`. Pager now set to `less`.
* User runs `nopager`, executes commands, then runs `pager`.
* `PAGER` is now set to `more`.

This PR updates this so that the set pager does not change on the user.