### PR TITLE
Submit against the latest tag instead of master

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,3 +128,5 @@ $ ./setup.py lint --fix
 ```
 
 Be sure to commit and push any PEP 8 fixes.
+
+For bugfixes: Submit against the latest tag instead of master!


### PR DESCRIPTION
## Description
Submit against the latest tag instead of master, this way the patches from bug fixes can be cleanly applied by packagers.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.