### PR TITLE
Do not add time from multiple queries together.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 TBD
 ===
 
+Bug Fixes:
+----------
+
+* Fixed incorrect timekeeping when running queries from a file. (Thanks: [Thomas Roten]).
+
 Internal Changes:
 -----------------
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -535,8 +535,7 @@ class MyCli(object):
                                                    max_width)
 
                     output.extend(formatted)
-                    end = time()
-                    total += end - start
+                    total = time() - start
                     mutating = mutating or is_mutating(status)
             except KeyboardInterrupt:
                 # get last connection id


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

This fixes a timing bug when you run queries from a file. The time outputted at the end was incorrect because it added time together like a factorial for each query.

See https://github.com/dbcli/pgcli/issues/575 for more information.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
