### PR TITLE
Enable history search via <C-r>.

### DIFF
--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -17,6 +17,7 @@ def mycli_bindings(get_key_bindings, set_key_bindings):
     key_binding_manager = KeyBindingManager(
             enable_open_in_editor=True,
             enable_system_bindings=True,
+            enable_search=True,
             enable_abort_and_exit_bindings=True,
             enable_vi_mode=Condition(lambda cli: get_key_bindings() == 'vi'))
 


### PR DESCRIPTION
@mdsrosa Can you review? 

We accidentally broke C-r in our previous version when we upgraded to the latest version of Prompt Toolkit. 

This fixes that issue. 

Addresses #258  #247