### PR TITLE
Fix mysql4 version comment retrieval

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Bug Fixes:
 ----------
 
 * Fix UnicodeEncodeError when editing sql command in external editor
+* Fix MySQL4 version comment retrieval (Thanks: [François Pietka])
 
 1.12.1:
 =======
@@ -499,3 +500,4 @@ Bug Fixes:
 [Casper Langemeijer]: https://github.com/langemeijer
 [Scrappy Soft]: https://github.com/scrappysoft
 [Dick Marinus]: https://github.com/meeuw
+[François Pietka]: https://github.com/fpietka

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -52,6 +52,7 @@ Contributors:
   * Terje Røsten
   * Ryan Smith
   * Klaus Wünschel
+  * François Pietka
 
 Creator:
 --------

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -227,6 +227,9 @@ class SQLExecute(object):
                               self.version_comment_query_mysql4)
                 cur.execute(self.version_comment_query_mysql4)
                 version_comment = cur.fetchone()[1].lower()
+                if isinstance(version_comment, bytes):
+                    # with python3 this query returns bytes
+                    version_comment = version_comment.decode('utf-8')
             else:
                 _logger.debug('Version Comment. sql: %r',
                               self.version_comment_query)

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -17,6 +17,7 @@ class SQLExecute(object):
     version_query = '''SELECT @@VERSION'''
 
     version_comment_query = '''SELECT @@VERSION_COMMENT'''
+    version_comment_query_mysql4 = '''SHOW VARIABLES LIKE "version_comment"'''
 
     show_candidates_query = '''SELECT name from mysql.help_topic WHERE name like "SHOW %"'''
 
@@ -221,9 +222,16 @@ class SQLExecute(object):
             _logger.debug('Version Query. sql: %r', self.version_query)
             cur.execute(self.version_query)
             version = cur.fetchone()[0]
-            _logger.debug('Version Comment. sql: %r', self.version_comment_query)
-            cur.execute(self.version_comment_query)
-            version_comment = cur.fetchone()[0].lower()
+            if version[0] == '4':
+                _logger.debug('Version Comment. sql: %r',
+                              self.version_comment_query_mysql4)
+                cur.execute(self.version_comment_query_mysql4)
+                version_comment = cur.fetchone()[1].lower()
+            else:
+                _logger.debug('Version Comment. sql: %r',
+                              self.version_comment_query)
+                cur.execute(self.version_comment_query)
+                version_comment = cur.fetchone()[0].lower()
 
         if 'mariadb' in version_comment:
             product_type = 'mariadb'


### PR DESCRIPTION
## Description
The query fetching version comment was failing on MySQL 4.
Fix #502 



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
