### PR TITLE
Honor the smart_completion setting in the config file.

### DIFF
--- a/mycli/completion_refresher.py
+++ b/mycli/completion_refresher.py
@@ -12,9 +12,10 @@ class CompletionRefresher(object):
 
     refreshers = OrderedDict()
 
-    def __init__(self):
+    def __init__(self, smart_completion):
         self._completer_thread = None
         self._restart_refresh = threading.Event()
+        self.smart_completion = smart_completion
 
     def refresh(self, executor, callbacks):
         """
@@ -43,7 +44,7 @@ class CompletionRefresher(object):
         return self._completer_thread and self._completer_thread.is_alive()
 
     def _bg_refresh(self, sqlexecute, callbacks):
-        completer = SQLCompleter(smart_completion=True)
+        completer = SQLCompleter(smart_completion=self.smart_completion)
 
         # Create a new pgexecute method to popoulate the completions.
         e = sqlexecute

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -142,7 +142,6 @@ class MyCli(object):
                 self.output('Error: Unable to open the audit log file. Your queries will not be logged.', err=True, fg='red')
                 self.logfile = False
 
-        self.completion_refresher = CompletionRefresher()
 
         self.logger = logging.getLogger(__name__)
         self.initialize_logging()
@@ -158,6 +157,7 @@ class MyCli(object):
         smart_completion = c['main'].as_bool('smart_completion')
         self.completer = SQLCompleter(smart_completion)
         self._completer_lock = threading.Lock()
+        self.completion_refresher = CompletionRefresher(smart_completion)
 
         # Register custom special commands.
         self.register_special_commands()

--- a/tests/test_completion_refresher.py
+++ b/tests/test_completion_refresher.py
@@ -6,7 +6,7 @@ from mock import Mock, patch
 @pytest.fixture
 def refresher():
     from mycli.completion_refresher import CompletionRefresher
-    return CompletionRefresher()
+    return CompletionRefresher(True)
 
 
 def test_ctor(refresher):


### PR DESCRIPTION
Reviewer: @tsroten

This fixes #334 

The smart_completion setting in the config file was ignored by the background refresher thread. This PR makes the CompletionRefresher class aware of that setting.