### PR TITLE
Use expanduser to expand the tilde in the path names.

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -720,22 +720,15 @@ def cli(database, user, host, port, socket, password, dbname,
     # Choose which ever one has a valid value.
     database = database or dbname
 
-    ssl_paths = {
-        'ca': ssl_ca,
-        'cert': ssl_cert,
-        'key': ssl_key,
-    }
-    ssl_params = {
-        'capath': ssl_capath,
-        'cipher': ssl_cipher,
-        'check_hostname': ssl_verify_server_cert,
-    }
-    for p in ssl_paths:
-        if p:
-            ssl_paths[p] = os.path.expanduser(p)
-    ssl = {}
-    ssl.update(ssl_paths)
-    ssl.update(ssl_params)
+    ssl = {
+            'ca': os.path.expanduser(ssl_ca),
+            'cert': os.path.expanduser(ssl_cert),
+            'key': os.path.expanduser(ssl_key),
+            'capath': ssl_capath,
+            'cipher': ssl_cipher,
+            'check_hostname': ssl_verify_server_cert,
+            }
+
     # remove empty ssl options
     ssl = dict((k, v) for (k, v) in ssl.items() if v is not None)
     if database and '://' in database:

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -721,9 +721,9 @@ def cli(database, user, host, port, socket, password, dbname,
     database = database or dbname
 
     ssl = {
-            'ca': os.path.expanduser(ssl_ca),
-            'cert': os.path.expanduser(ssl_cert),
-            'key': os.path.expanduser(ssl_key),
+            'ca': ssl_ca and os.path.expanduser(ssl_ca),
+            'cert': ssl_cert and os.path.expanduser(ssl_cert),
+            'key': ssl_key and os.path.expanduser(ssl_key),
             'capath': ssl_capath,
             'cipher': ssl_cipher,
             'check_hostname': ssl_verify_server_cert,


### PR DESCRIPTION
Reviewer: @tsroten 

This is a follow up PR for #232. 

In #232 @mrdeathless added the ability to supply ssl options to mycli. A few of the options were path names to ssl cert files. The path names with tilde must be expanded otherwise it will fail to find the file. 

The original PR added the expanduser() but it ended up overwriting the paths with incorrect values. This PR fixes that issue. 

