### PR TITLE
#402 use abbreviated prompt if the default causes it to be huge

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@ Features:
 ---------
 
 * Add ability to specify alternative myclirc file. (Thanks: [Dick Marinus]).
-* Add logic to shorten the default prompt if it becomes too long once generated. (Thanks: [John Sterling])
+* Add logic to shorten the default prompt if it becomes too long once generated. (Thanks: [John Sterling]).
 
 Bug Fixes:
 ----------

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features:
 ---------
 
 * Add ability to specify alternative myclirc file. (Thanks: [Dick Marinus]).
+* Add logic to shorten the default prompt if it becomes too long once generated. (Thanks: [John Sterling])
 
 Bug Fixes:
 ----------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -77,9 +77,9 @@ class NullHandler(logging.Handler):
 class MyCli(object):
 
     default_prompt = '\\t \\u@\\h:\\d> '
+    max_len_prompt = 45
     defaults_suffix = None
 
-    # In order of being loaded. Files lower in list override earlier ones.
     cnf_files = [
         '/etc/my.cnf',
         '/etc/mysql/my.cnf',
@@ -458,7 +458,10 @@ class MyCli(object):
             print('Thanks to the contributor -', thanks_picker([author_file, sponsor_file]))
 
         def prompt_tokens(cli):
-            return [(Token.Prompt, self.get_prompt(self.prompt_format))]
+            prompt = self.get_prompt(self.prompt_format)
+            if self.prompt_format == self.default_prompt and len(prompt) > self.max_len_prompt:
+                prompt = self.get_prompt('\\d> ')
+            return [(Token.Prompt, prompt)]
 
         def get_continuation_tokens(cli, width):
             continuation_prompt = self.get_prompt(self.prompt_continuation_format)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -80,6 +80,7 @@ class MyCli(object):
     max_len_prompt = 45
     defaults_suffix = None
 
+    # In order of being loaded. Files lower in list override earlier ones.
     cnf_files = [
         '/etc/my.cnf',
         '/etc/mysql/my.cnf',


### PR DESCRIPTION
## Description
Add logic to the prompt definition to use a very short prompt with only the db name if the default prompt is too long once generated.



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [X ] I've added this contribution to the `changelog.md`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
