### PR TITLE
Use appropriate CLI Helpers formatting.

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -13,6 +13,7 @@ from random import choice
 from io import open
 
 from cli_helpers.tabular_output import TabularOutputFormatter
+from cli_helpers.tabular_output import preprocessors
 import click
 import sqlparse
 from prompt_toolkit import CommandLineInterface, Application, AbortAction
@@ -786,18 +787,25 @@ class MyCli(object):
         expanded = expanded or self.formatter.format_name == 'vertical'
         output = []
 
+        output_kwargs = {
+            'disable_numparse': True,
+            'preserve_whitespace': True,
+            'preprocessors': (preprocessors.align_decimals, )
+        }
+
         if title:  # Only print the title if it's not None.
             output.append(title)
 
         if cur:
             rows = list(cur)
             formatted = self.formatter.format_output(
-                rows, headers, format_name='vertical' if expanded else None)
+                rows, headers, format_name='vertical' if expanded else None,
+                **output_kwargs)
 
             if (not expanded and max_width and rows and
                     content_exceeds_width(rows[0], max_width) and headers):
                 formatted = self.formatter.format_output(
-                    rows, headers, format_name='vertical')
+                    rows, headers, format_name='vertical', **output_kwargs)
 
             output.append(formatted)
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
- Disable tabulate's numparse.
- Uses tabulate's preserve whitespace (so whitespace is not stripped).
- Aligns decimal columns on decimal place (this preprocessor needs to be explicitly included since the pgcli change to CLI Helpers).


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- ~~I've added this contribution to the `changelog.md`.~~ Not needed, part of the CLI Helpers switch
- [x] I've added my name to the `AUTHORS` file (or it's already there).
