### PR TITLE
Default to last command in external editor.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Features:
 
 * Handle reserved space for completion menu better in small windows. (Thanks: [Thomas Roten]).
 * Display current vi mode in toolbar. (Thanks: [Thomas Roten]).
+* Opening an external editor will edit the last-run query. (Thanks: [Thomas Roten]).
 
 Bug Fixes:
 ----------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -419,9 +419,10 @@ class MyCli(object):
         saved_callables = cli.application.pre_run_callables
         while special.editor_command(document.text):
             filename = special.get_filename(document.text)
-            sql, message = special.open_external_editor(
-                filename, sql=document.text,
-                default_text=self.get_last_query() or '')
+            query = (special.get_editor_query(document.text) or
+                     self.get_last_query() or '')
+            sql, message = special.open_external_editor(filename,
+                                                        sql=query)
             if message:
                 # Something went wrong. Raise an exception and bail.
                 raise RuntimeError(message)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -420,7 +420,7 @@ class MyCli(object):
         while special.editor_command(document.text):
             filename = special.get_filename(document.text)
             query = (special.get_editor_query(document.text) or
-                     self.get_last_query() or '')
+                     self.get_last_query())
             sql, message = special.open_external_editor(filename,
                                                         sql=query)
             if message:

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -419,8 +419,9 @@ class MyCli(object):
         saved_callables = cli.application.pre_run_callables
         while special.editor_command(document.text):
             filename = special.get_filename(document.text)
-            sql, message = special.open_external_editor(filename,
-                                                          sql=document.text)
+            sql, message = special.open_external_editor(
+                filename, sql=document.text,
+                default_text=self.get_last_query() or '')
             if message:
                 # Something went wrong. Raise an exception and bail.
                 raise RuntimeError(message)
@@ -755,6 +756,10 @@ class MyCli(object):
         max_reserved_space = 8
         _, height = click.get_terminal_size()
         return min(round(height * reserved_space_ratio), max_reserved_space)
+
+    def get_last_query(self):
+        """Get the last query executed or None."""
+        return self.query_history[-1][0] if self.query_history else None
 
 
 @click.command()

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -421,8 +421,7 @@ class MyCli(object):
             filename = special.get_filename(document.text)
             query = (special.get_editor_query(document.text) or
                      self.get_last_query())
-            sql, message = special.open_external_editor(filename,
-                                                        sql=query)
+            sql, message = special.open_external_editor(filename, sql=query)
             if message:
                 # Something went wrong. Raise an exception and bail.
                 raise RuntimeError(message)

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -101,6 +101,7 @@ def get_filename(sql):
         command, _, filename = sql.partition(' ')
         return filename.strip() or None
 
+
 @export
 def get_editor_query(sql):
     """Get the query part of an editor command."""
@@ -114,6 +115,7 @@ def get_editor_query(sql):
         sql = pattern.sub('', sql)
 
     return sql
+
 
 @export
 def open_external_editor(filename=None, sql=None):

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -102,7 +102,7 @@ def get_filename(sql):
         return filename.strip() or None
 
 @export
-def open_external_editor(filename=None, sql=''):
+def open_external_editor(filename=None, sql='', default_text=''):
     """
     Open external editor, wait for the user to type in his query,
     return the query.
@@ -118,6 +118,8 @@ def open_external_editor(filename=None, sql=''):
     while pattern.search(sql):
         sql = pattern.sub('', sql)
 
+    text = sql if sql else default_text
+
     message = None
     filename = filename.strip().split(' ', 1)[0] if filename else None
 
@@ -125,7 +127,7 @@ def open_external_editor(filename=None, sql=''):
 
     # Populate the editor buffer with the partial sql (if available) and a
     # placeholder comment.
-    query = click.edit(sql + '\n\n' + MARKER, filename=filename,
+    query = click.edit(text + '\n\n' + MARKER, filename=filename,
             extension='.sql')
 
     if filename:

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -102,13 +102,8 @@ def get_filename(sql):
         return filename.strip() or None
 
 @export
-def open_external_editor(filename=None, sql='', default_text=''):
-    """
-    Open external editor, wait for the user to type in his query,
-    return the query.
-    :return: list with one tuple, query as first element.
-    """
-
+def get_editor_query(sql):
+    """Get the query part of an editor command."""
     sql = sql.strip()
 
     # The reason we can't simply do .strip('\e') is that it strips characters,
@@ -118,7 +113,15 @@ def open_external_editor(filename=None, sql='', default_text=''):
     while pattern.search(sql):
         sql = pattern.sub('', sql)
 
-    text = sql or default_text
+    return sql
+
+@export
+def open_external_editor(filename=None, sql='', default_text=''):
+    """
+    Open external editor, wait for the user to type in his query,
+    return the query.
+    :return: list with one tuple, query as first element.
+    """
 
     message = None
     filename = filename.strip().split(' ', 1)[0] if filename else None
@@ -127,7 +130,7 @@ def open_external_editor(filename=None, sql='', default_text=''):
 
     # Populate the editor buffer with the partial sql (if available) and a
     # placeholder comment.
-    query = click.edit(text + '\n\n' + MARKER, filename=filename,
+    query = click.edit(sql + '\n\n' + MARKER, filename=filename,
             extension='.sql')
 
     if filename:

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -117,9 +117,9 @@ def get_editor_query(sql):
 
 @export
 def open_external_editor(filename=None, sql=''):
-    """
-    Open external editor, wait for the user to type in his query,
-    return the query.
+    """Open external editor, wait for the user to type in their query, return
+    the query.
+
     :return: list with one tuple, query as first element.
     """
 

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -116,7 +116,7 @@ def get_editor_query(sql):
     return sql
 
 @export
-def open_external_editor(filename=None, sql='', default_text=''):
+def open_external_editor(filename=None, sql=''):
     """
     Open external editor, wait for the user to type in his query,
     return the query.

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -131,7 +131,7 @@ def open_external_editor(filename=None, sql=None):
 
     # Populate the editor buffer with the partial sql (if available) and a
     # placeholder comment.
-    query = click.edit("{sql}\n\n{marker}".format(sql=sql, marker=MARKER),
+    query = click.edit('{sql}\n\n{marker}'.format(sql=sql, marker=MARKER),
                        filename=filename, extension='.sql')
 
     if filename:

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -116,7 +116,7 @@ def get_editor_query(sql):
     return sql
 
 @export
-def open_external_editor(filename=None, sql=''):
+def open_external_editor(filename=None, sql=None):
     """Open external editor, wait for the user to type in their query, return
     the query.
 
@@ -126,12 +126,13 @@ def open_external_editor(filename=None, sql=''):
     message = None
     filename = filename.strip().split(' ', 1)[0] if filename else None
 
+    sql = sql or ''
     MARKER = '# Type your query above this line.\n'
 
     # Populate the editor buffer with the partial sql (if available) and a
     # placeholder comment.
-    query = click.edit(sql + '\n\n' + MARKER, filename=filename,
-            extension='.sql')
+    query = click.edit("{sql}\n\n{marker}".format(sql=sql, marker=MARKER),
+                       filename=filename, extension='.sql')
 
     if filename:
         try:

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -118,7 +118,7 @@ def open_external_editor(filename=None, sql='', default_text=''):
     while pattern.search(sql):
         sql = pattern.sub('', sql)
 
-    text = sql if sql else default_text
+    text = sql or default_text
 
     message = None
     filename = filename.strip().split(' ', 1)[0] if filename else None

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -123,6 +123,7 @@ def open_external_editor(filename=None, sql=None):
     the query.
 
     :return: list with one tuple, query as first element.
+
     """
 
     message = None


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

This pull request mimics some of the behavior in the official mysql client.
- When you type `\e` without a query in front of it, mycli use the last-run query as the default text in the editor.
- If you type `\e` and there were no queries run before it, then the editor will be blank.

This addresses https://github.com/dbcli/mycli/issues/35

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
