### PR TITLE
less_chatty config option

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -61,6 +61,11 @@ Query = namedtuple('Query', ['query', 'successful', 'mutating'])
 
 PACKAGE_ROOT = os.path.dirname(__file__)
 
+# no-op logging handler
+class NullHandler(logging.Handler):
+    def emit(self, record):
+        pass
+
 class MyCli(object):
 
     default_prompt = '\\t \\u@\\h:\\d> '
@@ -235,7 +240,13 @@ class MyCli(object):
                      'DEBUG': logging.DEBUG
                      }
 
-        handler = logging.FileHandler(os.path.expanduser(log_file))
+        # Disable logging if value is NONE by switching to a no-op handler
+        # Set log level to a high value so it doesn't even waste cycles getting called.
+        if log_level.upper() == "NONE":
+            handler = NullHandler()
+            log_level = "CRITICAL"
+        else:
+            handler = logging.FileHandler(os.path.expanduser(log_file))
 
         formatter = logging.Formatter(
             '%(asctime)s (%(process)d/%(threadName)s) '

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -107,7 +107,7 @@ class MyCli(object):
         special.set_timing_enabled(c['main'].as_bool('timing'))
         self.table_format = c['main']['table_format']
         self.syntax_style = c['main']['syntax_style']
-        self.skip_intro = c['main'].as_bool('skip_intro')
+        self.less_chatty = c['main'].as_bool('less_chatty')
         self.cli_style = c['colors']
         self.wider_completion_menu = c['main'].as_bool('wider_completion_menu')
         c_dest_warning = c['main'].as_bool('destructive_warning')
@@ -427,7 +427,7 @@ class MyCli(object):
 
         key_binding_manager = mycli_bindings()
 
-        if not self.skip_intro:
+        if not self.less_chatty:
             print('Version:', __version__)
             print('Chat: https://gitter.im/dbcli/mycli')
             print('Mail: https://groups.google.com/forum/#!forum/mycli-users')
@@ -612,7 +612,8 @@ class MyCli(object):
                 self.query_history.append(query)
 
         except EOFError:
-            self.output('Goodbye!')
+            if not self.less_chatty:
+                self.output('Goodbye!')
 
     def output(self, text, **kwargs):
         if self.logfile:

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -107,6 +107,7 @@ class MyCli(object):
         special.set_timing_enabled(c['main'].as_bool('timing'))
         self.table_format = c['main']['table_format']
         self.syntax_style = c['main']['syntax_style']
+        self.skip_intro = c['main'].as_bool('skip_intro')
         self.cli_style = c['colors']
         self.wider_completion_menu = c['main'].as_bool('wider_completion_menu')
         c_dest_warning = c['main'].as_bool('destructive_warning')
@@ -426,11 +427,12 @@ class MyCli(object):
 
         key_binding_manager = mycli_bindings()
 
-        print('Version:', __version__)
-        print('Chat: https://gitter.im/dbcli/mycli')
-        print('Mail: https://groups.google.com/forum/#!forum/mycli-users')
-        print('Home: http://mycli.net')
-        print('Thanks to the contributor -', thanks_picker([author_file, sponsor_file]))
+        if not self.skip_intro:
+            print('Version:', __version__)
+            print('Chat: https://gitter.im/dbcli/mycli')
+            print('Mail: https://groups.google.com/forum/#!forum/mycli-users')
+            print('Home: http://mycli.net')
+            print('Thanks to the contributor -', thanks_picker([author_file, sponsor_file]))
 
         def prompt_tokens(cli):
             return [(Token.Prompt, self.get_prompt(self.prompt_format))]

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -466,7 +466,7 @@ class MyCli(object):
                                       ])
         with self._completer_lock:
             buf = CLIBuffer(always_multiline=self.multi_line, completer=self.completer,
-                    history=FileHistory(os.path.expanduser('~/.mycli-history')),
+                    history=FileHistory(os.path.expanduser(os.environ.get('MYCLI_HISTFILE', '~/.mycli-history'))),
                     complete_while_typing=Always(), accept_action=AcceptAction.RETURN_DOCUMENT)
 
             if self.key_bindings == 'vi':

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -20,7 +20,7 @@ destructive_warning = True
 log_file = ~/.mycli.log
 
 # Default log level. Possible values: "CRITICAL", "ERROR", "WARNING", "INFO"
-# and "DEBUG".
+# and "DEBUG". "NONE" disables logging.
 log_level = INFO
 
 # Log every query and its results to a file. Enable this by uncommenting the

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -58,8 +58,8 @@ wider_completion_menu = False
 # \n - Newline
 prompt = '\t \u@\h:\d> '
 
-# Skip intro info on startup.
-skip_intro = False
+# Skip intro info on startup and outro info on exit
+less_chatty = False
 
 # Custom colors for the completion menu, toolbar, etc.
 [colors]

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -58,6 +58,9 @@ wider_completion_menu = False
 # \n - Newline
 prompt = '\t \u@\h:\d> '
 
+# Skip intro info on startup.
+skip_intro = False
+
 # Custom colors for the completion menu, toolbar, etc.
 [colors]
 # Completion menus.


### PR DESCRIPTION
I appreciate the contact URLs and giving credit to supporters and such, and friendly goodbye messages, but I prefer to suppress unwanted noise from appearing in my terminal window. 

The "less_chatty" option allows the user in _~/.myclirc_ to suppress these messages.

The default remains False, so that the messages will continue to appear as they do today unless explicitly suppressed.  By removing the corresponding change to the boilerplate _myclirc_ file, this could be an undocumented feature, if desired.