### PR TITLE
Add current vi mode to toolbar.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 TBD
 ===
 
+Features:
+---------
+
+* Display current vi mode in toolbar. (Thanks: [Thomas Roten]).
+
 Bug Fixes:
 ----------
 

--- a/mycli/clitoolbar.py
+++ b/mycli/clitoolbar.py
@@ -1,5 +1,6 @@
 from pygments.token import Token
 from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
+from prompt_toolkit.key_binding.vi_state import InputMode
 
 def create_toolbar_tokens_func(get_is_refreshing):
     """
@@ -26,7 +27,10 @@ def create_toolbar_tokens_func(get_is_refreshing):
                 ' (Semi-colon [;] will end the line)'))
 
         if cli.editing_mode == EditingMode.VI:
-            result.append((token.On, '[F4] Vi-mode'))
+            result.append((
+                token.On,
+                '[F4] Vi-mode ({})'.format(_get_vi_mode(cli))
+            ))
         else:
             result.append((token.On, '[F4] Emacs-mode'))
 
@@ -35,3 +39,13 @@ def create_toolbar_tokens_func(get_is_refreshing):
 
         return result
     return get_toolbar_tokens
+
+
+def _get_vi_mode(cli):
+    """Get the current vi mode for display."""
+    return {
+        InputMode.INSERT: 'I',
+        InputMode.NAVIGATION: 'N',
+        InputMode.REPLACE: 'R',
+        InputMode.INSERT_MULTIPLE: 'M'
+    }[cli.vi_state.input_mode]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

This is a port from pgcli: https://github.com/dbcli/pgcli/pull/620

It adds the current vi mode to the toolbar (if applicable).


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
