### PR TITLE
Auto-calculate reserved space for completion menu.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 TBD
 ===
 
+Features:
+---------
+
+* Add option to control how much space is reserved for the completion menu. (Thanks: [Thomas Roten]).
+
 Internal Changes:
 -----------------
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ TBD
 Features:
 ---------
 
-* Add option to control how much space is reserved for the completion menu. (Thanks: [Thomas Roten]).
+* Handle reserved space for completion menu better in small windows. (Thanks: [Thomas Roten]).
 
 Bug Fixes:
 ----------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -113,7 +113,6 @@ class MyCli(object):
         self.less_chatty = c['main'].as_bool('less_chatty')
         self.cli_style = c['colors']
         self.wider_completion_menu = c['main'].as_bool('wider_completion_menu')
-        self.min_num_menu_lines = c['main'].as_int('min_num_menu_lines')
         c_dest_warning = c['main'].as_bool('destructive_warning')
         self.destructive_warning = c_dest_warning if warn is None else warn
         self.login_path_as_host = c['main'].as_bool('login_path_as_host')
@@ -613,7 +612,7 @@ class MyCli(object):
                 processor=HighlightMatchingBracketProcessor(chars='[](){}'),
                 filter=HasFocus(DEFAULT_BUFFER) & ~IsDone()
             )],
-            reserve_space_for_menu=self.min_num_menu_lines
+            reserve_space_for_menu=self.get_reserved_space()
         )
         with self._completer_lock:
             buf = CLIBuffer(always_multiline=self.multi_line, completer=self.completer,
@@ -749,6 +748,13 @@ class MyCli(object):
             output.append(status)
 
         return output
+
+    def get_reserved_space(self):
+        """Get the number of lines to reserve for the completion menu."""
+        reserved_space_ratio = .2
+        max_reserved_space = 8
+        _, height = click.get_terminal_size()
+        return min(int(height * reserved_space_ratio), max_reserved_space)
 
 
 @click.command()

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -113,6 +113,7 @@ class MyCli(object):
         self.less_chatty = c['main'].as_bool('less_chatty')
         self.cli_style = c['colors']
         self.wider_completion_menu = c['main'].as_bool('wider_completion_menu')
+        self.min_num_menu_lines = c['main'].as_int('min_num_menu_lines')
         c_dest_warning = c['main'].as_bool('destructive_warning')
         self.destructive_warning = c_dest_warning if warn is None else warn
         self.login_path_as_host = c['main'].as_bool('login_path_as_host')
@@ -602,17 +603,19 @@ class MyCli(object):
 
         get_toolbar_tokens = create_toolbar_tokens_func(self.completion_refresher.is_refreshing)
 
-        layout = create_prompt_layout(lexer=MyCliLexer,
-                                      multiline=True,
-                                      get_prompt_tokens=prompt_tokens,
-                                      get_continuation_tokens=get_continuation_tokens,
-                                      get_bottom_toolbar_tokens=get_toolbar_tokens,
-                                      display_completions_in_columns=self.wider_completion_menu,
-                                      extra_input_processors=[
-                                          ConditionalProcessor(
-                                              processor=HighlightMatchingBracketProcessor(chars='[](){}'),
-                                              filter=HasFocus(DEFAULT_BUFFER) & ~IsDone()),
-                                      ])
+        layout = create_prompt_layout(
+            lexer=MyCliLexer,
+            multiline=True,
+            get_prompt_tokens=prompt_tokens,
+            get_continuation_tokens=get_continuation_tokens,
+            get_bottom_toolbar_tokens=get_toolbar_tokens,
+            display_completions_in_columns=self.wider_completion_menu,
+            extra_input_processors=[ConditionalProcessor(
+                processor=HighlightMatchingBracketProcessor(chars='[](){}'),
+                filter=HasFocus(DEFAULT_BUFFER) & ~IsDone()
+            )],
+            reserve_space_for_menu=self.min_num_menu_lines
+        )
         with self._completer_lock:
             buf = CLIBuffer(always_multiline=self.multi_line, completer=self.completer,
                     history=FileHistory(os.path.expanduser(os.environ.get('MYCLI_HISTFILE', '~/.mycli-history'))),

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -751,10 +751,10 @@ class MyCli(object):
 
     def get_reserved_space(self):
         """Get the number of lines to reserve for the completion menu."""
-        reserved_space_ratio = .2
+        reserved_space_ratio = .45
         max_reserved_space = 8
         _, height = click.get_terminal_size()
-        return min(int(height * reserved_space_ratio), max_reserved_space)
+        return min(round(height * reserved_space_ratio), max_reserved_space)
 
 
 @click.command()

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -51,9 +51,6 @@ key_bindings = emacs
 # Enabling this option will show the suggestions in a wider menu. Thus more items are suggested.
 wider_completion_menu = False
 
-# Number of lines to reserve for the completion menu.
-min_num_menu_lines = 8
-
 # MySQL prompt
 # \t - Product type (Percona, MySQL, Mariadb)
 # \u - Username

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -51,6 +51,9 @@ key_bindings = emacs
 # Enabling this option will show the suggestions in a wider menu. Thus more items are suggested.
 wider_completion_menu = False
 
+# Number of lines to reserve for the completion menu.
+min_num_menu_lines = 8
+
 # MySQL prompt
 # \t - Product type (Percona, MySQL, Mariadb)
 # \u - Username


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

This is influenced by pgcli: https://github.com/dbcli/pgcli/pull/642

~~This adds the ability for the user to control how many lines are reserved for the completion menu.~~

This automatically calculates how much space to reserve for the completion menu. The maximum number of lines is 8. The minimum is 0. The ratio used is 0.2, e.g. a terminal window with 20 rows would reserve 4 for the completion menu.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
