### PR TITLE
Fix error when displaying NULL and JSON values.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,8 @@ Bug Fixes:
 
 * Fix UnicodeEncodeError when editing sql command in external editor
 * Fix MySQL4 version comment retrieval (Thanks: [François Pietka])
+* Fix error that occurred when outputting JSON and NULL data (Thanks: [Thomas
+  Roten]).
 
 1.12.1:
 =======

--- a/changelog.md
+++ b/changelog.md
@@ -11,8 +11,7 @@ Bug Fixes:
 
 * Fix UnicodeEncodeError when editing sql command in external editor
 * Fix MySQL4 version comment retrieval (Thanks: [François Pietka])
-* Fix error that occurred when outputting JSON and NULL data (Thanks: [Thomas
-  Roten]).
+* Fix error that occurred when outputting JSON and NULL data (Thanks: [Thomas Roten]).
 
 1.12.1:
 =======

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -844,10 +844,10 @@ class MyCli(object):
         if cur:
             column_types = None
             if hasattr(cur, 'description'):
-                def sanitize(col):
-                    return col if type(col) is type else text_type
-                column_types = [sanitize(FIELD_TYPES.get(col[1], text_type))
-                                for col in cur.description]
+                def get_col_type(col):
+                    col_type = FIELD_TYPES.get(col[1], text_type)
+                    return col_type if type(col_type) is type else text_type
+                column_types = [get_col_type(col) for col in cur.description]
 
             if max_width is not None:
                 cur = list(cur)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -34,7 +34,7 @@ import mycli.packages.special as special
 from .sqlcompleter import SQLCompleter
 from .clitoolbar import create_toolbar_tokens_func
 from .clistyle import style_factory
-from .sqlexecute import SQLExecute
+from .sqlexecute import FIELD_TYPES, SQLExecute
 from .clibuffer import CLIBuffer
 from .completion_refresher import CompletionRefresher
 from .config import (write_default_config, get_mylogin_cnf_path,
@@ -846,7 +846,7 @@ class MyCli(object):
             if hasattr(cur, 'description'):
                 def sanitize(col):
                     return col if type(col) is type else text_type
-                column_types = [sanitize(converters.decoders[col[1]])
+                column_types = [sanitize(FIELD_TYPES.get(col[1]))
                                 for col in cur.description]
 
             if max_width is not None:

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -846,7 +846,7 @@ class MyCli(object):
             if hasattr(cur, 'description'):
                 def sanitize(col):
                     return col if type(col) is type else text_type
-                column_types = [sanitize(FIELD_TYPES.get(col[1]))
+                column_types = [sanitize(FIELD_TYPES.get(col[1], text_type))
                                 for col in cur.description]
 
             if max_width is not None:

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -4,9 +4,15 @@ import sqlparse
 from .packages import special
 from pymysql.constants import FIELD_TYPE
 from pymysql.converters import (convert_mysql_timestamp, convert_datetime,
-                                convert_timedelta, convert_date, conversions)
+                                convert_timedelta, convert_date, conversions,
+                                decoders)
 
 _logger = logging.getLogger(__name__)
+
+FIELD_TYPES = decoders.copy()
+FIELD_TYPES.update({
+    FIELD_TYPE.NULL: type(None)
+})
 
 class SQLExecute(object):
 

--- a/test/features/crud_table.feature
+++ b/test/features/crud_table.feature
@@ -18,3 +18,9 @@ Feature: manipulate tables:
       then we see table dropped
       when we connect to dbserver
       then we see database connected
+
+  Scenario: select null values
+    When we connect to test database
+      then we see database connected
+      when we select null
+      then we see null selected

--- a/test/features/steps/crud_table.py
+++ b/test/features/steps/crud_table.py
@@ -96,3 +96,23 @@ def step_see_data_deleted(context):
 def step_see_table_dropped(context):
     """Wait to see drop output."""
     wrappers.expect_exact(context, 'Query OK, 0 rows affected', timeout=2)
+
+
+@when('we select null')
+def step_select_null(context):
+    """Send select null."""
+    context.cli.sendline('select null;')
+
+
+@then('we see null selected')
+def step_see_null_selected(context):
+    """Wait to see null output."""
+    wrappers.expect_pager(
+        context, dedent("""\
+            +--------+\r
+            | NULL   |\r
+            +--------+\r
+            | <null> |\r
+            +--------+\r
+            """), timeout=1)
+    wrappers.expect_exact(context, '1 row in set', timeout=2)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This makes two changes:
- Adds a `FIELD_TYPES` dict in `sqlexecute` so we can add column types as needed.
- Uses `.get()` so that column types will fall back to a string if they don't exist in the field types dict.


This addresses https://github.com/dbcli/mycli/issues/509


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
