### PR TITLE
Switch from pycryptodome to pycryptodomex.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@ Internal Changes:
 * Test mycli using pexpect/python-behave (Thanks: [Dick Marinus]).
 * Run pep8 checks in travis (Thanks: [Irina Truong]).
 * Remove temporary hack for sqlparse (Thanks: [Dick Marinus]).
+* Switch from pycryptodome to pycryptodomex (Thanks: [Thomas Roten]).
 
 1.9.0:
 ======

--- a/mycli/config.py
+++ b/mycli/config.py
@@ -11,7 +11,7 @@ try:
     basestring
 except NameError:
     basestring = str
-from Crypto.Cipher import AES
+from Cryptodome.Cipher import AES
 
 
 logger = logging.getLogger(__name__)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requirements = [
     'PyMySQL >= 0.6.7',
     'sqlparse>=0.2.2,<0.3.0',
     'configobj >= 5.0.5',
-    'pycryptodome >= 3',
+    'pycryptodomex >= 3',
 ]
 
 setup(


### PR DESCRIPTION
## Description
This is another approach to solve the issue that #405 addresses. This uses pycryptodomex so that pycrypto installations do not conflict with pycryptodome.



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
