### PR TITLE
python27: Fix UnicodeEncodeError in open_external_editor

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+TBD
+===
+
+Bug Fixes:
+----------
+
+* Fix UnicodeEncodeError when editing sql command in external editor
+
 1.12.1:
 =======
 

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -51,6 +51,7 @@ Contributors:
   * Michał Górny
   * Terje Røsten
   * Ryan Smith
+  * Klaus Wünschel
 
 Creator:
 --------

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -131,7 +131,7 @@ def open_external_editor(filename=None, sql=None):
 
     # Populate the editor buffer with the partial sql (if available) and a
     # placeholder comment.
-    query = click.edit('{sql}\n\n{marker}'.format(sql=sql, marker=MARKER),
+    query = click.edit(u'{sql}\n\n{marker}'.format(sql=sql, marker=MARKER),
                        filename=filename, extension='.sql')
 
     if filename:


### PR DESCRIPTION
Fix UnicodeEncodeError when editing a sql command that contains non ASCII-
characters in an external editor.

## Description
Ensures that  the format string is unicode in python 2.7 and non-ASCII SQL-statements are converted properly.



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
