### PR TITLE
Simplify status message generation.

### DIFF
--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -122,28 +122,19 @@ class SQLExecute(object):
         _logger.debug('Regular sql statement. sql: %r', split_sql)
         cur = self.conn.cursor()
         num_rows = cur.execute(split_sql)
-        title = None
-        if num_rows == 1:
-            status = '%d row in set' % num_rows
-        else:
-            status = '%d rows in set' % num_rows
-        with self.conn.cursor() as temp_cursor:
-            temp_cursor.execute('SELECT row_count()')
-            n = temp_cursor.fetchone()[0]
-            if n < 0:
-                pass
-            elif n == 1:
-                status = 'Query OK, %d row affected' % n
-            else:
-                status = 'Query OK, %d rows affected' % n
-        # cur.description will be None for operations that do not return
-        # rows.
-        if cur.description:
+        title = headers = None
+
+        # cur.description is not None for queries that return result sets, e.g.
+        # SELECT or SHOW.
+        if cur.description is not None:
             headers = [x[0] for x in cur.description]
-            return (title, cur, headers, status)  # cur.statusmessage)
+            status = '{} row{} in set'
         else:
             _logger.debug('No rows in result.')
-            return (title, None, None, status)  # cur.statusmessage)
+            status = 'Query OK, {} row{} affected'
+        status = status.format(num_rows, '' if num_rows == 1 else 's')
+
+        return (title, cur if cur.description else None, headers, status)
 
     def tables(self):
         """Yields table names"""

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -128,10 +128,10 @@ class SQLExecute(object):
         # SELECT or SHOW.
         if cur.description is not None:
             headers = [x[0] for x in cur.description]
-            status = '{} row{} in set'
+            status = '{0} row{1} in set'
         else:
             _logger.debug('No rows in result.')
-            status = 'Query OK, {} row{} affected'
+            status = 'Query OK, {0} row{1} affected'
         status = status.format(num_rows, '' if num_rows == 1 else 's')
 
         return (title, cur if cur.description else None, headers, status)


### PR DESCRIPTION
This removes the extra SQL call to `ROW_COUNT()` by using `cur.execute()`'s return value (which is [PEP 0249's `rowcount`](https://www.python.org/dev/peps/pep-0249/#rowcount) -- the number of affected rows) in order display the number of rows produced or affected.

It also simplifies the code that makes `row` single or plural in the status message.

This is also related to #233, where the call to `row_count()` appears to be displayed as the result. I'm not sure if it will fix that problem, though.

Reviewer: @amjith 