### PR TITLE
Amjith/sqlparse upgrade

### DIFF
--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -28,26 +28,32 @@ def suggest_type(full_text, text_before_cursor):
 
     identifier = None
 
-    # If we've partially typed a word then word_before_cursor won't be an empty
-    # string. In that case we want to remove the partially typed string before
-    # sending it to the sqlparser. Otherwise the last token will always be the
-    # partially typed string which renders the smart completion useless because
-    # it will always return the list of keywords as completion.
-    if word_before_cursor:
-        if word_before_cursor[-1] == '(' or word_before_cursor[0] == '\\':
-            parsed = sqlparse.parse(text_before_cursor)
-        else:
-            parsed = sqlparse.parse(
-                    text_before_cursor[:-len(word_before_cursor)])
+    # This is a temporary hack; the exception handling
+    # here should be removed once sqlparse has been fixed
+    try:
+        # If we've partially typed a word then word_before_cursor won't be an empty
+        # string. In that case we want to remove the partially typed string before
+        # sending it to the sqlparser. Otherwise the last token will always be the
+        # partially typed string which renders the smart completion useless because
+        # it will always return the list of keywords as completion.
+        if word_before_cursor:
+            if word_before_cursor[-1] == '(' or word_before_cursor[0] == '\\':
+                parsed = sqlparse.parse(text_before_cursor)
+            else:
+                parsed = sqlparse.parse(
+                        text_before_cursor[:-len(word_before_cursor)])
 
-            # word_before_cursor may include a schema qualification, like
-            # "schema_name.partial_name" or "schema_name.", so parse it
-            # separately
-            p = sqlparse.parse(word_before_cursor)[0]
-            if p.tokens and isinstance(p.tokens[0], Identifier):
-                identifier = p.tokens[0]
-    else:
-        parsed = sqlparse.parse(text_before_cursor)
+                # word_before_cursor may include a schema qualification, like
+                # "schema_name.partial_name" or "schema_name.", so parse it
+                # separately
+                p = sqlparse.parse(word_before_cursor)[0]
+
+                if p.tokens and isinstance(p.tokens[0], Identifier):
+                    identifier = p.tokens[0]
+        else:
+            parsed = sqlparse.parse(text_before_cursor)
+    except (TypeError, AttributeError):
+        return []
 
     if len(parsed) > 1:
         # Multiple statements being edited -- isolate the current one by

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requirements = [
     'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
     'prompt_toolkit>=1.0.0,<1.1.0',
     'PyMySQL >= 0.6.2',
-    'sqlparse >= 0.2.0',
+    'sqlparse == 0.2.0',
     'configobj >= 5.0.6',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requirements = [
     'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
     'prompt_toolkit>=1.0.0,<1.1.0',
     'PyMySQL >= 0.6.2',
-    'sqlparse == 0.2.0',
+    'sqlparse>=0.2.0,<0.2.2',
     'configobj >= 5.0.6',
 ]
 

--- a/tests/test_completion_engine.py
+++ b/tests/test_completion_engine.py
@@ -442,3 +442,11 @@ def test_cross_join():
          {'type': 'table', 'schema': []},
          {'type': 'view', 'schema': []},
          {'type': 'schema'}])
+
+@pytest.mark.parametrize('expression', [
+    'SELECT 1 AS ',
+    'SELECT 1 FROM tabl AS ',
+])
+def test_after_as(expression):
+    suggestions = suggest_type(expression, expression)
+    assert set(suggestions) == set()


### PR DESCRIPTION
@meeuw After I merged your PR I noticed that the completion engine would crash after the keyword `AS`. This PR addresses that issue. There is already a bug filed with sqlparse to handle that case correctly, so this try/except block is merely a temporary hack before it is fixed in sqlparse. 

I've pinned the version of sqlparse to 0.2.0. The reason being we've been burned in the past by specifying the dependency as `>=0.1.x`.

Reviewer: @tsroten 