### PR TITLE
output once special command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ Features:
 * Handle reserved space for completion menu better in small windows. (Thanks: [Thomas Roten]).
 * Display current vi mode in toolbar. (Thanks: [Thomas Roten]).
 * Opening an external editor will edit the last-run query. (Thanks: [Thomas Roten]).
+* Output once special command. (Thanks: [Dick Marinus]).
 
 Bug Fixes:
 ----------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -580,6 +580,7 @@ class MyCli(object):
             else:
                 try:
                     special.write_tee('\n'.join(output))
+                    special.write_once('\n'.join(output))
                     if special.is_pager_enabled():
                         self.output_via_pager('\n'.join(output))
                     else:

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -267,7 +267,6 @@ def parseargfile(arg):
     return {'file': filename, 'mode': mode}
 
 
-
 @special_command('tee', 'tee [-o] filename',
                  'write to an output file (optionally overwrite using -o)')
 def set_tee(arg, **_):

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -17,6 +17,7 @@ TIMING_ENABLED = False
 use_expanded_output = False
 PAGER_ENABLED = True
 tee_file = None
+once_file = None
 
 @export
 def set_timing_enabled(val):
@@ -251,10 +252,8 @@ def execute_system_command(arg, **_):
     except OSError as e:
         return [(None, None, None, 'OSError: %s' % e.strerror)]
 
-@special_command('tee', 'tee [-o] filename',
-                 'write to an output file (optionally overwrite using -o)')
-def set_tee(arg, **_):
-    global tee_file
+
+def parseargfile(arg):
     if arg.startswith('-o '):
         mode = "w"
         filename = arg[3:]
@@ -265,8 +264,17 @@ def set_tee(arg, **_):
     if not filename:
         raise TypeError('You must provide a filename.')
 
+    return {'file': filename, 'mode': mode}
+
+
+
+@special_command('tee', 'tee [-o] filename',
+                 'write to an output file (optionally overwrite using -o)')
+def set_tee(arg, **_):
+    global tee_file
+
     try:
-        tee_file = open(filename, mode)
+        tee_file = open(**parseargfile(arg))
     except (IOError, OSError) as e:
         raise OSError("Cannot write to file '{}': {}".format(e.filename, e.strerror))
 
@@ -291,3 +299,30 @@ def write_tee(output):
         tee_file.write(output)
         tee_file.write(u"\n")
         tee_file.flush()
+
+
+@special_command('\\once', '\\o [-o] filename', 'Output for the next SQL command only to FILENAME', aliases=('\\o', ))
+def set_once(arg, **_):
+    global once_file
+
+    once_file = parseargfile(arg)
+
+    return [(None, None, None, "")]
+
+
+@export
+def write_once(output):
+    global once_file
+    if output and once_file:
+        try:
+            f = open(**once_file)
+        except (IOError, OSError) as e:
+            once_file = None
+            raise OSError("Cannot write to file '{}': {}".format(
+                e.filename, e.strerror))
+
+        with f:
+            f.write(output)
+            f.write(u"\n")
+
+        once_file = None

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -83,3 +83,23 @@ def test_favorite_query():
         mycli.packages.special.execute(cur, u'\\fs check {0}'.format(query))
         assert next(mycli.packages.special.execute(
             cur, u'\\f check'))[0] == "> " + query
+
+
+def test_once_command():
+    with pytest.raises(TypeError):
+        mycli.packages.special.execute(None, u"\once")
+
+    mycli.packages.special.execute(None, u"\once /proc/access-denied")
+    with pytest.raises(OSError):
+        mycli.packages.special.write_once(u"hello world")
+
+    mycli.packages.special.write_once(u"hello world")  # write without file set
+    with tempfile.NamedTemporaryFile() as f:
+        mycli.packages.special.execute(None, u"\once " + f.name)
+        mycli.packages.special.write_once(u"hello world")
+        assert f.read() == b"hello world\n"
+
+        mycli.packages.special.execute(None, u"\once -o " + f.name)
+        mycli.packages.special.write_once(u"hello world")
+        f.seek(0)
+        assert f.read() == b"hello world\n"


### PR DESCRIPTION
## Description
output once special command (related to https://github.com/dbcli/mycli/pull/353)

the usage is a bit tricky, it can only be used like this:
`> \once testfile ; select 1`
or
`select 1; \o testfile`

this doesn't work:
```
> \once testfile
> select 1
```
(gives empty file)

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
~- [ ] I've added my name to the `AUTHORS` file (or it's already there).~
