### PR TITLE
Don't use user config files in tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+TBD:
+=======
+
+Internal Changes:
+-----------------
+
+* Make tests ignore user config files (Thanks: [Thomas Roten]).
+
 1.13.0:
 =======
 

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -19,8 +19,8 @@ def before_all(context):
     os.environ['COLUMNS'] = "100"
     os.environ['EDITOR'] = 'ex'
 
-    login_path_file = os.path.abspath(os.path.join(
-        os.path.dirname(os.path.dirname(__file__)), 'mylogin.cnf'))
+    test_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+    login_path_file = os.path.join(test_dir, 'mylogin.cnf')
     os.environ['MYSQL_TEST_LOGIN_FILE'] = login_path_file
 
     context.package_root = os.path.abspath(
@@ -69,6 +69,8 @@ def before_all(context):
                 context.conf['pager_boundary'])
         )
     context.conf['defaults-file'] = my_cnf
+    context.conf['myclirc'] = os.path.join(context.package_root, 'mycli',
+                                           'myclirc')
 
     context.cn = dbutils.create_db(context.conf['host'], context.conf['user'],
                                    context.conf['pass'],

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -19,6 +19,10 @@ def before_all(context):
     os.environ['COLUMNS'] = "100"
     os.environ['EDITOR'] = 'ex'
 
+    login_path_file = os.path.abspath(os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), 'mylogin.cnf'))
+    os.environ['MYSQL_TEST_LOGIN_FILE'] = login_path_file
+
     context.package_root = os.path.abspath(
         os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 

--- a/test/features/steps/wrappers.py
+++ b/test/features/steps/wrappers.py
@@ -35,6 +35,8 @@ def run_cli(context, run_args=None):
         run_args.extend(('-D', context.conf['dbname']))
     if context.conf.get('defaults-file', None):
         run_args.extend(('--defaults-file', context.conf['defaults-file']))
+    if context.conf.get('myclirc', None):
+        run_args.extend(('--myclirc', context.conf['myclirc']))
     cli_cmd = context.conf.get('cli_command', None) or sys.executable + \
         ' -c "import coverage ; coverage.process_startup(); import mycli.main; mycli.main.cli()"'
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -20,8 +20,13 @@ except NameError:
 default_config_file = os.path.abspath(os.path.join(
     os.path.join(os.path.dirname(os.path.dirname(__file__)), 'mycli'),
     'myclirc'))
+login_path_file = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                               'mylogin.cnf'))
+
+os.environ['MYSQL_TEST_LOGIN_FILE'] = login_path_file
 CLI_ARGS = ['--user', USER, '--host', HOST, '--port', PORT,
             '--password', PASSWORD, '--myclirc', default_config_file,
+            '--defaults-file', default_config_file,
             '_test_db']
 
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -17,8 +17,12 @@ try:
 except NameError:
     text_type = str
 
+default_config_file = os.path.abspath(os.path.join(
+    os.path.join(os.path.dirname(os.path.dirname(__file__)), 'mycli'),
+    'myclirc'))
 CLI_ARGS = ['--user', USER, '--host', HOST, '--port', PORT,
-            '--password', PASSWORD, '_test_db']
+            '--password', PASSWORD, '--myclirc', default_config_file,
+            '_test_db']
 
 
 @dbtest

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -17,11 +17,10 @@ try:
 except NameError:
     text_type = str
 
-default_config_file = os.path.abspath(os.path.join(
-    os.path.join(os.path.dirname(os.path.dirname(__file__)), 'mycli'),
-    'myclirc'))
-login_path_file = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                               'mylogin.cnf'))
+test_dir = os.path.abspath(os.path.dirname(__file__))
+project_dir = os.path.dirname(test_dir)
+default_config_file = os.path.join(project_dir, 'mycli', 'myclirc')
+login_path_file = os.path.join(test_dir, 'mylogin.cnf')
 
 os.environ['MYSQL_TEST_LOGIN_FILE'] = login_path_file
 CLI_ARGS = ['--user', USER, '--host', HOST, '--port', PORT,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This makes the tests ignore the following user config files:
- login path file
- my.cnf
- myclirc

See https://github.com/dbcli/mycli/issues/522


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
