### PR TITLE
Use standard library logging.NullHandler.

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -57,10 +57,6 @@ Query = namedtuple('Query', ['query', 'successful', 'mutating'])
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 
-# no-op logging handler
-class NullHandler(logging.Handler):
-    def emit(self, record):
-        pass
 
 class MyCli(object):
 
@@ -249,7 +245,7 @@ class MyCli(object):
         # Disable logging if value is NONE by switching to a no-op handler
         # Set log level to a high value so it doesn't even waste cycles getting called.
         if log_level.upper() == "NONE":
-            handler = NullHandler()
+            handler = logging.NullHandler()
             log_level = "CRITICAL"
         else:
             handler = logging.FileHandler(os.path.expanduser(log_file))


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Use the standard library `logging.NullHandler` since we don't need to support Python 2.6 any longer.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] ~~I've added this contribution to the `changelog.md`.~~ N/A
- [x] I've added my name to the `AUTHORS` file (or it's already there).
