### PR TITLE
Fix: Crash if statement starts with #

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -954,7 +954,7 @@ def query_starts_with(query, prefixes):
     """Check if the query starts with any item from *prefixes*."""
     prefixes = [prefix.lower() for prefix in prefixes]
     formatted_sql = sqlparse.format(query.lower(), strip_comments=True)
-    return formatted_sql.split()[0] in prefixes
+    return bool(formatted_sql) and formatted_sql.split()[0] in prefixes
 
 def queries_start_with(queries, prefixes):
     """Check if any queries start with any item from *prefixes*."""


### PR DESCRIPTION
mycil will crash if the statement starts with #.