### PR TITLE
Add missing @dbtest to tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@ Internal Changes:
 * Reverted removal of temporary hack for sqlparse (Thanks: [Dick Marinus]).
 * Add setup.py commands to simplify development tasks (Thanks: [Thomas Roten]).
 * Add behave tests to tox (Thanks: [Dick Marinus]).
+* Add missing @dbtest to tests (Thanks: [Dick Marinus]).
 
 1.10.0:
 =======

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -131,6 +131,7 @@ def test_batch_mode_csv(executor):
     assert expected in result.output
 
 
+@dbtest
 def test_query_starts_with(executor):
     query = 'USE test;'
     assert query_starts_with(query, ('use', )) is True
@@ -139,11 +140,13 @@ def test_query_starts_with(executor):
     assert query_starts_with(query, ('use', )) is False
 
 
+@dbtest
 def test_query_starts_with_comment(executor):
     query = '# comment\nUSE test;'
     assert query_starts_with(query, ('use', )) is True
 
 
+@dbtest
 def test_queries_start_with(executor):
     sql = (
         '# comment\n'
@@ -155,6 +158,7 @@ def test_queries_start_with(executor):
     assert queries_start_with(sql, ('delete', 'update')) is False
 
 
+@dbtest
 def test_is_destructive(executor):
     sql = (
         'use test;\n'
@@ -164,6 +168,7 @@ def test_is_destructive(executor):
     assert is_destructive(sql) is True
 
 
+@dbtest
 def test_confirm_destructive_query_notty(executor):
     stdin = click.get_text_stream('stdin')
     assert stdin.isatty() is False

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -6,7 +6,8 @@ import tempfile
 import pytest
 
 import mycli.packages.special
-import utils
+
+from utils import dbtest, db_connection
 
 
 def test_set_get_pager():
@@ -77,8 +78,9 @@ def test_tee_command_error():
             mycli.packages.special.execute(None, 'tee {}'.format(f.name))
 
 
+@dbtest
 def test_favorite_query():
-    with utils.db_connection().cursor() as cur:
+    with db_connection().cursor() as cur:
         query = u'select "✔"'
         mycli.packages.special.execute(cur, u'\\fs check {0}'.format(query))
         assert next(mycli.packages.special.execute(


### PR DESCRIPTION
## Description
Add missing @dbtest to tests, to enable testing without mysql server.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
~- [ ] I've added my name to the `AUTHORS` file (or it's already there).~