### PR TITLE
Add current time to prompt.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Features:
 * Opening an external editor will edit the last-run query. (Thanks: [Thomas Roten]).
 * Output once special command. (Thanks: [Dick Marinus]).
 * Add special command to show create table statement. (Thanks: [Ryan Smith])
+* Add current time to prompt options (Thanks: [Thomas Roten]).
 
 Bug Fixes:
 ----------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -744,17 +744,18 @@ class MyCli(object):
     def get_prompt(self, string):
         sqlexecute = self.sqlexecute
         host = self.login_path if self.login_path and self.login_path_as_host else sqlexecute.host
+        now = datetime.now()
         string = string.replace('\\u', sqlexecute.user or '(none)')
         string = string.replace('\\h', host or '(none)')
         string = string.replace('\\d', sqlexecute.dbname or '(none)')
         string = string.replace('\\t', sqlexecute.server_type()[0] or 'mycli')
         string = string.replace('\\n', "\n")
-        string = string.replace('\\D', datetime.now().strftime('%a %b %d %H:%M:%S %Y'))
-        string = string.replace('\\m', datetime.now().strftime('%M'))
-        string = string.replace('\\P', datetime.now().strftime('%p'))
-        string = string.replace('\\R', datetime.now().strftime('%H'))
-        string = string.replace('\\r', datetime.now().strftime('%I'))
-        string = string.replace('\\s', datetime.now().strftime('%S'))
+        string = string.replace('\\D', now.strftime('%a %b %d %H:%M:%S %Y'))
+        string = string.replace('\\m', now.strftime('%M'))
+        string = string.replace('\\P', now.strftime('%p'))
+        string = string.replace('\\R', now.strftime('%H'))
+        string = string.replace('\\r', now.strftime('%I'))
+        string = string.replace('\\s', now.strftime('%S'))
         string = string.replace('\\p', str(sqlexecute.port))
         string = string.replace('\\_', ' ')
         return string

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -750,6 +750,11 @@ class MyCli(object):
         string = string.replace('\\t', sqlexecute.server_type()[0] or 'mycli')
         string = string.replace('\\n', "\n")
         string = string.replace('\\D', datetime.now().strftime('%a %b %d %H:%M:%S %Y'))
+        string = string.replace('\\m', datetime.now().strftime('%M'))
+        string = string.replace('\\P', datetime.now().strftime('%p'))
+        string = string.replace('\\R', datetime.now().strftime('%H'))
+        string = string.replace('\\r', datetime.now().strftime('%I'))
+        string = string.replace('\\s', datetime.now().strftime('%S'))
         string = string.replace('\\p', str(sqlexecute.port))
         string = string.replace('\\_', ' ')
         return string

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -52,11 +52,18 @@ key_bindings = emacs
 wider_completion_menu = False
 
 # MySQL prompt
+# \D - The full current date
+# \d - Database name
+# \h - Hostname of the server
+# \m - Minutes of the current time
+# \n - Newline
+# \P - AM/PM
+# \p - Port
+# \R - The current time, in 24-hour military time (0–23)
+# \r - The current time, standard 12-hour time (1–12)
+# \s - Seconds of the current time
 # \t - Product type (Percona, MySQL, Mariadb)
 # \u - Username
-# \h - Hostname of the server
-# \d - Database name
-# \n - Newline
 prompt = '\t \u@\h:\d> '
 prompt_continuation = '-> '
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

This adds individual time components to the prompt (to match MySQL):
- `\R`: hours (0-23)
- `\r`: hours (1-12)
- `\m`: minutes
- `\s`: seconds
- `\P`: AM/PM

It also adds missing prompt items to the `myclirc` comments.

This addresses #437.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
