### PR TITLE
Add stdin batch mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Check the [detailed install instructions](#detailed-install-instructions) for de
       -S, --socket TEXT             The socket file to use for connection.
       -p, --password                Force password prompt.
       --pass TEXT                   Password to connect to the database
+      --ssl-ca PATH                 CA file in PEM format
+      --ssl-capath TEXT             CA directory
+      --ssl-cert PATH               X509 cert in PEM format
+      --ssl-key PATH                X509 key in PEM format
+      --ssl-cipher TEXT             SSL cipher to use
+      --ssl-verify-server-cert      Verify server's "Common Name" in its cert
+                                    against hostname used when connecting. This
+                                    option is disabled by default
       -v, --version                 Version of mycli.
       -D, --database TEXT     	    Database to use.
       -R, --prompt TEXT             Prompt format (Default: "\t \u@\h:\d> ")
@@ -56,6 +64,9 @@ Check the [detailed install instructions](#detailed-install-instructions) for de
       --auto-vertical-output        Automatically switch to vertical output mode
                                     if the result is wider than the terminal
                                     width.
+      -t, --table                   Display batch output in table format.
+      --warn / --no-warn            Warn before running a destructive query.
+      --local-infile BOOLEAN        Enable/disable LOAD DATA LOCAL INFILE.
       --login-path TEXT             Read this path from the login file.
       --help                        Show this message and exit.
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -861,13 +861,13 @@ def is_destructive(queries):
 def confirm_destructive_query(queries):
     """Check if the query is destructive and prompts the user to confirm.
     Returns:
-    None if the query is non-destructive.
+    None if the query is non-destructive or we can't prompt the user.
     True if the query is destructive and the user wants to proceed.
     False if the query is destructive and the user doesn't want to proceed.
     """
     prompt_text = ("You're about to run a destructive command.\n"
                    "Do you want to proceed? (y/n)")
-    if is_destructive(queries):
+    if is_destructive(queries) and sys.stdin.isatty():
         return click.prompt(prompt_text, type=bool)
 
 def quit_command(sql):

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -777,13 +777,17 @@ def cli(database, user, host, port, socket, password, dbname,
         if (mycli.destructive_warning and
                 confirm_destructive_query(stdin_text) is False):
             exit(0)
-        results = mycli.sqlexecute.run(stdin_text)
-        for result in results:
-            title, cur, headers, status = result
-            table_format = mycli.table_format if table else None
-            output = format_output(title, cur, headers, None, table_format)
-            for line in output:
-                click.echo(line)
+        try:
+            results = mycli.sqlexecute.run(stdin_text)
+            for result in results:
+                title, cur, headers, status = result
+                table_format = mycli.table_format if table else None
+                output = format_output(title, cur, headers, None, table_format)
+                for line in output:
+                    click.echo(line)
+        except Exception as e:
+            click.secho(str(e), err=True, fg='red')
+            exit(1)
 
 def format_output(title, cur, headers, status, table_format, expanded=False, max_width=None):
     output = []

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -202,6 +202,12 @@ class MyCli(object):
                 query = f.read()
         except IOError as e:
             return [(None, None, None, str(e))]
+
+        if (self.destructive_warning and
+            confirm_destructive_query(query) is False):
+            message = 'Wise choice. Command execution stopped.'
+            return [(None, None, None, message)]
+
         return self.sqlexecute.run(query)
 
     def change_prompt_format(self, arg, **_):

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -49,6 +49,7 @@ click.disable_unicode_literals_warning = True
 
 try:
     from urlparse import urlparse
+    FileNotFoundError = OSError
 except ImportError:
     from urllib.parse import urlparse
 from pymysql import OperationalError

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -754,18 +754,27 @@ def cli(database, user, host, port, socket, password, dbname,
             '\thost: %r'
             '\tport: %r', database, user, host, port)
 
-    stdin = click.get_text_stream('stdin')
-    if not stdin.isatty():
-        results = mycli.sqlexecute.run(stdin.read())
-        for result in results:
-            title, cur, headers, status = result
-            table_format = mycli.table_format if table else None
-            output = format_output(title, cur, headers, None, table_format)
-            for line in output:
-                click.echo(line)
-        exit(0)
+    if sys.stdin.isatty():
+        mycli.run_cli()
 
-    mycli.run_cli()
+    stdin = click.get_text_stream('stdin')
+    stdin_text = stdin.read()
+
+    try:
+        sys.stdin = open('/dev/tty')
+    except FileNotFoundError:
+        mycli.logger.warning('Unable to open TTY as stdin.')
+
+    if confirm_destructive_query(stdin_text) is False:
+        exit(0)
+    results = mycli.sqlexecute.run(stdin_text)
+    for result in results:
+        title, cur, headers, status = result
+        table_format = mycli.table_format if table else None
+        output = format_output(title, cur, headers, None, table_format)
+        for line in output:
+            click.echo(line)
+    exit(0)
 
 def format_output(title, cur, headers, status, table_format, expanded=False, max_width=None):
     output = []

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -84,7 +84,7 @@ class MyCli(object):
 
     def __init__(self, sqlexecute=None, prompt=None,
             logfile=None, defaults_suffix=None, defaults_file=None,
-            login_path=None, auto_vertical_output=False):
+            login_path=None, auto_vertical_output=False, warn=None):
         self.sqlexecute = sqlexecute
         self.logfile = logfile
         self.defaults_suffix = defaults_suffix
@@ -103,13 +103,14 @@ class MyCli(object):
                         [self.user_config_file])
         c = self.config = read_config_files(config_files)
         self.multi_line = c['main'].as_bool('multi_line')
-        self.destructive_warning = c['main'].as_bool('destructive_warning')
         self.key_bindings = c['main']['key_bindings']
         special.set_timing_enabled(c['main'].as_bool('timing'))
         self.table_format = c['main']['table_format']
         self.syntax_style = c['main']['syntax_style']
         self.cli_style = c['colors']
         self.wider_completion_menu = c['main'].as_bool('wider_completion_menu')
+        c_dest_warning = c['main'].as_bool('destructive_warning')
+        self.destructive_warning = c_dest_warning if warn is None else warn
 
         # Write user config if system config wasn't the last config loaded.
         if c.filename not in self.system_config_files:
@@ -715,6 +716,8 @@ class MyCli(object):
               help='Automatically switch to vertical output mode if the result is wider than the terminal width.')
 @click.option('-t', '--table', is_flag=True,
               help='Display batch output in table format.')
+@click.option('--warn/--no-warn', default=None,
+              help='Warn before running a destructive query.')
 @click.option('--local-infile', type=bool,
               help='Enable/disable LOAD DATA LOCAL INFILE.')
 @click.option('--login-path', type=str,
@@ -723,7 +726,7 @@ class MyCli(object):
 def cli(database, user, host, port, socket, password, dbname,
         version, prompt, logfile, defaults_group_suffix, defaults_file,
         login_path, auto_vertical_output, local_infile, ssl_ca, ssl_capath,
-        ssl_cert, ssl_key, ssl_cipher, ssl_verify_server_cert, table):
+        ssl_cert, ssl_key, ssl_cipher, ssl_verify_server_cert, table, warn):
 
     if version:
         print('Version:', __version__)
@@ -732,7 +735,7 @@ def cli(database, user, host, port, socket, password, dbname,
     mycli = MyCli(prompt=prompt, logfile=logfile,
                   defaults_suffix=defaults_group_suffix,
                   defaults_file=defaults_file, login_path=login_path,
-                  auto_vertical_output=auto_vertical_output)
+                  auto_vertical_output=auto_vertical_output, warn=warn)
 
     # Choose which ever one has a valid value.
     database = database or dbname

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -204,7 +204,7 @@ class MyCli(object):
             return [(None, None, None, str(e))]
 
         if (self.destructive_warning and
-            confirm_destructive_query(query) is False):
+                confirm_destructive_query(query) is False):
             message = 'Wise choice. Command execution stopped.'
             return [(None, None, None, message)]
 
@@ -771,7 +771,8 @@ def cli(database, user, host, port, socket, password, dbname,
         except FileNotFoundError:
             mycli.logger.warning('Unable to open TTY as stdin.')
 
-        if confirm_destructive_query(stdin_text) is False:
+        if (mycli.destructive_warning and
+                confirm_destructive_query(stdin_text) is False):
             exit(0)
         results = mycli.sqlexecute.run(stdin_text)
         for result in results:

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -239,7 +239,11 @@ class MyCli(object):
         root_logger.addHandler(handler)
         root_logger.setLevel(level_map[log_level.upper()])
 
-        logging.captureWarnings(True)
+        # Only capture warnings on Python 2.7 and later.
+        try:
+            logging.captureWarnings(True)
+        except AttributeError:
+            pass
 
         root_logger.debug('Initializing mycli logging.')
         root_logger.debug('Log file %r.', log_file)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,10 @@
-import pytest
-from mycli.main import format_output
+from click.testing import CliRunner
+
+from mycli.main import cli, format_output
+from utils import USER, HOST, PORT, PASSWORD, dbtest, run
+
+CLI_ARGS = ['--user', USER, '--host', HOST, '--port', PORT,
+            '--password', PASSWORD, '_test_db']
 
 def test_format_output():
     results = format_output('Title', [('abc', 'def')], ['head1', 'head2'],
@@ -19,3 +24,46 @@ def test_format_output_auto_expand():
                                      max_width=1)
     expanded = ['Title', u'***************************[ 1. row ]***************************\nhead1 | abc\nhead2 | def\n', 'test status']
     assert expanded_results == expanded
+
+def test_format_output_no_table():
+    results = format_output('Title', [('abc', 'def')], ['head1', 'head2'],
+                            'test status', None)
+    expected = ['Title', 'head1\thead2', 'abc\tdef', 'test status']
+    assert results == expected
+
+@dbtest
+def test_batch_mode(executor):
+    run(executor, '''create table test(a text)''')
+    run(executor, '''insert into test values('abc'), ('def'), ('ghi')''')
+
+    sql = (
+        'select count(*) from test;\n'
+        'select * from test limit 1;'
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, args=CLI_ARGS, input=sql)
+
+    assert result.exit_code == 0
+    assert 'count(*)\n3\na\nabc' in result.output
+
+@dbtest
+def test_batch_mode_table(executor):
+    run(executor, '''create table test(a text)''')
+    run(executor, '''insert into test values('abc'), ('def'), ('ghi')''')
+
+    sql = (
+        'select count(*) from test;\n'
+        'select * from test limit 1;'
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, args=CLI_ARGS + ['-t'], input=sql)
+
+    expected = (
+        '|   count(*) |\n|------------|\n|          3 |\n+------------+\n'
+        '+-----+\n| a   |\n|-----|\n| abc |\n+-----+'
+    )
+
+    assert result.exit_code == 0
+    assert expected in result.output

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,8 @@
+import click
 from click.testing import CliRunner
 
-from mycli.main import (cli, format_output, is_destructive, query_starts_with,
-                        queries_start_with)
+from mycli.main import (cli, confirm_destructive_query, format_output,
+                        is_destructive, query_starts_with, queries_start_with)
 from utils import USER, HOST, PORT, PASSWORD, dbtest, run
 
 CLI_ARGS = ['--user', USER, '--host', HOST, '--port', PORT,
@@ -97,3 +98,10 @@ def test_is_destructive(executor):
         'drop database foo;'
     )
     assert is_destructive(sql) is True
+
+def test_confirm_destructive_query_notty(executor):
+    stdin = click.get_text_stream('stdin')
+    assert stdin.isatty() is False
+
+    sql = 'drop database foo;'
+    assert confirm_destructive_query(sql) is None

--- a/tests/test_sqlexecute.py
+++ b/tests/test_sqlexecute.py
@@ -213,7 +213,7 @@ def test_favorite_query_expanded_output(executor):
 @dbtest
 def test_special_command(executor):
     results = run(executor, '\\?')
-    expected_line = u'| help      | \\?               | Show this help.                              |\n'
+    expected_line = u'| help        | \\?               | Show this help.                                        |\n'
     assert len(results) == 1
     assert expected_line in results[0]
 


### PR DESCRIPTION
This pull request adds support for reading commands from stdin. It works similar to the mysql client. If you pipe commands to mycli like this:
```bash
cat test.sql | mycli
```
or this
```bash
mycli < test.sql
```

Then, mycli will output the results in a plain, tab-separated format (no padding or status messages). If you use the `-t`/`--table` argument, then mycli will output the results in your configured table format.

After processing stdin, mycli will quit.

I can also see use for a yet-to-be-added (different PR) verbose mode that will add support for displaying the commands that are running as well as possibly status messages.

This addresses #179.