### PR TITLE
Expand user directory for tee/once output files.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@ Bug Fixes:
 * Fixed issue where quit command would sometimes not work (Thanks: [Thomas Roten]).
 * Remove shebang from main.py (Thanks: [Dick Marinus]).
 * Only use pager if output doesn't fit. (Thanks: [Dick Marinus]).
+* Support tilde user directory for output file names (Thanks: [Thomas Roten]).
 
 Internal Changes:
 -----------------

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -260,7 +260,7 @@ def parseargfile(arg):
     if not filename:
         raise TypeError('You must provide a filename.')
 
-    return {'file': filename, 'mode': mode}
+    return {'file': os.path.expanduser(filename), 'mode': mode}
 
 
 @special_command('tee', 'tee [-o] filename',

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -120,7 +120,6 @@ def test_parseargfile():
         '-o ~/filename')
 
 
-
 def test_parseargfile_no_file():
     """Test that parseargfile raises a TypeError if there is no filename."""
     with pytest.raises(TypeError):

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -105,3 +105,26 @@ def test_once_command():
         mycli.packages.special.write_once(u"hello world")
         f.seek(0)
         assert f.read() == b"hello world\n"
+
+
+def test_parseargfile():
+    """Test that parseargfile expands the user directory."""
+    expected = {'file': os.path.join(os.path.expanduser('~'), 'filename'),
+                'mode': 'a'}
+    assert expected == mycli.packages.special.iocommands.parseargfile(
+        '~/filename')
+
+    expected = {'file': os.path.join(os.path.expanduser('~'), 'filename'),
+                'mode': 'w'}
+    assert expected == mycli.packages.special.iocommands.parseargfile(
+        '-o ~/filename')
+
+
+
+def test_parseargfile_no_file():
+    """Test that parseargfile raises a TypeError if there is no filename."""
+    with pytest.raises(TypeError):
+        mycli.packages.special.iocommands.parseargfile('')
+
+    with pytest.raises(TypeError):
+        mycli.packages.special.iocommands.parseargfile('-o ')


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Expand the user directory (i.e. `~`) when using `tee` and `\once`.
See https://github.com/dbcli/mycli/issues/467.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
