### PR TITLE
Make quit command use special command logic.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ Bug Fixes:
 
 * Fixed incorrect timekeeping when running queries from a file. (Thanks: [Thomas Roten]).
 * Do not display time and empty line for blank queries (Thanks: [Thomas Roten]).
+* Fixed issue where quit command would sometimes not work (Thanks: [Thomas Roten]).
 
 Internal Changes:
 -----------------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -468,13 +468,6 @@ class MyCli(object):
 
                 special.set_expanded_output(False)
 
-                # The reason we check here instead of inside the sqlexecute is
-                # because we want to raise the Exit exception which will be
-                # caught by the try/except block that wraps the
-                # sqlexecute.run() statement.
-                if quit_command(document.text):
-                    raise EOFError
-
                 try:
                     document = self.handle_editor_command(self.cli, document)
                 except RuntimeError as e:
@@ -541,6 +534,8 @@ class MyCli(object):
                     output.extend(formatted)
                     total = time() - start
                     mutating = mutating or is_mutating(status)
+            except EOFError as e:
+                raise e
             except KeyboardInterrupt:
                 # get last connection id
                 connection_id_to_kill = sqlexecute.connection_id
@@ -981,11 +976,6 @@ def confirm_destructive_query(queries):
     if is_destructive(queries) and sys.stdin.isatty():
         return click.prompt(prompt_text, type=bool)
 
-def quit_command(sql):
-    return (sql.strip().lower() == 'exit'
-            or sql.strip().lower() == 'quit'
-            or sql.strip() == '\q'
-            or sql.strip() == ':q')
 
 def thanks_picker(files=()):
     for filename in files:

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -78,10 +78,6 @@ def set_expanded_output(val):
 def is_expanded_output():
     return use_expanded_output
 
-
-def stub(*args):
-    raise NotImplementedError
-
 _logger = logging.getLogger(__name__)
 
 @export

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -78,8 +78,6 @@ def set_expanded_output(val):
 def is_expanded_output():
     return use_expanded_output
 
-def quit(*args):
-    raise NotImplementedError
 
 def stub(*args):
     raise NotImplementedError

--- a/mycli/packages/special/main.py
+++ b/mycli/packages/special/main.py
@@ -101,8 +101,13 @@ def show_keyword_help(cur, arg):
     else:
         return [(None, None, None, 'No help found for {0}.'.format(keyword))]
 
+
 @special_command('exit', '\\q', 'Exit.', arg_type=NO_QUERY, aliases=('\\q', ))
 @special_command('quit', '\\q', 'Quit.', arg_type=NO_QUERY)
+def quit(*_args):
+    raise EOFError
+
+
 @special_command('\\e', '\\e', 'Edit command with editor. (uses $EDITOR)', arg_type=NO_QUERY, case_sensitive=True)
 @special_command('\\G', '\\G', 'Display results vertically.', arg_type=NO_QUERY, case_sensitive=True)
 def stub():


### PR DESCRIPTION
## Description
This fixes an issue where the quit command was not being recognized once the editor was called.

This addresses #445.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
