### PR TITLE
Replace obsolete pycrypto with pycryptodome fork

### DIFF
--- a/mycli/config.py
+++ b/mycli/config.py
@@ -19,7 +19,7 @@ except ImportError:
 
 class CryptoError(Exception):
     """
-    Exception to signal about pycrypto not available.
+    Exception to signal about pycrypto(dome) not available.
     """
     pass
 
@@ -126,7 +126,7 @@ def read_and_decrypt_mylogin_cnf(f):
     :rtype: io.BytesIO or None
     """
     if AES is None:
-        raise CryptoError('pycrypto is not available.')
+        raise CryptoError('pycrypto(dome) is not available.')
 
     # Number of bytes used to store the length of ciphertext.
     MAX_CIPHER_STORE_LEN = 4

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -174,7 +174,7 @@ class MyCli(object):
                     # There was an error reading the login path file.
                     print('Error: Unable to read login path file.')
             except CryptoError:
-                click.secho('Warning: .mylogin.cnf was not read: pycrypto '
+                click.secho('Warning: .mylogin.cnf was not read: pycrypto(dome) '
                             'module is not available.')
 
         self.cli = None

--- a/setup.py
+++ b/setup.py
@@ -18,13 +18,8 @@ install_requirements = [
     'PyMySQL >= 0.6.2',
     'sqlparse>=0.2.2,<0.3.0',
     'configobj >= 5.0.6',
+    'pycryptodome',
 ]
-
-# pycrypto is a hard package to install on Windows, so we make it an optional
-# dependency. When it's installed, we can read mylogin.cnf, when it is not
-# available, we skip reading mylogin.cnf and print a warning message.
-if platform.system() != 'Windows':
-    install_requirements.append('pycrypto >= 2.6.1')
 
 setup(
         name='mycli',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,7 +11,7 @@ from mycli.config import (CryptoError, get_mylogin_cnf_path,
                           open_mylogin_cnf, read_and_decrypt_mylogin_cnf,
                           str_to_bool)
 
-with_pycrypto = ['pycrypto' in set([package.project_name for package in
+with_pycryptodome = ['pycryptodome' in set([package.project_name for package in
                                     pip.get_installed_distributions()])]
 
 LOGIN_PATH_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__),
@@ -26,13 +26,13 @@ def open_bmylogin_cnf(name):
     return buf
 
 
-@pytest.mark.skipif(with_pycrypto, reason='requires pycrypto missing')
+@pytest.mark.skipif(with_pycryptodome, reason='requires pycryptodome missing')
 def test_read_mylogin_cnf_without_crypto():
     with pytest.raises(CryptoError):
         mylogin_cnf = open_mylogin_cnf(LOGIN_PATH_FILE)
 
 
-@pytest.mark.skipif(not with_pycrypto, reason='requires pycrypto')
+@pytest.mark.skipif(not with_pycryptodome, reason='requires pycryptodome')
 def test_read_mylogin_cnf():
     """Tests that a login path file can be read and decrypted."""
     mylogin_cnf = open_mylogin_cnf(LOGIN_PATH_FILE)
@@ -44,14 +44,14 @@ def test_read_mylogin_cnf():
         assert word in contents
 
 
-@pytest.mark.skipif(not with_pycrypto, reason='requires pycrypto')
+@pytest.mark.skipif(not with_pycryptodome, reason='requires pycryptodome')
 def test_decrypt_blank_mylogin_cnf():
     """Test that a blank login path file is handled correctly."""
     mylogin_cnf = read_and_decrypt_mylogin_cnf(BytesIO())
     assert mylogin_cnf is None
 
 
-@pytest.mark.skipif(not with_pycrypto, reason='requires pycrypto')
+@pytest.mark.skipif(not with_pycryptodome, reason='requires pycryptodome')
 def test_corrupted_login_key():
     """Test that a corrupted login path key is handled correctly."""
     buf = open_bmylogin_cnf(LOGIN_PATH_FILE)
@@ -68,7 +68,7 @@ def test_corrupted_login_key():
     assert mylogin_cnf is None
 
 
-@pytest.mark.skipif(not with_pycrypto, reason='requires pycrypto')
+@pytest.mark.skipif(not with_pycryptodome, reason='requires pycryptodome')
 def test_corrupted_pad():
     """Tests that a login path file with a corrupted pad is partially read."""
     buf = open_bmylogin_cnf(LOGIN_PATH_FILE)


### PR DESCRIPTION
The pycrypto library is abandoned since 2014 with a lot of bugs open.
It has been forked into pycryptodome which is mostly API-compatible with
pycrypto. FWICS, the bits used by mycli work fine with the new library.

Therefore, switch to using pycryptodome instead of obsolete pycrypto.
I've also enabled it for Windows since the latter library officially
supports this system and provides binary wheels for it, so
the dependency should no longer be a problem.

Since the actual Python code isn't changed, mycli can still formally
work with pycrypto or without the library at all. However, pip will now
install the new library.