### PR TITLE
Custom converters for time/date types.

### DIFF
--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -65,10 +65,10 @@ class SQLExecute(object):
             '\tssl: %r',
             database, user, host, port, socket, charset, local_infile, ssl)
         conv = {
-                FIELD_TYPE.TIMESTAMP: lambda obj: (convert_mysql_timestamp(obj) or '0000-00-00 00:00:00'),
-                FIELD_TYPE.DATETIME: lambda obj: (convert_datetime(obj) or '0000-00-00 00:00:00'),
-                FIELD_TYPE.TIME: lambda obj: (convert_timedelta(obj) or '00:00:00'),
-                FIELD_TYPE.DATE: lambda obj: (convert_date(obj) or '0000-00-00'),
+                FIELD_TYPE.TIMESTAMP: lambda obj: (convert_mysql_timestamp(obj) or obj),
+                FIELD_TYPE.DATETIME: lambda obj: (convert_datetime(obj) or obj),
+                FIELD_TYPE.TIME: lambda obj: (convert_timedelta(obj) or obj),
+                FIELD_TYPE.DATE: lambda obj: (convert_date(obj) or obj),
                 }
 
         conn = connection.connect(database=db, user=user, password=password,

--- a/tests/test_sqlexecute.py
+++ b/tests/test_sqlexecute.py
@@ -277,3 +277,55 @@ def test_favorite_query_multiline_statement(executor):
 
     results = run(executor, "\\fd test-ad")
     assert results == ['test-ad: Deleted']
+
+@dbtest
+def test_timestamp_null(executor):
+    run(executor, '''create table ts_null(a timestamp)''')
+    run(executor, '''insert into ts_null values(0)''')
+    results = run(executor, '''select * from ts_null''', join=True)
+    assert results == dedent("""\
+        +---------------------+
+        | a                   |
+        |---------------------|
+        | 0000-00-00 00:00:00 |
+        +---------------------+
+        1 row in set""")
+
+@dbtest
+def test_datetime_null(executor):
+    run(executor, '''create table dt_null(a datetime)''')
+    run(executor, '''insert into dt_null values(0)''')
+    results = run(executor, '''select * from dt_null''', join=True)
+    assert results == dedent("""\
+        +---------------------+
+        | a                   |
+        |---------------------|
+        | 0000-00-00 00:00:00 |
+        +---------------------+
+        1 row in set""")
+
+@dbtest
+def test_date_null(executor):
+    run(executor, '''create table date_null(a date)''')
+    run(executor, '''insert into date_null values(0)''')
+    results = run(executor, '''select * from date_null''', join=True)
+    assert results == dedent("""\
+        +------------+
+        | a          |
+        |------------|
+        | 0000-00-00 |
+        +------------+
+        1 row in set""")
+
+@dbtest
+def test_time_null(executor):
+    run(executor, '''create table time_null(a time)''')
+    run(executor, '''insert into time_null values(0)''')
+    results = run(executor, '''select * from time_null''', join=True)
+    assert results == dedent("""\
+        +----------+
+        | a        |
+        |----------|
+        | 00:00:00 |
+        +----------+
+        1 row in set""")


### PR DESCRIPTION
Having invalid time/date values in database causes mycli to display
their values as <null>. Having custom converters will handle that case.

Reviewer: @j-bennet 

This is to address #285 