### PR TITLE
Catch ValueError when reading login path file.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+TBD:
+=======
+
+Bug Fixes:
+----------
+
+* Prevent mycli from crashing when failing to read login path file (Thanks: [Thomas Roten]).
+
 1.13.0:
 =======
 

--- a/mycli/config.py
+++ b/mycli/config.py
@@ -101,7 +101,7 @@ def open_mylogin_cnf(name):
     try:
         with open(name, 'rb') as f:
             plaintext = read_and_decrypt_mylogin_cnf(f)
-    except (OSError, IOError):
+    except (OSError, IOError, ValueError):
         logger.error('Unable to open login path file.')
         return None
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,7 +1,6 @@
 """Unit tests for the mycli.config module."""
 from io import BytesIO, TextIOWrapper
 import os
-import pip
 import struct
 import sys
 import tempfile
@@ -9,9 +8,6 @@ import pytest
 
 from mycli.config import (get_mylogin_cnf_path, open_mylogin_cnf,
                           read_and_decrypt_mylogin_cnf, str_to_bool)
-
-with_pycryptodome = ['pycryptodome' in set([package.project_name for package in
-                                            pip.get_installed_distributions()])]
 
 LOGIN_PATH_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                                'mylogin.cnf'))
@@ -25,7 +21,6 @@ def open_bmylogin_cnf(name):
     return buf
 
 
-@pytest.mark.skipif(not with_pycryptodome, reason='requires pycryptodome')
 def test_read_mylogin_cnf():
     """Tests that a login path file can be read and decrypted."""
     mylogin_cnf = open_mylogin_cnf(LOGIN_PATH_FILE)
@@ -37,14 +32,12 @@ def test_read_mylogin_cnf():
         assert word in contents
 
 
-@pytest.mark.skipif(not with_pycryptodome, reason='requires pycryptodome')
 def test_decrypt_blank_mylogin_cnf():
     """Test that a blank login path file is handled correctly."""
     mylogin_cnf = read_and_decrypt_mylogin_cnf(BytesIO())
     assert mylogin_cnf is None
 
 
-@pytest.mark.skipif(not with_pycryptodome, reason='requires pycryptodome')
 def test_corrupted_login_key():
     """Test that a corrupted login path key is handled correctly."""
     buf = open_bmylogin_cnf(LOGIN_PATH_FILE)
@@ -61,7 +54,6 @@ def test_corrupted_login_key():
     assert mylogin_cnf is None
 
 
-@pytest.mark.skipif(not with_pycryptodome, reason='requires pycryptodome')
 def test_corrupted_pad():
     """Tests that a login path file with a corrupted pad is partially read."""
     buf = open_bmylogin_cnf(LOGIN_PATH_FILE)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
We already catch quite a few errors while reading the login path file. However, if the part of the login path file that says how many bytes to read was corrupted, then mycli would crash with a `ValueError`. This fixes that.

This also removes old pycryptodome test-related code that is no long applicable.

See https://github.com/dbcli/mycli/issues/508


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
