### PR TITLE
Adds status command

### DIFF
--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -4,6 +4,7 @@ import platform
 from mycli import __version__
 from mycli.packages.tabulate import tabulate
 from mycli.packages.special import iocommands
+from mycli.packages.special.utils import format_uptime
 from .main import special_command, RAW_QUERY, PARSED_QUERY
 
 log = logging.getLogger(__name__)
@@ -32,36 +33,6 @@ def list_databases(cur, **_):
         return [(None, cur, headers, '')]
     else:
         return [(None, None, None, '')]
-
-def format_uptime(uptime_in_seconds):
-    """Format number of seconds into human-readable string.
-
-    :param uptime_in_seconds: The server uptime in seconds.
-    :returns: A human-readable string representing the uptime.
-
-    >>> uptime = format_uptime('56892')
-    >>> print(uptime)
-    15 hours 48 min 12 sec
-    """
-
-    m, s = divmod(int(uptime_in_seconds), 60)
-    h, m = divmod(m, 60)
-    d, h = divmod(h, 24)
-
-    uptime_values = []
-
-    for value, unit in ((d, 'days'), (h, 'hours'), (m, 'min'), (s, 'sec')):
-        if value == 0 and not uptime_values:
-            # Don't include a value/unit if the unit isn't applicable to
-            # the uptime. E.g. don't do 0 days 0 hours 1 min 30 sec.
-            continue
-        elif value == 1 and unit.endswith('s'):
-            # Remove the "s" if the unit is singular.
-            unit = unit[:-1]
-        uptime_values.append('{} {}'.format(value, unit))
-
-    uptime = ' '.join(uptime_values)
-    return uptime
 
 @special_command('status', '\\s', 'Get status information from the server.',
                  arg_type=RAW_QUERY, aliases=('\\s', ), case_sensitive=True)

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -1,4 +1,9 @@
 import logging
+import os
+import platform
+from mycli import __version__
+from mycli.packages.tabulate import tabulate
+from mycli.packages.special import iocommands
 from .main import special_command, RAW_QUERY, PARSED_QUERY
 
 log = logging.getLogger(__name__)
@@ -28,3 +33,126 @@ def list_databases(cur, **_):
     else:
         return [(None, None, None, '')]
 
+def format_uptime(uptime_in_seconds):
+    """Format number of seconds into human-readable string.
+
+    :param uptime_in_seconds: The server uptime in seconds.
+    :returns: A human-readable string representing the uptime.
+
+    >>> uptime = format_uptime('56892')
+    >>> print(uptime)
+    15 hours 48 min 12 sec
+    """
+
+    m, s = divmod(int(uptime_in_seconds), 60)
+    h, m = divmod(m, 60)
+    d, h = divmod(h, 24)
+
+    uptime_values = []
+
+    for value, unit in ((d, 'days'), (h, 'hours'), (m, 'min'), (s, 'sec')):
+        if value == 0 and not uptime_values:
+            # Don't include a value/unit if the unit isn't applicable to
+            # the uptime. E.g. don't do 0 days 0 hours 1 min 30 sec.
+            continue
+        elif value == 1 and unit.endswith('s'):
+            # Remove the "s" if the unit is singular.
+            unit = unit[:-1]
+        uptime_values.append('{} {}'.format(value, unit))
+
+    uptime = ' '.join(uptime_values)
+    return uptime
+
+@special_command('status', '\\s', 'Get status information from the server.',
+                 arg_type=RAW_QUERY, case_sensitive=True)
+def status(cur, **_):
+    query = 'SHOW GLOBAL STATUS;'
+    log.debug(query)
+    cur.execute(query)
+    status = dict(cur.fetchall())
+
+    query = 'SHOW GLOBAL VARIABLES;'
+    log.debug(query)
+    cur.execute(query)
+    variables = dict(cur.fetchall())
+
+    print('--------------')
+
+    # Output the mycli client information.
+    implementation = platform.python_implementation()
+    version = platform.python_version()
+    header = []
+    header.append('mycli {},'.format(__version__))
+    header.append('running on {} {}'.format(implementation, version))
+    print(' '.join(header) + '\n')
+
+    # Build the output that will be displayed as a table.
+    output = []
+
+    output.append(('Connection id:', cur.connection.thread_id()))
+
+    query = 'SELECT DATABASE(), USER();'
+    log.debug(query)
+    cur.execute(query)
+    db, user = cur.fetchone()
+    if db is None:
+        db = ''
+
+    output.append(('Current database:', db))
+    output.append(('Current user:', user))
+
+    if iocommands.is_pager_enabled():
+        if 'PAGER' in os.environ:
+            pager = os.environ['PAGER']
+        else:
+            pager = 'System default'
+    else:
+        pager = 'stdout'
+    output.append(('Current pager:', pager))
+
+    output.append(('Server version:', '{} {}'.format(
+        variables['version'], variables['version_comment'])))
+    output.append(('Protocol version:', variables['protocol_version']))
+
+    if 'unix' in cur.connection.host_info.lower():
+        host_info = cur.connection.host_info
+    else:
+        host_info = '{} via TCP/IP'.format(cur.connection.host)
+
+    output.append(('Connection:', host_info))
+
+    query = ('SELECT @@character_set_server, @@character_set_database, '
+             '@@character_set_client, @@character_set_connection LIMIT 1;')
+    log.debug(query)
+    cur.execute(query)
+    charset = cur.fetchone()
+    output.append(('Server characterset:', charset[0]))
+    output.append(('Db characterset:', charset[1]))
+    output.append(('Client characterset:', charset[2]))
+    output.append(('Conn. characterset:', charset[3]))
+
+    if 'TCP/IP' in host_info:
+        output.append(('TCP port:', cur.connection.port))
+    else:
+        output.append(('UNIX socket:', variables['socket']))
+
+    output.append(('Uptime:', format_uptime(status['Uptime'])))
+
+    # Print the buffered output in two columns.
+    print(tabulate(output, tablefmt='plain')[0])
+
+    # Print the current server statistics.
+    stats = []
+    stats.append('Connections: {}'.format(status['Threads_connected']))
+    stats.append('Questions: {}'.format(status['Queries']))
+    stats.append('Slow queries: {}'.format(status['Slow_queries']))
+    stats.append('Opens: {}'.format(status['Opened_tables']))
+    stats.append('Flush tables: {}'.format(status['Flush_commands']))
+    stats.append('Open tables: {}'.format(status['Open_tables']))
+    queries_per_second = int(status['Queries']) / int(status['Uptime'])
+    stats.append('Queries per second avg: {:.3f}'.format(queries_per_second))
+    stats = '  '.join(stats)
+    print('\n' + stats)
+
+    print('--------------')
+    return [(None, None, None, '')]

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -64,7 +64,7 @@ def format_uptime(uptime_in_seconds):
     return uptime
 
 @special_command('status', '\\s', 'Get status information from the server.',
-                 arg_type=RAW_QUERY, case_sensitive=True)
+                 arg_type=RAW_QUERY, aliases=('\\s', ), case_sensitive=True)
 def status(cur, **_):
     query = 'SHOW GLOBAL STATUS;'
     log.debug(query)

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -53,8 +53,8 @@ def status(cur, **_):
     implementation = platform.python_implementation()
     version = platform.python_version()
     header = []
-    header.append('mycli {},'.format(__version__))
-    header.append('running on {} {}'.format(implementation, version))
+    header.append('mycli {0},'.format(__version__))
+    header.append('running on {0} {1}'.format(implementation, version))
     print(' '.join(header) + '\n')
 
     # Build the output that will be displayed as a table.
@@ -81,14 +81,14 @@ def status(cur, **_):
         pager = 'stdout'
     output.append(('Current pager:', pager))
 
-    output.append(('Server version:', '{} {}'.format(
+    output.append(('Server version:', '{0} {1}'.format(
         variables['version'], variables['version_comment'])))
     output.append(('Protocol version:', variables['protocol_version']))
 
     if 'unix' in cur.connection.host_info.lower():
         host_info = cur.connection.host_info
     else:
-        host_info = '{} via TCP/IP'.format(cur.connection.host)
+        host_info = '{0} via TCP/IP'.format(cur.connection.host)
 
     output.append(('Connection:', host_info))
 
@@ -114,12 +114,12 @@ def status(cur, **_):
 
     # Print the current server statistics.
     stats = []
-    stats.append('Connections: {}'.format(status['Threads_connected']))
-    stats.append('Questions: {}'.format(status['Queries']))
-    stats.append('Slow queries: {}'.format(status['Slow_queries']))
-    stats.append('Opens: {}'.format(status['Opened_tables']))
-    stats.append('Flush tables: {}'.format(status['Flush_commands']))
-    stats.append('Open tables: {}'.format(status['Open_tables']))
+    stats.append('Connections: {0}'.format(status['Threads_connected']))
+    stats.append('Questions: {0}'.format(status['Queries']))
+    stats.append('Slow queries: {0}'.format(status['Slow_queries']))
+    stats.append('Opens: {0}'.format(status['Opened_tables']))
+    stats.append('Flush tables: {0}'.format(status['Flush_commands']))
+    stats.append('Open tables: {0}'.format(status['Open_tables']))
     queries_per_second = int(status['Queries']) / int(status['Uptime'])
     stats.append('Queries per second avg: {:.3f}'.format(queries_per_second))
     stats = '  '.join(stats)

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -115,7 +115,7 @@ def status(cur, **_):
     # Print the current server statistics.
     stats = []
     stats.append('Connections: {0}'.format(status['Threads_connected']))
-    stats.append('Questions: {0}'.format(status['Queries']))
+    stats.append('Queries: {0}'.format(status['Queries']))
     stats.append('Slow queries: {0}'.format(status['Slow_queries']))
     stats.append('Opens: {0}'.format(status['Opened_tables']))
     stats.append('Flush tables: {0}'.format(status['Flush_commands']))

--- a/mycli/packages/special/utils.py
+++ b/mycli/packages/special/utils.py
@@ -14,3 +14,33 @@ def handle_cd_command(arg):
         return True, None
     except OSError as e:
         return False, e.strerror
+
+def format_uptime(uptime_in_seconds):
+    """Format number of seconds into human-readable string.
+
+    :param uptime_in_seconds: The server uptime in seconds.
+    :returns: A human-readable string representing the uptime.
+
+    >>> uptime = format_uptime('56892')
+    >>> print(uptime)
+    15 hours 48 min 12 sec
+    """
+
+    m, s = divmod(int(uptime_in_seconds), 60)
+    h, m = divmod(m, 60)
+    d, h = divmod(h, 24)
+
+    uptime_values = []
+
+    for value, unit in ((d, 'days'), (h, 'hours'), (m, 'min'), (s, 'sec')):
+        if value == 0 and not uptime_values:
+            # Don't include a value/unit if the unit isn't applicable to
+            # the uptime. E.g. don't do 0 days 0 hours 1 min 30 sec.
+            continue
+        elif value == 1 and unit.endswith('s'):
+            # Remove the "s" if the unit is singular.
+            unit = unit[:-1]
+        uptime_values.append('{} {}'.format(value, unit))
+
+    uptime = ' '.join(uptime_values)
+    return uptime

--- a/mycli/packages/special/utils.py
+++ b/mycli/packages/special/utils.py
@@ -40,7 +40,7 @@ def format_uptime(uptime_in_seconds):
         elif value == 1 and unit.endswith('s'):
             # Remove the "s" if the unit is singular.
             unit = unit[:-1]
-        uptime_values.append('{} {}'.format(value, unit))
+        uptime_values.append('{0} {1}'.format(value, unit))
 
     uptime = ' '.join(uptime_values)
     return uptime

--- a/tests/test_dbspecial.py
+++ b/tests/test_dbspecial.py
@@ -1,5 +1,6 @@
 from mycli.packages.completion_engine import suggest_type
 from test_completion_engine import sorted_dicts
+from mycli.packages.special.utils import format_uptime
 
 def test_u_suggests_databases():
     suggestions = suggest_type('\\u ', '\\u ')
@@ -13,3 +14,20 @@ def test_describe_table():
         {'type': 'table', 'schema': []},
         {'type': 'view', 'schema': []},
         {'type': 'schema'}])
+
+
+def test_format_uptime():
+    seconds = 59
+    assert '59 sec' == format_uptime(seconds)
+
+    seconds = 120
+    assert '2 min 0 sec' == format_uptime(seconds)
+
+    seconds = 54890
+    assert '15 hours 14 min 50 sec' == format_uptime(seconds)
+
+    seconds = 598244
+    assert '6 days 22 hours 10 min 44 sec' == format_uptime(seconds)
+
+    seconds = 522600
+    assert '6 days 1 hour 10 min 0 sec' == format_uptime(seconds)


### PR DESCRIPTION
This addresses #223.

The `status`/`\s` command is implemented by the official MySQL command-line client. It provides information about the server, client, and connection. The implementation offered in this pull request is extremely similar. The differences are detailed below.

Here is some example output from this command (with the IP address scrubbed).
```
mysql troten@db02:(none)> \s
--------------
mycli 1.5.2, running on CPython 3.5.0

Connection id:        9889
Current database:
Current user:         troten@XX-XX-XX-XXX.ded.swbell.net
Current pager:        System default
Server version:       5.6.28-0ubuntu0.14.04.1-log (Ubuntu)
Protocol version:     10
Connection:           db02 via TCP/IP
Server characterset:  latin1
Db characterset:      latin1
Client characterset:  utf8
Conn. characterset:   utf8
TCP port:             3306
Uptime:               9 days 12 hours 52 min 38 sec

Connections: 4  Queries: 51493578  Slow queries: 23333  Opens: 909  Flush tables: 1  Open tables: 672  Queries per second avg: 62.495
--------------

Time: 0.193s
```

A few things to note:

* The first line of the output is information about the client. The MySQL CLI client includes information about the server the client is bundled with (not the connected server). I opted to provide information about mycli and what version/flavor of Python it is running on (e.g. Jython, PyPy, etc.).
* I've left out the information about the delimiter and outfile. The delimiter is not applicable to mycli. The outfile (called audit log in mycli) is applicable, but I couldn't figure out a clean way to detect that file from the `dbcommands.py` module.
* The SSL data has not been included because, as of right now, mycli does not support this.
* The bottom line contains current statistics about the server. I've done away with "Threads" in favor of "Connections" (like MySQL Workbench) because the number of active connections is, to me, a more helpful number than the number of threads.
* I've also renamed the statistic "Questions" to "Queries" so it is less cryptic and truer to the status variable it references on the server.

Here is a detailed description of each line/statistic in the `status` output:

* Client information: mycli's version number, the python implementation, and python version
* [Connection id](http://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_connection-id): The unique connection (or thread) ID. This is the ID used in the `INFORMATION_SCHEMA.PROCESSLIST` table.
* Current database: the name of the database currently being used, or a blank string if there is none.
* [Current user](http://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_user): The user name specified when connecting to the server and the client host from which you connected.
* Current pager: The configured pager or output method. If the pager is enabled, this is the value of `os.environ['PAGER']` or `System default`. If the pager is disabled, then `stdout`.
* Server version: The version number and version comment of the server. E.g. `5.7.10 Homebrew` or `5.6.28-0ubuntu0.14.04.1-log (Ubuntu)`
* Protocol version: the version of the client/server protocol used by the server.
* Connection: whether or not the connection is over TCP/IP or a UNIX socket.
* Character sets: The character encoding used at the various stages in the client <--> server connection.
* TCP port (or UNIX socket): Information about the connection. If over TCP, then the port. If via a socket, then the specific socket being used.
* Uptime: the human-readable server uptime.
* Server statistics:
  - [Connections](http://dev.mysql.com/doc/refman/5.7/en/server-status-variables.html#statvar_Threads_connected): The number of currently open connections.
  - [Queries](http://dev.mysql.com/doc/refman/5.7/en/server-status-variables.html#statvar_Queries): The number of statements executed by the server. This includes those executed within stored programs.
  - [Slow queries](http://dev.mysql.com/doc/refman/5.7/en/server-status-variables.html#statvar_Slow_queries): The number of queries that have taken a long time (greater than `long_query_time` seconds).
  - [Opens](http://dev.mysql.com/doc/refman/5.7/en/server-status-variables.html#statvar_Opened_tables): The number of tables that have been opened.
  - [Flush tables](http://dev.mysql.com/doc/refman/5.7/en/server-status-variables.html#statvar_Flush_commands): The number of times the server flushes tables. This could be due to internal server operation or a user calling a `FLUSH TABLES` statement.
  - [Open tables](http://dev.mysql.com/doc/refman/5.7/en/server-status-variables.html#statvar_Open_tables): The number of tables that are open.
  - Queries per second avg.: The total number of statements divided by the uptime in seconds. This number is rounded to 3 decimal places.

Reviewer: @amjith 