### PR TITLE
Open thanks files using UTF-8 encoding.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@ Bug Fixes:
 * Fixed bug so that favorite queries can include unicode characters. (Thanks:
   [Thomas Roten]).
 * Fix requirements and remove old compatibility code (Thanks: [Dick Marinus])
+* Fix bug where mycli would not start due to the thanks/credit intro text.
+  (Thanks: [Thomas Roten]).
 
 Internal Changes:
 -----------------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -981,7 +981,7 @@ def quit_command(sql):
 
 def thanks_picker(files=()):
     for filename in files:
-        with open(filename) as f:
+        with open(filename, encoding='utf-8') as f:
             contents = f.readlines()
 
     return choice([x.split('*')[1].strip() for x in contents if x.startswith('*')])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,17 @@
+import os
+
 import click
 from click.testing import CliRunner
 
 from mycli.main import (cli, confirm_destructive_query, format_output,
-                        is_destructive, query_starts_with, queries_start_with)
+                        is_destructive, query_starts_with, queries_start_with,
+                        thanks_picker, PACKAGE_ROOT)
 from utils import USER, HOST, PORT, PASSWORD, dbtest, run
+
+try:
+    text_type = basestring
+except NameError:
+    text_type = str
 
 CLI_ARGS = ['--user', USER, '--host', HOST, '--port', PORT,
             '--password', PASSWORD, '_test_db']
@@ -171,3 +179,11 @@ def test_confirm_destructive_query_notty(executor):
 
     sql = 'drop database foo;'
     assert confirm_destructive_query(sql) is None
+
+def test_thanks_picker_utf8():
+    project_root = os.path.dirname(PACKAGE_ROOT)
+    author_file = os.path.join(project_root, 'AUTHORS')
+    sponsor_file = os.path.join(project_root, 'SPONSORS')
+
+    name = thanks_picker((author_file, sponsor_file))
+    assert isinstance(name, text_type)


### PR DESCRIPTION
## Description
Our latest release (1.9.0) introduced non-ASCII characters to the `AUTHORS` file. This pull request makes sure we use UTF-8 encoding when opening that file.

This addresses #381.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
