### PR TITLE
Do not display time and empty line for blank query.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ Bug Fixes:
 ----------
 
 * Fixed incorrect timekeeping when running queries from a file. (Thanks: [Thomas Roten]).
+* Do not display time and empty line for blank queries (Thanks: [Thomas Roten]).
 
 Internal Changes:
 -----------------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -483,7 +483,7 @@ class MyCli(object):
                     self.output(str(e), err=True, fg='red')
                     return
 
-            if not document.text:
+            if not document.text.strip():
                 return
 
             if self.destructive_warning:

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -367,6 +367,7 @@ class MyCli(object):
         # Favor whichever local_infile option is set.
         for local_infile_option in (local_infile, cnf['local-infile'],
                                     cnf['loose-local-infile'], False):
+
             try:
                 local_infile = str_to_bool(local_infile_option)
                 break
@@ -482,6 +483,9 @@ class MyCli(object):
                     logger.error("traceback: %r", traceback.format_exc())
                     self.output(str(e), err=True, fg='red')
                     return
+
+            if not document.text:
+                return
 
             if self.destructive_warning:
                 destroy = confirm_destructive_query(document.text)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -367,7 +367,6 @@ class MyCli(object):
         # Favor whichever local_infile option is set.
         for local_infile_option in (local_infile, cnf['local-infile'],
                                     cnf['loose-local-infile'], False):
-
             try:
                 local_infile = str_to_bool(local_infile_option)
                 break


### PR DESCRIPTION
## Description
This pull request makes mycli work more like a shell when you just hit enter without typing something. This addresses https://github.com/dbcli/mycli/issues/248.

Before:
```
mycli> 

Time: 0.00
mycli >
```

After:
```
mycli>
mycli>
```

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
