### PR TITLE
Catch error for missing help_topic database.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+TBD:
+=======
+
+Bug Fixes:
+----------
+
+* Prevent missing MySQL help database from causing errors in completions (Thanks: [Thomas Roten]).
+
 1.12.0:
 =======
 

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -195,7 +195,7 @@ class SQLExecute(object):
             _logger.debug('Show Query. sql: %r', self.show_candidates_query)
             try:
                 cur.execute(self.show_candidates_query)
-            except pymysql.OperationalError as e:
+            except pymysql.DatabaseError as e:
                 _logger.error('No show completions due to %r', e)
                 yield ''
             else:
@@ -207,7 +207,7 @@ class SQLExecute(object):
             _logger.debug('Users Query. sql: %r', self.users_query)
             try:
                 cur.execute(self.users_query)
-            except pymysql.OperationalError as e:
+            except pymysql.DatabaseError as e:
                 _logger.error('No user completions due to %r', e)
                 yield ''
             else:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
The `mysql.help_topic` database doesn't always exist on MySQL servers. We query it for completion data.

This PR catches the PyMySQL error in the case that the database doesn't exit.

See https://github.com/dbcli/mycli/issues/485 for more information.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
