### PR TITLE
unix like redirect output

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,11 @@ Internal Changes:
 * Move AUTHORS and SPONSORS to mycli directory. (Thanks: [Terje Røsten] []).
 * Add pager wrapper for behave tests (Thanks: [Dick Marinus]).
 
+Features:
+---------
+
+* Add unix like redirect output (Thanks: [Dick Marinus]).
+
 1.10.0:
 =======
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -466,6 +466,7 @@ class MyCli(object):
                 document = self.cli.run()
 
                 special.set_expanded_output(False)
+                special.set_redirected_output(enabled=False)
 
                 # The reason we check here instead of inside the sqlexecute is
                 # because we want to raise the Exit exception which will be
@@ -580,6 +581,7 @@ class MyCli(object):
             else:
                 try:
                     special.write_tee('\n'.join(output))
+                    special.output_to_file('\n'.join(output))
                     if special.is_pager_enabled():
                         self.output_via_pager('\n'.join(output))
                     else:

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -282,3 +282,65 @@ def write_tee(output):
         tee_file.write(output)
         tee_file.write(u"\n")
         tee_file.flush()
+
+
+@export
+def set_redirected_output(append=False, filename=None, enabled=False):
+    global use_redirected_output
+    use_redirected_output = {'append': append,
+                             'filename': filename, 'enabled': enabled}
+
+
+@export
+def get_redirected_output():
+    return use_redirected_output
+
+
+@export
+def redirectmatch(sql):
+    filename = None
+    if sql and sql[-1] in ("'", '"'):  # find filename in quoted redirect
+        quote = sql[-1]
+        m = re.match(r'.*([^\\]' + quote + r'.*' + quote + '$)', sql)
+        if m:
+            filename = m.group(1).replace('\\' + quote, quote)
+    else:  # find filename for non-quoted redirect
+        quote = ''
+        m = re.match(r'.*?([^\][^>]*$)', sql)
+        if m:
+            filename = m.group(1)
+
+    if filename is None:
+        redirect = None
+    else:
+        redirect = sql[:-len(filename)].strip()
+
+    if redirect and (redirect[-2:] == r'\>' or redirect[-3:] == r'\>>'):
+        append = redirect[-3:] == r'\>>'
+
+        sql = redirect[:-3] if append else redirect[:-2]
+        sql = sql.strip()
+        filename = filename.strip()
+
+        if quote:
+            filename = filename[len(quote):-len(quote)]
+        return (sql, {
+            "enabled": True,
+            "filename": filename,
+            "append": append,
+        })
+    else:
+        return (sql, {
+            "enabled": False,
+            "filename": None,
+            "append": False,
+        })
+
+
+@export
+def output_to_file(text):
+    output = get_redirected_output()
+    if output["enabled"]:
+        mode = 'a' if output['append'] else 'w'
+        with open(output["filename"], mode, encoding='utf-8') as f:
+            f.write(text)

--- a/mycli/packages/special/main.py
+++ b/mycli/packages/special/main.py
@@ -105,5 +105,7 @@ def show_keyword_help(cur, arg):
 @special_command('quit', '\\q', 'Quit.', arg_type=NO_QUERY)
 @special_command('\\e', '\\e', 'Edit command with editor. (uses $EDITOR)', arg_type=NO_QUERY, case_sensitive=True)
 @special_command('\\G', '\\G', 'Display results vertically.', arg_type=NO_QUERY, case_sensitive=True)
+@special_command('redirect', 'query \> filename', 'Write the query results to filename')
+@special_command('redirectappend', 'query \>> filename', 'Append the query results to filename')
 def stub():
     raise NotImplementedError

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -123,6 +123,8 @@ class SQLExecute(object):
             if sql.endswith('\\G'):
                 special.set_expanded_output(True)
                 sql = sql[:-2].strip()
+            sql, redirect = special.redirectmatch(sql)
+            special.set_redirected_output(**redirect)
             try:   # Special command
                 _logger.debug('Trying a dbspecial command. sql: %r', sql)
                 cur = self.conn.cursor()

--- a/test/features/fixture_data/help_commands.txt
+++ b/test/features/fixture_data/help_commands.txt
@@ -1,27 +1,29 @@
-+-------------+-------------------+---------------------------------------------------------+
-| Command     | Shortcut          | Description                                             |
-+-------------+-------------------+---------------------------------------------------------+
-| \G          | \G                | Display results vertically.                             |
-| \dt         | \dt [table]       | List or describe tables.                                |
-| \e          | \e                | Edit command with editor. (uses $EDITOR)                |
-| \f          | \f [name]         | List or execute favorite queries.                       |
-| \fd         | \fd [name]        | Delete a favorite query.                                |
-| \fs         | \fs name query    | Save a favorite query.                                  |
-| \l          | \l                | List databases.                                         |
-| \timing     | \t                | Toggle timing of commands.                              |
-| connect     | \r                | Reconnect to the database. Optional database argument.  |
-| exit        | \q                | Exit.                                                   |
-| help        | \?                | Show this help.                                         |
-| nopager     | \n                | Disable pager, print to stdout.                         |
-| notee       | notee             | stop writing to an output file                          |
-| pager       | \P [command]      | Set PAGER. Print the query results via PAGER            |
-| prompt      | \R                | Change prompt format.                                   |
-| quit        | \q                | Quit.                                                   |
-| rehash      | \#                | Refresh auto-completions.                               |
-| source      | \. filename       | Execute commands from file.                             |
-| status      | \s                | Get status information from the server.                 |
-| system      | system [command]  | Execute a system commmand.                              |
-| tableformat | \T                | Change Table Type.                                      |
-| tee         | tee [-o] filename | write to an output file (optionally overwrite using -o) |
-| use         | \u                | Change to a new database.                               |
-+-------------+-------------------+---------------------------------------------------------+
++----------------+--------------------+---------------------------------------------------------+
+| Command        | Shortcut           | Description                                             |
++----------------+--------------------+---------------------------------------------------------+
+| \G             | \G                 | Display results vertically.                             |
+| \dt            | \dt [table]        | List or describe tables.                                |
+| \e             | \e                 | Edit command with editor. (uses $EDITOR)                |
+| \f             | \f [name]          | List or execute favorite queries.                       |
+| \fd            | \fd [name]         | Delete a favorite query.                                |
+| \fs            | \fs name query     | Save a favorite query.                                  |
+| \l             | \l                 | List databases.                                         |
+| \timing        | \t                 | Toggle timing of commands.                              |
+| connect        | \r                 | Reconnect to the database. Optional database argument.  |
+| exit           | \q                 | Exit.                                                   |
+| help           | \?                 | Show this help.                                         |
+| nopager        | \n                 | Disable pager, print to stdout.                         |
+| notee          | notee              | stop writing to an output file                          |
+| pager          | \P [command]       | Set PAGER. Print the query results via PAGER            |
+| prompt         | \R                 | Change prompt format.                                   |
+| quit           | \q                 | Quit.                                                   |
+| redirect       | query \> filename  | Write the query results to filename                     |
+| redirectappend | query \>> filename | Append the query results to filename                    |
+| rehash         | \#                 | Refresh auto-completions.                               |
+| source         | \. filename        | Execute commands from file.                             |
+| status         | \s                 | Get status information from the server.                 |
+| system         | system [command]   | Execute a system commmand.                              |
+| tableformat    | \T                 | Change Table Type.                                      |
+| tee            | tee [-o] filename  | write to an output file (optionally overwrite using -o) |
+| use            | \u                 | Change to a new database.                               |
++----------------+--------------------+---------------------------------------------------------+


### PR DESCRIPTION
## Description
Hi, could you please give me some feedback on this PR? (It might be a fix for issue #91)
I need to write some unit tests to improve the code coverage.

Output from a query can be redirected like:
mysql root@172.17.0.2:(none)> select 1 > /tmp/output

Output from a query can be appended like:
mysql root@172.17.0.2:(none)> select 2 >> /tmp/output

You can also use spaces for redirection like:
mysql root@172.17.0.2:(none)> select 1 > "/tmp/output 123"

And even escape quotes:
mysql root@172.17.0.2:(none)> select 1 > "/tmp/\\"weird\\""

After a query the redirection is automatically disabled. The complete output is written to a file, including the "1 row in set"

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).