### PR TITLE
Make sure that terminal size is returned as an integer.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Bug Fixes:
 ----------
 
 * Prevent missing MySQL help database from causing errors in completions (Thanks: [Thomas Roten]).
+* Fix mycli from crashing with small terminal windows under Python 2 (Thanks: [Thomas Roten]).
 
 1.12.0:
 =======

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -831,7 +831,7 @@ class MyCli(object):
         reserved_space_ratio = .45
         max_reserved_space = 8
         _, height = click.get_terminal_size()
-        return min(round(height * reserved_space_ratio), max_reserved_space)
+        return min(int(round(height * reserved_space_ratio)), max_reserved_space)
 
     def get_last_query(self):
         """Get the last query executed or None."""

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -199,3 +199,17 @@ def test_command_descriptions_end_with_periods():
     MyCli()
     for _, command in SPECIAL_COMMANDS.items():
         assert command[3].endswith('.')
+
+
+def test_reserved_space_is_integer():
+    """Make sure that reserved space is returned as an integer."""
+    def stub_terminal_size():
+        return (5, 5)
+
+    old_func = click.get_terminal_size
+
+    click.get_terminal_size = stub_terminal_size
+    mycli = MyCli()
+    assert isinstance(mycli.get_reserved_space(), int)
+
+    click.get_terminal_size = old_func


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Under Python 2 `round(n)` returns a float. In Python 3 it returns an integer. We use `round` to determine the amount of reserved space we should use for the completion menu. Prompt Toolkit requires this to be an integer (because it passes it to `range()`).

See https://github.com/dbcli/mycli/issues/488


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
