### PR TITLE
Special helper for showing `SHOW CREATE TABLE`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ Features:
 * Display current vi mode in toolbar. (Thanks: [Thomas Roten]).
 * Opening an external editor will edit the last-run query. (Thanks: [Thomas Roten]).
 * Output once special command. (Thanks: [Dick Marinus]).
+* Add special command to show create table statement. (Thanks: [Ryan Smith])
 
 Bug Fixes:
 ----------

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -50,6 +50,7 @@ Contributors:
   * chainkite
   * Michał Górny
   * Terje Røsten
+  * Ryan Smith
 
 Creator:
 --------

--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -109,7 +109,7 @@ def suggest_special(text):
     if cmd in ['\\f', '\\fs', '\\fd']:
         return [{'type': 'favoritequery'}]
 
-    if cmd in ['\\dt', '\\d']:
+    if cmd in ['\\dt', '\\dt+']:
         return [
             {'type': 'table', 'schema': []},
             {'type': 'view', 'schema': []},

--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -109,7 +109,7 @@ def suggest_special(text):
     if cmd in ['\\f', '\\fs', '\\fd']:
         return [{'type': 'favoritequery'}]
 
-    if cmd in ['\\dt']:
+    if cmd in ['\\dt', '\\d']:
         return [
             {'type': 'table', 'schema': []},
             {'type': 'view', 'schema': []},

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -23,7 +23,7 @@ def list_tables(cur, arg=None, arg_type=PARSED_QUERY):
         return [(None, None, None, '')]
 
 
-@special_command('\\d', '\\d [table]', 'List tables or show create table.', arg_type=PARSED_QUERY, case_sensitive=True)
+@special_command('\\dt+', '\\dt+ [table]', 'List tables or show create table.', arg_type=PARSED_QUERY, case_sensitive=True)
 def list_or_show_create_tables(cur, arg=None, arg_type=PARSED_QUERY):
     if arg:
         query = 'SHOW CREATE TABLE {0}'.format(arg)

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -22,6 +22,21 @@ def list_tables(cur, arg=None, arg_type=PARSED_QUERY):
     else:
         return [(None, None, None, '')]
 
+
+@special_command('\\d', '\\d [table]', 'List tables or show create table.', arg_type=PARSED_QUERY, case_sensitive=True)
+def list_or_show_create_tables(cur, arg=None, arg_type=PARSED_QUERY):
+    if arg:
+        query = 'SHOW CREATE TABLE {0}'.format(arg)
+    else:
+        query = 'SHOW TABLES'
+    log.debug(query)
+    cur.execute(query)
+    if cur.description:
+        headers = [x[0] for x in cur.description]
+        return [(None, cur, headers, '')]
+    else:
+        return [(None, None, None, '')]
+
 @special_command('\\l', '\\l', 'List databases.', arg_type=RAW_QUERY, case_sensitive=True)
 def list_databases(cur, **_):
     query = 'SHOW DATABASES'

--- a/test/features/fixture_data/help_commands.txt
+++ b/test/features/fixture_data/help_commands.txt
@@ -3,6 +3,7 @@
 +-------------+-------------------+------------------------------------------------------------+
 | \G          | \G                | Display current query results vertically.                  |
 | \dt         | \dt [table]       | List or describe tables.                                   |
+| \dt+        | \dt+ [table]      | List tables or show create table.                          |
 | \e          | \e                | Edit command with editor (uses $EDITOR).                   |
 | \f          | \f [name]         | List or execute favorite queries.                          |
 | \fd         | \fd [name]        | Delete a favorite query.                                   |

--- a/test/test_dbspecial.py
+++ b/test/test_dbspecial.py
@@ -17,6 +17,14 @@ def test_describe_table():
         {'type': 'schema'}])
 
 
+def test_list_or_show_create_tables():
+    suggestions = suggest_type('\\d', '\\d ')
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {'type': 'table', 'schema': []},
+        {'type': 'view', 'schema': []},
+        {'type': 'schema'}])
+
+
 def test_format_uptime():
     seconds = 59
     assert '59 sec' == format_uptime(seconds)

--- a/test/test_dbspecial.py
+++ b/test/test_dbspecial.py
@@ -18,7 +18,7 @@ def test_describe_table():
 
 
 def test_list_or_show_create_tables():
-    suggestions = suggest_type('\\d', '\\d ')
+    suggestions = suggest_type('\\dt+', '\\dt+ ')
     assert sorted_dicts(suggestions) == sorted_dicts([
         {'type': 'table', 'schema': []},
         {'type': 'view', 'schema': []},


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

I regularly want to list both the columns in the table as well as the foreign
keys and in depth information about indexes (I'm used to the behavior of `\d`
from psql/pgcli), `SHOW CREATE TABLE`, which lists the create table statement is
the closest that mysql seems to have for this view.

```
mysql user@some_db> \d django_admin_log
***************************[ 1. row ]***************************
Table        | django_admin_log
Create Table | CREATE TABLE `django_admin_log` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `action_time` datetime(6) NOT NULL,
  `object_id` longtext,
  `object_repr` varchar(200) NOT NULL,
  `action_flag` smallint(5) unsigned NOT NULL,
  `change_message` longtext NOT NULL,
  `content_type_id` int(11) DEFAULT NULL,
  `user_id` int(11) NOT NULL,
  PRIMARY KEY (`id`),
  KEY `django_admin__content_type_id_c4bce8eb_fk_django_content_type_id` (`content_type_id`),
  KEY `django_admin_log_user_id_c564eba6_fk_some_user_id` (`user_id`),
  CONSTRAINT `django_admin__content_type_id_c4bce8eb_fk_django_content_type_id` FOREIGN KEY (`content_type_id`) REFERENCES `django_content_type` (`id`),
  CONSTRAINT `django_admin_log_user_id_c564eba6_fk_some_user_id` FOREIGN KEY (`user_id`) REFERENCES `some_user` (`id`)
) ENGINE=InnoDB AUTO_INCREMENT=1205 DEFAULT CHARSET=latin1

Time: 0.039s
```


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [X] I've added this contribution to the `changelog.md`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
