### PR TITLE
Add CSV support for batch output

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -702,15 +702,14 @@ class MyCli(object):
         string = string.replace('\\n', "\n")
         return string
 
-    def run_query(self, query, table_format=None):
+    def run_query(self, query, table_format=None, new_line=True):
         """Runs query"""
         results = self.sqlexecute.run(query)
         for result in results:
             title, cur, headers, status = result
-            table_format = self.table_format if table_format else None
             output = format_output(title, cur, headers, None, table_format)
             for line in output:
-                click.echo(line)
+                click.echo(line, nl=new_line)
 
 @click.command()
 @click.option('-h', '--host', envvar='MYSQL_HOST', help='Host address of the database.')
@@ -827,7 +826,6 @@ def cli(database, user, host, port, socket, password, dbname,
                 confirm_destructive_query(stdin_text) is False):
             exit(0)
         try:
-            results = mycli.sqlexecute.run(stdin_text)
             table_format = None
             new_line = True
 
@@ -837,12 +835,8 @@ def cli(database, user, host, port, socket, password, dbname,
             elif table:
                 table_format = mycli.table_format
 
-            for result in results:
-                title, cur, headers, status = result
-                output = format_output(title, cur, headers, None, table_format)
-                for line in output:
-                    click.echo(line, nl=new_line)
-
+            mycli.run_query(stdin_text, table_format=table_format, new_line=new_line)
+            exit(0)
         except Exception as e:
             click.secho(str(e), err=True, fg='red')
             exit(1)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -867,11 +867,10 @@ def format_output(title, cur, headers, status, table_format, expanded=False, max
             output.append(content.getvalue())
             content.truncate(0)
             for row in cur:
-                row = ['null' if val is None else val.encode('utf-8') for val in row]
+                row = ['null' if val is None else str(val) for val in row]
                 writer.writerow(row)
                 output.append(content.getvalue())
                 content.truncate(0)
-            output.append('\n')
             content.close()
         else:
             rows = list(cur)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -805,7 +805,12 @@ def cli(database, user, host, port, socket, password, dbname,
     #  --execute argument
     if execute:
         try:
-            mycli.run_query(execute, table_format=table)
+            table_format = None
+            if table:
+                table_format = mycli.table_format
+            elif csv:
+                table_format = 'csv'
+            mycli.run_query(execute, table_format=table_format)
             exit(0)
         except Exception as e:
             click.secho(str(e), err=True, fg='red')

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -16,7 +16,7 @@ from io import open
 
 # support StringIO for Python 2 and 3
 try:
-    from StringIO import StringIO
+    from cStringIO import StringIO
 except ImportError:
     from io import StringIO
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -864,13 +864,12 @@ def format_output(title, cur, headers, status, table_format, expanded=False, max
             content = StringIO()
             writer = csv.writer(content)
             writer.writerow(headers)
-            output.append(content.getvalue())
-            content.truncate(0)
+
             for row in cur:
                 row = ['null' if val is None else str(val) for val in row]
                 writer.writerow(row)
-                output.append(content.getvalue())
-                content.truncate(0)
+
+            output.append(content.getvalue())
             content.close()
         else:
             rows = list(cur)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -848,12 +848,10 @@ def format_output(title, cur, headers, status, table_format, expanded=False, max
         output.append(title)
     if cur:
         headers = [utf8tounicode(x) for x in headers]
+        table_format = 'tsv' if table_format is None else table_format
+
         if expanded:
             output.append(expanded_table(cur, headers))
-        elif table_format is None:
-            output.append('\t'.join(headers))
-            for row in cur:
-                output.append('\t'.join([str(r) for r in row]))
         elif table_format == 'csv':
             content = StringIO()
             writer = csv.writer(content)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -829,16 +829,17 @@ def cli(database, user, host, port, socket, password, dbname,
         try:
             results = mycli.sqlexecute.run(stdin_text)
             table_format = None
+            new_line = True
 
             if csv:
                 table_format = 'csv'
                 new_line = False
             elif table:
-                new_line = True
+                table_format = mycli.table_format
 
             for result in results:
                 title, cur, headers, status = result
-                output = format_output(title, cur, headers, status, table_format)
+                output = format_output(title, cur, headers, None, table_format)
                 for line in output:
                     click.echo(line, nl=new_line)
 
@@ -855,7 +856,7 @@ def format_output(title, cur, headers, status, table_format, expanded=False, max
         headers = [utf8tounicode(x) for x in headers]
         if expanded:
             output.append(expanded_table(cur, headers))
-        if table_format is None:
+        elif table_format is None:
             output.append('\t'.join(headers))
             for row in cur:
                 output.append('\t'.join([str(r) for r in row]))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -98,10 +98,11 @@ def test_batch_mode_csv(executor):
     runner = CliRunner()
     result = runner.invoke(cli, args=CLI_ARGS + ['--csv'], input=sql)
 
-    expected = 'a,b\nabc,def\nghi,jkl\n\n'
+    expected = 'a,b\nabc,def\nghi,jkl\n'
+    result_output = result.output.replace('\x00', '') # python 3
 
     assert result.exit_code == 0
-    assert expected in result.output
+    assert expected in result_output
 
 def test_query_starts_with(executor):
     query = 'USE test;'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -51,6 +51,38 @@ def test_execute_arg(executor):
     assert result.exit_code == 0
     assert 'abc' in result.output
 
+    expected = 'a\nabc\n'
+
+    assert result.output == expected
+
+
+@dbtest
+def test_execute_arg_with_table(executor):
+    run(executor, 'create table test (a text)')
+    run(executor, 'insert into test values("abc")')
+
+    sql = 'select * from test;'
+    runner = CliRunner()
+    result = runner.invoke(cli, args=CLI_ARGS + ['-e', sql] + ['--table'])
+    expected = '+-----+\n| a   |\n|-----|\n| abc |\n+-----+\n'
+
+    assert result.exit_code == 0
+    assert result.output == expected
+
+
+@dbtest
+def test_execute_arg_with_csv(executor):
+    run(executor, 'create table test (a text)')
+    run(executor, 'insert into test values("abc")')
+
+    sql = 'select * from test;'
+    runner = CliRunner()
+    result = runner.invoke(cli, args=CLI_ARGS + ['-e', sql] + ['--csv'])
+    expected = 'a\nabc\n\n'
+
+    assert result.exit_code == 0
+    assert result.output == expected
+
 
 @dbtest
 def test_batch_mode(executor):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -53,7 +53,7 @@ def test_execute_arg(executor):
 
     expected = 'a\nabc\n'
 
-    assert result.output == expected
+    assert expected in result.output
 
 
 @dbtest
@@ -67,7 +67,7 @@ def test_execute_arg_with_table(executor):
     expected = '+-----+\n| a   |\n|-----|\n| abc |\n+-----+\n'
 
     assert result.exit_code == 0
-    assert result.output == expected
+    assert expected in result.output
 
 
 @dbtest
@@ -81,7 +81,7 @@ def test_execute_arg_with_csv(executor):
     expected = 'a\nabc\n\n'
 
     assert result.exit_code == 0
-    assert result.output == expected
+    assert expected in result.output
 
 
 @dbtest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,7 +30,8 @@ def test_format_output_auto_expand():
 def test_format_output_no_table():
     results = format_output('Title', [('abc', 'def')], ['head1', 'head2'],
                             'test status', None)
-    expected = ['Title', 'head1\thead2', 'abc\tdef', 'test status']
+
+    expected = ['Title', u'head1  \thead2\nabc    \tdef', 'test status']
     assert results == expected
 
 @dbtest
@@ -65,7 +66,7 @@ def test_batch_mode(executor):
     result = runner.invoke(cli, args=CLI_ARGS, input=sql)
 
     assert result.exit_code == 0
-    assert 'count(*)\n3\na\nabc' in result.output
+    assert '  count(*)\n         3\na\nabc\n' in result.output
 
 @dbtest
 def test_batch_mode_table(executor):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -88,6 +88,21 @@ def test_batch_mode_table(executor):
     assert result.exit_code == 0
     assert expected in result.output
 
+@dbtest
+def test_batch_mode_csv(executor):
+    run(executor, '''create table test(a text, b text)''')
+    run(executor, '''insert into test (a, b) values('abc', 'def'), ('ghi', 'jkl')''')
+
+    sql = 'select * from test;'
+
+    runner = CliRunner()
+    result = runner.invoke(cli, args=CLI_ARGS + ['--csv'], input=sql)
+
+    expected = 'a,b\nabc,def\nghi,jkl\n\n'
+
+    assert result.exit_code == 0
+    assert expected in result.output
+
 def test_query_starts_with(executor):
     query = 'USE test;'
     assert query_starts_with(query, ('use', )) is True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -99,10 +99,9 @@ def test_batch_mode_csv(executor):
     result = runner.invoke(cli, args=CLI_ARGS + ['--csv'], input=sql)
 
     expected = 'a,b\nabc,def\nghi,jkl\n'
-    result_output = result.output.replace('\x00', '') # python 3
 
     assert result.exit_code == 0
-    assert expected in result_output
+    assert expected in result.output
 
 def test_query_starts_with(executor):
     query = 'USE test;'


### PR DESCRIPTION
This PR is a follow up on the PR https://github.com/dbcli/mycli/pull/270. This PR add CSV support for batch output feature.

```
$ cat query.txt | mycli -u root test_db --csv
id,email,name
1,email1@gmail.com,Foo Bar
2,emal2@gmail.com,Bar Foo
3,null,John Doe
```

Thanks @gubbin!
