### PR TITLE
Add styled/colored output.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ Features:
 * Add special command to show create table statement. (Thanks: [Ryan Smith])
 * Display all result sets returned by stored procedures (Thanks: [Thomas Roten]).
 * Add current time to prompt options (Thanks: [Thomas Roten]).
+* Add colored/styled headers and odd/even rows (Thanks: [Thomas Roten]).
 
 Bug Fixes:
 ----------

--- a/mycli/clistyle.py
+++ b/mycli/clistyle.py
@@ -1,19 +1,28 @@
+import pygments.style
+import pygments.styles
 from pygments.token import string_to_tokentype
 from pygments.util import ClassNotFound
-from prompt_toolkit.styles import default_style_extensions, style_from_dict
-import pygments.styles
 
 
 def style_factory(name, cli_style):
+    """Create a Pygments Style class based on the user's preferences.
+
+    :param str name: The name of a built-in Pygments style.
+    :param dict cli_style: The user's token-type style preferences.
+
+    """
     try:
         style = pygments.styles.get_style_by_name(name)
     except ClassNotFound:
         style = pygments.styles.get_style_by_name('native')
 
-    styles = {}
-    styles.update(style.styles)
-    styles.update(default_style_extensions)
+    style_tokens = {}
+    style_tokens.update(style.styles)
     custom_styles = {string_to_tokentype(x): y for x, y in cli_style.items()}
-    styles.update(custom_styles)
+    style_tokens.update(custom_styles)
 
-    return style_from_dict(styles)
+    class MycliStyle(pygments.style.Style):
+        default_styles = ''
+        styles = style_tokens
+
+    return MycliStyle

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -19,6 +19,7 @@ from prompt_toolkit import CommandLineInterface, Application, AbortAction
 from prompt_toolkit.interface import AcceptAction
 from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
 from prompt_toolkit.shortcuts import create_prompt_layout, create_eventloop
+from prompt_toolkit.styles.from_pygments import style_from_pygments
 from prompt_toolkit.document import Document
 from prompt_toolkit.filters import Always, HasFocus, IsDone
 from prompt_toolkit.layout.processors import (HighlightMatchingBracketProcessor,
@@ -111,6 +112,7 @@ class MyCli(object):
         self.syntax_style = c['main']['syntax_style']
         self.less_chatty = c['main'].as_bool('less_chatty')
         self.cli_style = c['colors']
+        self.output_style = style_factory(self.syntax_style, self.cli_style)
         self.wider_completion_menu = c['main'].as_bool('wider_completion_menu')
         c_dest_warning = c['main'].as_bool('destructive_warning')
         self.destructive_warning = c_dest_warning if warn is None else warn
@@ -627,13 +629,13 @@ class MyCli(object):
             else:
                 editing_mode = EditingMode.EMACS
 
-            application = Application(style=style_factory(self.syntax_style, self.cli_style),
-                                      layout=layout, buffer=buf,
-                                      key_bindings_registry=key_binding_manager.registry,
-                                      on_exit=AbortAction.RAISE_EXCEPTION,
-                                      on_abort=AbortAction.RETRY,
-                                      editing_mode=editing_mode,
-                                      ignore_case=True)
+            application = Application(
+                style=style_from_pygments(style_cls=self.output_style),
+                layout=layout, buffer=buf,
+                key_bindings_registry=key_binding_manager.registry,
+                on_exit=AbortAction.RAISE_EXCEPTION,
+                on_abort=AbortAction.RETRY, editing_mode=editing_mode,
+                ignore_case=True)
             self.cli = CommandLineInterface(application=application,
                                        eventloop=create_eventloop())
 
@@ -783,12 +785,14 @@ class MyCli(object):
         if cur:
             rows = list(cur)
             formatted = self.formatter.format_output(
-                rows, headers, format_name='vertical' if expanded else None)
+                rows, headers, format_name='vertical' if expanded else None,
+                style=self.output_style)
 
             if (not expanded and max_width and rows and
                     content_exceeds_width(rows[0], max_width) and headers):
                 formatted = self.formatter.format_output(
-                    rows, headers, format_name='vertical')
+                    rows, headers, format_name='vertical',
+                    style=self.output_style)
 
             output.append(formatted)
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -650,8 +650,7 @@ class MyCli(object):
     def log_output(self, output):
         """Log the output in the audit log, if it's enabled."""
         if self.logfile:
-            self.logfile.write(utf8tounicode(output))
-            self.logfile.write('\n')
+            click.echo(utf8tounicode(output), file=self.logfile)
 
     def echo(self, s, **kwargs):
         """Print a message to stdout.

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -86,6 +86,11 @@ Token.Menu.Completions.MultiColumnMeta = 'bg:#aaffff #000000'
 Token.Menu.Completions.ProgressButton = 'bg:#003333'
 Token.Menu.Completions.ProgressBar = 'bg:#00aaaa'
 
+# Query results
+Token.Output.Header = 'bold'
+Token.Output.OddRow = ''
+Token.Output.EvenRow = ''
+
 # Selected text.
 Token.SelectedText = '#ffffff bg:#6666aa'
 

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -292,8 +292,8 @@ def no_tee(arg, **_):
 def write_tee(output):
     global tee_file
     if tee_file:
-        tee_file.write(output)
-        tee_file.write(u"\n")
+        click.echo(output, file=tee_file)
+        click.echo(u'\n', file=tee_file)
         tee_file.flush()
 
 
@@ -320,8 +320,8 @@ def write_once(output):
                 e.filename, e.strerror))
 
         with f:
-            f.write(output)
-            f.write(u"\n")
+            click.echo(output, file=f)
+            click.echo(u"\n", file=f)
         written_to_once_file = True
 
 

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -292,8 +292,8 @@ def no_tee(arg, **_):
 def write_tee(output):
     global tee_file
     if tee_file:
-        click.echo(output, file=tee_file)
-        click.echo(u'\n', file=tee_file)
+        click.echo(output, file=tee_file, nl=False)
+        click.echo(u'\n', file=tee_file, nl=False)
         tee_file.flush()
 
 
@@ -320,8 +320,8 @@ def write_once(output):
                 e.filename, e.strerror))
 
         with f:
-            click.echo(output, file=f)
-            click.echo(u"\n", file=f)
+            click.echo(output, file=f, nl=False)
+            click.echo(u"\n", file=f, nl=False)
         written_to_once_file = True
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requirements = [
     'sqlparse>=0.2.2,<0.3.0',
     'configobj >= 5.0.5',
     'cryptography >= 1.0.0',
-    'cli_helpers >= 0.1.0',
+    'cli_helpers[styles] >= 0.2.0',
 ]
 
 setup(

--- a/test/test_clistyle.py
+++ b/test/test_clistyle.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""Test the mycli.clistyle module."""
+
+from pygments.style import Style
+from pygments.token import Token
+
+from mycli.clistyle import style_factory
+
+
+def test_style_factory():
+    """Test that a Pygments Style class is created."""
+    header = 'bold underline #ansired'
+    cli_style = {'Token.Output.Header': header}
+    style = style_factory('default', cli_style)
+
+    assert isinstance(style(), Style)
+    assert Token.Output.Header in style.styles
+    assert header == style.styles[Token.Output.Header]
+
+
+def test_style_factory_unknown_name():
+    """Test that an unrecognized name will not throw an error."""
+    style = style_factory('foobar', {})
+
+    assert isinstance(style(), Style)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This adds styled output (headers, odd row, even rows). Configuring it is the same as the current styles (i.e. Pygments token-type strings). It defaults the config file to do bold headers.

This addresses #364.

~~The tests will fail until CLI Helpers is released with https://github.com/dbcli/cli_helpers/pull/10.~~


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
