### PR TITLE
Gracefully handle dropping default database.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Bug Fixes:
 
 * Prevent missing MySQL help database from causing errors in completions (Thanks: [Thomas Roten]).
 * Fix mycli from crashing with small terminal windows under Python 2 (Thanks: [Thomas Roten]).
+* Prevent an error from displaying when you drop the current database (Thanks: [Thomas Roten]).
 
 Internal Changes:
 -----------------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1014,17 +1014,16 @@ def need_completion_refresh(queries):
 
 def is_dropping_database(queries, dbname):
     """Determine if the query is dropping a specific database."""
-    for query in sqlparse.split(queries):
-        try:
-            stmt = sqlparse.parse(query)[0]
-            first_token = stmt.token_first(skip_cm=True)
-            _, second_token = stmt.token_next(0, skip_cm=True)
-            if (first_token.value.lower() == 'drop' and
-                    second_token.value.lower() in ('database', 'schema') and
-                    stmt.get_name().lower() == dbname.lower()):
-                return True
-        except Exception:
-            return False
+    if dbname is None:
+        return False
+
+    for query in sqlparse.parse(queries):
+        first_token = query.token_first(skip_cm=True)
+        _, second_token = query.token_next(0, skip_cm=True)
+        if (first_token.value.lower() == 'drop' and
+                second_token.value.lower() in ('database', 'schema') and
+                query.get_name().lower() == dbname.lower()):
+            return True
 
 
 def need_completion_reset(queries):

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1017,8 +1017,8 @@ def is_dropping_database(queries, dbname):
     for query in sqlparse.split(queries):
         try:
             stmt = sqlparse.parse(query)[0]
-            first_token = stmt.token_first(skip_ws=True, skip_cm=True)
-            _, second_token = stmt.token_next(0, skip_ws=True, skip_cm=True)
+            first_token = stmt.token_first(skip_cm=True)
+            _, second_token = stmt.token_next(0, skip_cm=True)
             if (first_token.value.lower() == 'drop' and
                     second_token.value.lower() in ('database', 'schema') and
                     stmt.get_name().lower() == dbname.lower()):

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1017,12 +1017,21 @@ def is_dropping_database(queries, dbname):
     if dbname is None:
         return False
 
+    def normalize_db_name(db):
+        return db.lower().strip('`"')
+
+    dbname = normalize_db_name(dbname)
+
     for query in sqlparse.parse(queries):
+        if query.get_name() is None:
+            continue
+
         first_token = query.token_first(skip_cm=True)
         _, second_token = query.token_next(0, skip_cm=True)
+        database_name = normalize_db_name(query.get_name())
         if (first_token.value.lower() == 'drop' and
                 second_token.value.lower() in ('database', 'schema') and
-                query.get_name().lower() == dbname.lower()):
+                database_name == dbname):
             return True
 
 

--- a/test/features/crud_database.feature
+++ b/test/features/crud_database.feature
@@ -14,3 +14,11 @@ Feature: manipulate databases:
       then we see database connected
       when we connect to dbserver
       then we see database connected
+
+  Scenario: create and drop default database
+     When we create database
+      then we see database created
+      when we connect to tmp database
+      then we see database connected
+      when we drop database
+      then we see database dropped and no default database

--- a/test/features/steps/crud_database.py
+++ b/test/features/steps/crud_database.py
@@ -42,6 +42,13 @@ def step_db_connect_test(context):
     context.currentdb = db_name
     context.cli.sendline('use {0}'.format(db_name))
 
+@when('we connect to tmp database')
+def step_db_connect_tmp(context):
+    """Send connect to database."""
+    db_name = context.conf['dbname_tmp']
+    context.currentdb = db_name
+    context.cli.sendline('use {0}'.format(db_name))
+
 
 @when('we connect to dbserver')
 def step_db_connect_dbserver(context):
@@ -82,6 +89,16 @@ def step_see_db_created(context):
 @then('we see database dropped')
 def step_see_db_dropped(context):
     """Wait to see drop database output."""
+    wrappers.expect_exact(context, 'Query OK, 0 rows affected', timeout=2)
+
+
+@then('we see database dropped and no default database')
+def step_see_db_dropped_no_default(context):
+    """Wait to see drop database output."""
+    user = context.conf['user']
+    host = context.conf['host']
+    context.currentdb = '(none)'
+
     wrappers.expect_exact(context, 'Query OK, 0 rows affected', timeout=2)
 
 

--- a/test/features/steps/crud_database.py
+++ b/test/features/steps/crud_database.py
@@ -42,6 +42,7 @@ def step_db_connect_test(context):
     context.currentdb = db_name
     context.cli.sendline('use {0}'.format(db_name))
 
+
 @when('we connect to tmp database')
 def step_db_connect_tmp(context):
     """Send connect to database."""

--- a/test/features/steps/crud_database.py
+++ b/test/features/steps/crud_database.py
@@ -98,9 +98,14 @@ def step_see_db_dropped_no_default(context):
     """Wait to see drop database output."""
     user = context.conf['user']
     host = context.conf['host']
-    context.currentdb = '(none)'
+    database = '(none)'
+    context.currentdb = None
 
     wrappers.expect_exact(context, 'Query OK, 0 rows affected', timeout=2)
+    wrappers.expect_exact(context, 'mysql {0}@{1}:{2}> '.format(
+        user, host, database), timeout=5)
+
+    context.atprompt = True
 
 
 @then('we see database connected')


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

In mycli, the current behavior when dropping the current default database is to:
- display a stack track for the background completion refresher's error
- keep the now-dropped database as the default database for the current connection

This PR:
- resets the current database in the connection when it is dropped

This means that the prompt is updated to display `(none)` as the current database once you drop it (i.e. same behavior as mysql).

See https://github.com/dbcli/mycli/issues/253 for more information.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
