### PR TITLE
Use twine for uploading to PyPI.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+TBD
+===
+
+Internal Changes:
+-----------------
+
+* Upload mycli distributions in a safer manner (using twine). (Thanks: [Thomas
+  Roten]).
+
 1.9.0:
 ======
 

--- a/release.py
+++ b/release.py
@@ -72,12 +72,8 @@ def register_with_pypi():
     run_step('python', 'setup.py', 'register')
 
 
-def create_source_tarball():
-    run_step('python', 'setup.py', 'sdist')
-
-
-def create_python_wheel():
-    run_step('python', 'setup.py', 'bdist_wheel')
+def create_distribution_files():
+    run_step('python', 'setup.py', 'sdist', 'bdist_wheel')
 
 
 def upload_distribution_files():
@@ -133,8 +129,7 @@ if __name__ == '__main__':
     commit_for_release('mycli/__init__.py', ver)
     create_git_tag('v%s' % ver)
     register_with_pypi()
-    create_source_tarball()
-    create_python_wheel()
+    create_distribution_files()
     push_to_github()
     push_tags_to_github()
     upload_distribution_files()

--- a/release.py
+++ b/release.py
@@ -71,10 +71,11 @@ def create_source_tarball():
     run_step('python', 'setup.py', 'sdist')
 
 def create_python_wheel():
-    run_step('python', 'setup.py', 'sdist', 'bdist_wheel')
+    run_step('python', 'setup.py', 'bdist_wheel')
 
-def upload_source_tarball():
-    run_step('python', 'setup.py', 'sdist', 'upload')
+
+def upload_distribution_files():
+    run_step('twine', 'upload', 'dist/*')
 
 
 def push_to_github():
@@ -130,4 +131,4 @@ if __name__ == '__main__':
     create_python_wheel()
     push_to_github()
     push_tags_to_github()
-    upload_source_tarball()
+    upload_distribution_files()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 mock
 pytest
 tox
+twine==1.8.1


### PR DESCRIPTION
## Description
This pull request switches mycli's release script to use [twine](https://github.com/pypa/twine) for uploading to PyPI. Setuptools is officially [not recommended](https://packaging.python.org/distributing/#upload-your-distributions) by the Python Packaging Authority.

And, it removes an extra call to `sdist`.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
