### PR TITLE
Refactor \dt+ command.

### DIFF
--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -94,7 +94,7 @@ def suggest_type(full_text, text_before_cursor):
 
 def suggest_special(text):
     text = text.lstrip()
-    cmd, arg = parse_special_command(text)
+    cmd, _, arg = parse_special_command(text)
 
     if cmd == text:
         # Trying to complete the special command itself

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -24,7 +24,7 @@ def list_tables(cur, arg=None, arg_type=PARSED_QUERY, verbose=False):
     else:
         return [(None, None, None, '')]
 
-    if verbose:
+    if verbose and arg:
         log.debug(query)
         cur.execute('SHOW CREATE TABLE {0}'.format(arg))
         status = cur.fetchone()[1]

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -9,33 +9,26 @@ from .main import special_command, RAW_QUERY, PARSED_QUERY
 log = logging.getLogger(__name__)
 
 @special_command('\\dt', '\\dt [table]', 'List or describe tables.', arg_type=PARSED_QUERY, case_sensitive=True)
-def list_tables(cur, arg=None, arg_type=PARSED_QUERY):
+def list_tables(cur, arg=None, arg_type=PARSED_QUERY, verbose=False):
     if arg:
         query = 'SHOW FIELDS FROM {0}'.format(arg)
     else:
         query = 'SHOW TABLES'
     log.debug(query)
     cur.execute(query)
+    tables = cur.fetchall()
+    status = ''
     if cur.description:
         headers = [x[0] for x in cur.description]
-        return [(None, cur, headers, '')]
     else:
         return [(None, None, None, '')]
 
+    if verbose:
+        log.debug(query)
+        cur.execute('SHOW CREATE TABLE {0}'.format(arg))
+        status = cur.fetchone()[1]
 
-@special_command('\\dt+', '\\dt+ [table]', 'List tables or show create table.', arg_type=PARSED_QUERY, case_sensitive=True)
-def list_or_show_create_tables(cur, arg=None, arg_type=PARSED_QUERY):
-    if arg:
-        query = 'SHOW CREATE TABLE {0}'.format(arg)
-    else:
-        query = 'SHOW TABLES'
-    log.debug(query)
-    cur.execute(query)
-    if cur.description:
-        headers = [x[0] for x in cur.description]
-        return [(None, cur, headers, '')]
-    else:
-        return [(None, None, None, '')]
+    return [(None, tables, headers, status)]
 
 @special_command('\\l', '\\l', 'List databases.', arg_type=RAW_QUERY, case_sensitive=True)
 def list_databases(cur, **_):

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -8,6 +8,7 @@ from .main import special_command, RAW_QUERY, PARSED_QUERY
 
 log = logging.getLogger(__name__)
 
+
 @special_command('\\dt', '\\dt[+] [table]', 'List or describe tables.',
                  arg_type=PARSED_QUERY, case_sensitive=True)
 def list_tables(cur, arg=None, arg_type=PARSED_QUERY, verbose=False):

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -8,7 +8,8 @@ from .main import special_command, RAW_QUERY, PARSED_QUERY
 
 log = logging.getLogger(__name__)
 
-@special_command('\\dt', '\\dt [table]', 'List or describe tables.', arg_type=PARSED_QUERY, case_sensitive=True)
+@special_command('\\dt', '\\dt[+] [table]', 'List or describe tables.',
+                 arg_type=PARSED_QUERY, case_sensitive=True)
 def list_tables(cur, arg=None, arg_type=PARSED_QUERY, verbose=False):
     if arg:
         query = 'SHOW FIELDS FROM {0}'.format(arg)

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -26,8 +26,9 @@ def list_tables(cur, arg=None, arg_type=PARSED_QUERY, verbose=False):
         return [(None, None, None, '')]
 
     if verbose and arg:
+        query = 'SHOW CREATE TABLE {0}'.format(arg)
         log.debug(query)
-        cur.execute('SHOW CREATE TABLE {0}'.format(arg))
+        cur.execute(query)
         status = cur.fetchone()[1]
 
     return [(None, tables, headers, status)]

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -151,7 +151,7 @@ def open_external_editor(filename=None, sql=None):
     return (query, message)
 
 @special_command('\\f', '\\f [name]', 'List or execute favorite queries.', arg_type=PARSED_QUERY, case_sensitive=True)
-def execute_favorite_query(cur, arg):
+def execute_favorite_query(cur, arg, **_):
     """Returns (title, rows, headers, status)"""
     if arg == '':
         for result in list_favorite_queries():

--- a/mycli/packages/special/main.py
+++ b/mycli/packages/special/main.py
@@ -22,7 +22,9 @@ class CommandNotFound(Exception):
 @export
 def parse_special_command(sql):
     command, _, arg = sql.partition(' ')
-    return (command, arg.strip())
+    verbose = '+' in command
+    command = command.strip().replace('+', '')
+    return (command, verbose, arg.strip())
 
 @export
 def special_command(command, shortcut, description, arg_type=PARSED_QUERY,
@@ -50,7 +52,7 @@ def execute(cur, sql):
     """Execute a special command and return the results. If the special command
     is not supported a KeyError will be raised.
     """
-    command, arg = parse_special_command(sql)
+    command, verbose, arg = parse_special_command(sql)
 
     if (command not in COMMANDS) and (command.lower() not in COMMANDS):
         raise CommandNotFound
@@ -70,7 +72,7 @@ def execute(cur, sql):
     if special_cmd.arg_type == NO_QUERY:
         return special_cmd.handler()
     elif special_cmd.arg_type == PARSED_QUERY:
-        return special_cmd.handler(cur=cur, arg=arg)
+        return special_cmd.handler(cur=cur, arg=arg, verbose=verbose)
     elif special_cmd.arg_type == RAW_QUERY:
         return special_cmd.handler(cur=cur, query=sql)
 

--- a/test/features/fixture_data/help_commands.txt
+++ b/test/features/fixture_data/help_commands.txt
@@ -2,8 +2,7 @@
 | Command     | Shortcut          | Description                                                |
 +-------------+-------------------+------------------------------------------------------------+
 | \G          | \G                | Display current query results vertically.                  |
-| \dt         | \dt [table]       | List or describe tables.                                   |
-| \dt+        | \dt+ [table]      | List tables or show create table.                          |
+| \dt         | \dt[+] [table]    | List or describe tables.                                   |
 | \e          | \e                | Edit command with editor (uses $EDITOR).                   |
 | \f          | \f [name]         | List or execute favorite queries.                          |
 | \fd         | \fd [name]        | Delete a favorite query.                                   |


### PR DESCRIPTION
## Description

* Add the ability to handle verbose flag in special command. 
* Convert `\dt+` to use the verbose flag.

/cc @tanzoniteblack this PR refactors your code. After I did the refactor I realized why you chose to implement `\dt+` as a separate function. It was because never had the ability to handle the `+` sign in special commands. But pgcli has that ability. So I chose to port over that code from pgcli. Once again thank you for this clever idea to use pgcli style verbosity in mycli. :smile: 

Reviewer: @tsroten 