### PR TITLE
Upgrade to prompt-toolkit 1.0.0

### DIFF
--- a/mycli/clistyle.py
+++ b/mycli/clistyle.py
@@ -1,7 +1,6 @@
 from pygments.token import string_to_tokentype
-from pygments.style import Style
 from pygments.util import ClassNotFound
-from prompt_toolkit.styles import default_style_extensions, PygmentsStyle
+from prompt_toolkit.styles import default_style_extensions, style_from_dict
 import pygments.styles
 
 
@@ -11,12 +10,10 @@ def style_factory(name, cli_style):
     except ClassNotFound:
         style = pygments.styles.get_style_by_name('native')
 
-    class CLIStyle(Style):
-        styles = {}
+    styles = {}
+    styles.update(style.styles)
+    styles.update(default_style_extensions)
+    custom_styles = dict([(string_to_tokentype(x), y) for x, y in cli_style.items()])
+    styles.update(custom_styles)
 
-        styles.update(style.styles)
-        styles.update(default_style_extensions)
-        custom_styles = dict([(string_to_tokentype(x), y) for x, y in cli_style.items()])
-        styles.update(custom_styles)
-
-    return PygmentsStyle(CLIStyle)
+    return style_from_dict(styles)

--- a/mycli/clitoolbar.py
+++ b/mycli/clitoolbar.py
@@ -1,12 +1,10 @@
 from pygments.token import Token
-from prompt_toolkit.enums import DEFAULT_BUFFER
+from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
 
-def create_toolbar_tokens_func(get_key_bindings, get_is_refreshing):
+def create_toolbar_tokens_func(get_is_refreshing):
     """
     Return a function that generates the toolbar tokens.
     """
-    assert callable(get_key_bindings)
-
     token = Token.Toolbar
 
     def get_toolbar_tokens(cli):
@@ -27,7 +25,7 @@ def create_toolbar_tokens_func(get_key_bindings, get_is_refreshing):
             result.append((token,
                 ' (Semi-colon [;] will end the line)'))
 
-        if get_key_bindings() == 'vi':
+        if cli.editing_mode == EditingMode.VI:
             result.append((token.On, '[F4] Vi-mode'))
         else:
             result.append((token.On, '[F4] Emacs-mode'))

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -1,4 +1,5 @@
 import logging
+from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.key_binding.manager import KeyBindingManager
 from prompt_toolkit.filters import Condition
@@ -7,19 +8,15 @@ from .filters import HasSelectedCompletion
 _logger = logging.getLogger(__name__)
 
 
-def mycli_bindings(get_key_bindings, set_key_bindings):
+def mycli_bindings():
     """
     Custom key bindings for mycli.
     """
-    assert callable(get_key_bindings)
-    assert callable(set_key_bindings)
-
     key_binding_manager = KeyBindingManager(
             enable_open_in_editor=True,
             enable_system_bindings=True,
             enable_search=True,
-            enable_abort_and_exit_bindings=True,
-            enable_vi_mode=Condition(lambda cli: get_key_bindings() == 'vi'))
+            enable_abort_and_exit_bindings=True)
 
     @key_binding_manager.registry.add_binding(Keys.F2)
     def _(event):
@@ -45,10 +42,10 @@ def mycli_bindings(get_key_bindings, set_key_bindings):
         Toggle between Vi and Emacs mode.
         """
         _logger.debug('Detected F4 key.')
-        if get_key_bindings() == 'vi':
-            set_key_bindings('emacs')
+        if event.cli.editing_mode == EditingMode.VI:
+            event.cli.editing_mode = EditingMode.EMACS
         else:
-            set_key_bindings('vi')
+            event.cli.editing_mode = EditingMode.VI
 
     @key_binding_manager.registry.add_binding(Keys.Tab)
     def _(event):

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -75,6 +75,7 @@ Token.SearchMatch = '#ffffff bg:#4444aa'
 Token.SearchMatch.Current = '#ffffff bg:#44aa44'
 
 # The bottom toolbar.
+Token.Toolbar = 'bg:#222222 #aaaaaa'
 Token.Toolbar.Off = 'bg:#222222 #888888'
 Token.Toolbar.On = 'bg:#222222 #ffffff'
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ description = 'CLI for MySQL Database. With auto-completion and syntax highlight
 install_requirements = [
     'click >= 4.1',
     'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
-    'prompt_toolkit==0.60',
+    'prompt_toolkit>=1.0.0,<1.1.0',
     'PyMySQL >= 0.6.2',
     'sqlparse >= 0.1.19',
     'configobj >= 5.0.6',


### PR DESCRIPTION
A few changes for being compatible with the latest prompt-toolkit.

The changelog: https://github.com/jonathanslenders/python-prompt-toolkit/blob/master/CHANGELOG

The most important change is that the `vi_state` parameter for `KeyBindingManager` isn't used anymore. (It's ignored.) Instead, we have `CommandLineInterface.editing_mode`.