### PR TITLE
Fix auto vertical mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@ Bug Fixes:
 * Remove shebang from main.py (Thanks: [Dick Marinus]).
 * Only use pager if output doesn't fit. (Thanks: [Dick Marinus]).
 * Support tilde user directory for output file names (Thanks: [Thomas Roten]).
+* Auto vertical output is a little bit better at its calculations (Thanks: [Thomas Roten]).
 
 Internal Changes:
 -----------------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -793,9 +793,10 @@ class MyCli(object):
             rows = list(cur)
             formatted = self.formatter.format_output(
                 rows, headers, format_name='vertical' if expanded else None)
+            first_line = formatted[:formatted.find('\n')]
 
-            if (not expanded and max_width and rows and
-                    content_exceeds_width(rows[0], max_width) and headers):
+            if (not expanded and max_width and headers and rows and
+                    len(first_line) > max_width):
                 formatted = self.formatter.format_output(
                     rows, headers, format_name='vertical')
 
@@ -961,13 +962,6 @@ def cli(database, user, host, port, socket, password, dbname,
             click.secho(str(e), err=True, fg='red')
             exit(1)
 
-
-def content_exceeds_width(row, width):
-    # Account for 3 characters between each column
-    separator_space = (len(row)*3)
-    # Add 2 columns for a bit of buffer
-    line_len = sum([len(str(x)) for x in row]) + separator_space + 2
-    return line_len > width
 
 def need_completion_refresh(queries):
     """Determines if the completion needs a refresh by checking if the sql

--- a/test/features/auto_vertical.feature
+++ b/test/features/auto_vertical.feature
@@ -1,0 +1,12 @@
+Feature: auto_vertical mode:
+  on, off
+
+  Scenario: auto_vertical on with small query
+    When we run dbcli with --auto-vertical-output
+      and we execute a small query
+      then we see small results in horizontal format
+
+  Scenario: auto_vertical on with large query
+    When we run dbcli with --auto-vertical-output
+      and we execute a large query
+      then we see large results in vertical format

--- a/test/features/steps/auto_vertical.py
+++ b/test/features/steps/auto_vertical.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8
+from __future__ import unicode_literals
+from textwrap import dedent
+
+from behave import then, when
+
+import wrappers
+
+
+@when('we run dbcli with {arg}')
+def step_run_cli_with_arg(context, arg):
+    wrappers.run_cli(context, run_args=arg.split('='))
+
+
+@when('we execute a small query')
+def step_execute_small_query(context):
+    context.cli.sendline('select 1')
+
+
+@when('we execute a large query')
+def step_execute_large_query(context):
+    context.cli.sendline(
+        'select {}'.format(','.join([str(n) for n in range(1, 50)])))
+
+
+@then('we see small results in horizontal format')
+def step_see_small_results(context):
+    wrappers.expect_pager(context, dedent("""\
+        +---+\r
+        | 1 |\r
+        +---+\r
+        | 1 |\r
+        +---+\r
+        """), timeout=5)
+    wrappers.expect_exact(context, '1 row in set', timeout=2)
+
+
+@then('we see large results in vertical format')
+def step_see_large_results(context):
+    rows = ['{n:3}| {n}'.format(n=str(n)) for n in range(1, 50)]
+    expected = ('***************************[ 1. row ]'
+                '***************************\r\n' +
+                '{}\r\n\r\n'.format('\r\n'.join(rows)))
+
+    wrappers.expect_pager(context, expected, timeout=5)
+    wrappers.expect_exact(context, '1 row in set', timeout=2)

--- a/test/features/steps/wrappers.py
+++ b/test/features/steps/wrappers.py
@@ -22,9 +22,9 @@ def expect_pager(context, expected, timeout):
         context.conf['pager_boundary'], expected), timeout=timeout)
 
 
-def run_cli(context):
+def run_cli(context, run_args=None):
     """Run the process using pexpect."""
-    run_args = []
+    run_args = run_args or []
     if context.conf.get('host', None):
         run_args.extend(('-h', context.conf['host']))
     if context.conf.get('user', None):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
The auto vertical mode was using unformatted output (with its best guess of table delimiters) to calculate whether or not the output was too big. This makes it use the first line of the formatted output.

It's not fool-proof because of TSV and CSV formats where the first line (header), might be shorter than other lines, but the previous method of measuring width had the same problem. So, this improves in some but not all ways.

Also, adds behave tests for auto vertical mode.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
