### PR TITLE
add prompt_continuation support

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -138,6 +138,7 @@ class MyCli(object):
         prompt_cnf = self.read_my_cnf_files(self.cnf_files, ['prompt'])['prompt']
         self.prompt_format = prompt or prompt_cnf or c['main']['prompt'] or \
                              self.default_prompt
+        self.prompt_continuation_format = c['main']['prompt_continuation']
 
         self.query_history = []
 
@@ -449,7 +450,8 @@ class MyCli(object):
             return [(Token.Prompt, self.get_prompt(self.prompt_format))]
 
         def get_continuation_tokens(cli, width):
-            return [(Token.Continuation, ' ' * (width - 3) + '-> ')]
+            continuation_prompt = self.get_prompt(self.prompt_continuation_format)
+            return [(Token.Continuation, ' ' * (width - len(continuation_prompt)) + continuation_prompt)]
 
         get_toolbar_tokens = create_toolbar_tokens_func(self.completion_refresher.is_refreshing)
 

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -57,6 +57,7 @@ wider_completion_menu = False
 # \d - Database name
 # \n - Newline
 prompt = '\t \u@\h:\d> '
+prompt_continuation = '-> '
 
 # Skip intro info on startup and outro info on exit
 less_chatty = False


### PR DESCRIPTION
Add ability to configure the continuation prompt string.

It supports the same expansion as **prompt**, so that you can have values like:
```
prompt = "\d > "
prompt_continuation = "\d*> "
```

In this example, the full prompt is repeated, adding an asterisk on continuation lines.

More importantly, it allows the prompt continuation string to be empty.  

```
prompt_continuation = ""
```

This makes it possible to copy multi-line queries to the clipboard without the injection of prompt characters, or having to resort to launching an editor just to get to the pure query text.

It defaults to "-> ", so the default behavior is unchanged.