### PR TITLE
Pin sqlparse to 0.1.19

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requirements = [
     'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
     'prompt_toolkit>=1.0.0,<1.1.0',
     'PyMySQL >= 0.6.2',
-    'sqlparse >= 0.1.19',
+    'sqlparse == 0.1.19',
     'configobj >= 5.0.6',
 ]
 


### PR DESCRIPTION
Latest version of sqlparse (0.20.0) is breaking everything. I'm going to pin the dependency to 0.1.19 until we fix all the issues associated with the upgrade. 

/cc @mdsrosa 

Closes: #294 