### PR TITLE
Remove license meta-data.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         author='Amjith Ramanujam',
         author_email='amjith[dot]r[at]gmail.com',
         version=version,
-        license='LICENSE.txt',
         url='http://mycli.net',
         packages=find_packages(),
         package_data={'mycli': ['myclirc', '../AUTHORS', '../SPONSORS']},


### PR DESCRIPTION
This is a very short/unimportant PR :)

[Per the Python docs](https://docs.python.org/3/distutils/setupscript.html#additional-meta-data), the `license` meta-data attribute shouldn't be used in mycli's case:
```The license field is a text indicating the license covering the package where the license is not a selection from the “License” Trove classifiers.```

Mycli uses the license Trove classifier, so we don't need the `license` field.