### PR TITLE
Fix PyMySQL version check.

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -533,7 +533,7 @@ class MyCli(object):
                         mutating = mutating or is_mutating(status)
                 except UnicodeDecodeError as e:
                     import pymysql
-                    if pymysql.VERSION < ('0', '6', '7'):
+                    if pymysql.VERSION < (0, 6, 7):
                         message = ('You are running an older version of pymysql.\n'
                                 'Please upgrade to 0.6.7 or above to view binary data.\n'
                                 'Try \'pip install -U pymysql\'.')

--- a/tests/test_sqlexecute.py
+++ b/tests/test_sqlexecute.py
@@ -6,6 +6,9 @@ import os
 from textwrap import dedent
 from utils import run, dbtest, set_expanded_output
 
+
+pymysql_support_binary = pymysql.VERSION >= (0, 6, 7)
+
 @dbtest
 def test_conn(executor):
     run(executor, '''create table test(a text)''')
@@ -33,6 +36,7 @@ def test_bools(executor):
         1 row in set""")
 
 @dbtest
+@pytest.mark.skipif(not pymysql_support_binary, reason='pymysql < 0.6.7')
 def test_binary(executor):
     run(executor, '''create table bt(geom linestring NOT NULL)''')
     run(executor, '''INSERT INTO bt VALUES (GeomFromText('LINESTRING(116.37604 39.73979,116.375 39.73965)'));''')
@@ -46,6 +50,7 @@ def test_binary(executor):
         1 row in set""")
 
 @dbtest
+@pytest.mark.skipif(not pymysql_support_binary, reason='pymysql < 0.6.7')
 def test_binary_expanded(executor):
     run(executor, '''create table bt(geom linestring NOT NULL)''')
     run(executor, '''INSERT INTO bt VALUES (GeomFromText('LINESTRING(116.37604 39.73979,116.375 39.73965)'));''')


### PR DESCRIPTION
If you use a version of PyMySQL less than 0.6.7, you get this error (and mycli crashes) when attempting to read binary data:

```
  File "/Users/troten/code/mycli/mycli/main.py", line 536, in run_cli
    if pymysql.VERSION < ('0', '6', '7'):
TypeError: unorderable types: int() < str()
```

This pull request fixes this by comparing the version using integers, not strings. It also makes the test suite skip the appropriate tests if the version doesn't support them.

Reviewer: @mdsrosa 