### PR TITLE
Open config file using UTF8 encoding.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@ Bug Fixes:
 ----------
 
 * Fix external editor bug (issue #377). (Thanks: [Irina Truong]).
+* Fixed bug so that favorite queries can include unicode characters. (Thanks:
+  [Thomas Roten]).
 
 Internal Changes:
 -----------------

--- a/mycli/config.py
+++ b/mycli/config.py
@@ -40,7 +40,7 @@ def read_config_file(f):
         f = os.path.expanduser(f)
 
     try:
-        config = ConfigObj(f, interpolation=False)
+        config = ConfigObj(f, interpolation=False, encoding='utf8')
     except ConfigObjError as e:
         log(logger, logging.ERROR, "Unable to parse line {0} of config file "
             "'{1}'.".format(e.line_number, f))

--- a/tests/test_special_iocommands.py
+++ b/tests/test_special_iocommands.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 import os
 import stat
 import tempfile
@@ -5,6 +6,7 @@ import tempfile
 import pytest
 
 import mycli.packages.special
+import utils
 
 
 def test_set_get_pager():
@@ -68,3 +70,9 @@ def test_tee_command_error():
         with tempfile.NamedTemporaryFile() as f:
             os.chmod(f.name, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
             mycli.packages.special.execute(None, 'tee {}'.format(f.name))
+
+def test_favorite_query():
+    with utils.db_connection().cursor() as cur:
+        query = u'select "✔"'
+        mycli.packages.special.execute(cur, u'\\fs check {0}'.format(query))
+        assert next(mycli.packages.special.execute(cur, u'\\f check'))[0] == "> " + query


### PR DESCRIPTION
## Description
This opens the `myclirc` file using UTF-8 encoding so that unicode characters can be written properly.



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
