### PR TITLE
Add Python 3.5 to test environments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
 
 env:
   - PYMYSQL_VERSION=0.6.7

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
             'Programming Language :: Python :: 3',
             'Programming Language :: Python :: 3.3',
             'Programming Language :: Python :: 3.4',
+            'Programming Language :: Python :: 3.5',
             'Programming Language :: SQL',
             'Topic :: Database',
             'Topic :: Database :: Front-Ends',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py26, py27, py33, py34, py35
 [testenv]
 deps = pytest
     mock


### PR DESCRIPTION
This PR adds Python 3.5 to Tox, Travis CI, and the setup file (Trove classification). Python 3.5 has been out for almost 6 months. I've been using mycli on a daily basis on Python 3.5 for months and haven't had any problems (that were specific to Python 3.5).

The tests seem to pass just fine.

Reviewer: @amjith 