### PR TITLE
Add `watch` command - repeat a query every N seconds

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+TBD:
+=======
+
+Features:
+---------
+
+* Add `watch [seconds] query` command to repeat a query every [seconds] seconds (by default 5).
+
 1.13.1:
 =======
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -30,6 +30,7 @@ from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from pygments.token import Token
 
 from .packages.special.main import NO_QUERY
+from .packages.prompt_utils import confirm_destructive_query
 import mycli.packages.special as special
 from .sqlcompleter import SQLCompleter
 from .clitoolbar import create_toolbar_tokens_func
@@ -1098,35 +1099,6 @@ def is_select(status):
     if not status:
         return False
     return status.split(None, 1)[0].lower() == 'select'
-
-def query_starts_with(query, prefixes):
-    """Check if the query starts with any item from *prefixes*."""
-    prefixes = [prefix.lower() for prefix in prefixes]
-    formatted_sql = sqlparse.format(query.lower(), strip_comments=True)
-    return bool(formatted_sql) and formatted_sql.split()[0] in prefixes
-
-def queries_start_with(queries, prefixes):
-    """Check if any queries start with any item from *prefixes*."""
-    for query in sqlparse.split(queries):
-        if query and query_starts_with(query, prefixes) is True:
-            return True
-    return False
-
-def is_destructive(queries):
-    keywords = ('drop', 'shutdown', 'delete', 'truncate')
-    return queries_start_with(queries, keywords)
-
-def confirm_destructive_query(queries):
-    """Check if the query is destructive and prompts the user to confirm.
-    Returns:
-    None if the query is non-destructive or we can't prompt the user.
-    True if the query is destructive and the user wants to proceed.
-    False if the query is destructive and the user doesn't want to proceed.
-    """
-    prompt_text = ("You're about to run a destructive command.\n"
-                   "Do you want to proceed? (y/n)")
-    if is_destructive(queries) and sys.stdin.isatty():
-        return click.prompt(prompt_text, type=bool)
 
 
 def thanks_picker(files=()):

--- a/mycli/packages/parseutils.py
+++ b/mycli/packages/parseutils.py
@@ -187,6 +187,28 @@ def find_prev_keyword(sql):
 
     return None, ''
 
+
+def query_starts_with(query, prefixes):
+    """Check if the query starts with any item from *prefixes*."""
+    prefixes = [prefix.lower() for prefix in prefixes]
+    formatted_sql = sqlparse.format(query.lower(), strip_comments=True)
+    return bool(formatted_sql) and formatted_sql.split()[0] in prefixes
+
+
+def queries_start_with(queries, prefixes):
+    """Check if any queries start with any item from *prefixes*."""
+    for query in sqlparse.split(queries):
+        if query and query_starts_with(query, prefixes) is True:
+            return True
+    return False
+
+
+def is_destructive(queries):
+    """Returns if any of the queries in *queries* is destructive."""
+    keywords = ('drop', 'shutdown', 'delete', 'truncate')
+    return queries_start_with(queries, keywords)
+
+
 if __name__ == '__main__':
     sql = 'select * from (select t. from tabl t'
     print (extract_tables(sql))

--- a/mycli/packages/prompt_utils.py
+++ b/mycli/packages/prompt_utils.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+
+import sys
+import click
+from .parseutils import is_destructive
+
+
+def confirm_destructive_query(queries):
+    """Check if the query is destructive and prompts the user to confirm.
+
+    Returns:
+    * None if the query is non-destructive or we can't prompt the user.
+    * True if the query is destructive and the user wants to proceed.
+    * False if the query is destructive and the user doesn't want to proceed.
+
+    """
+    prompt_text = ("You're about to run a destructive command.\n"
+                   "Do you want to proceed? (y/n)")
+    if is_destructive(queries) and sys.stdin.isatty():
+        return click.prompt(prompt_text, type=bool)

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -356,11 +356,15 @@ def watch_query(arg, **kwargs):
         raise StopIteration
     cur = kwargs['cur']
     sql_list = [
-        (sql.rstrip(';'), '> %s' % (sql))
+        (sql.rstrip(';'), "> {0!s}".format(sql))
         for sql in sqlparse.split(statement)
     ]
+    old_pager_enabled = is_pager_enabled()
     while True:
         try:
+            # Somewhere in the code the pager its activated after every yield,
+            # so we disable it in every iteration
+            set_pager_enabled(False)
             for (sql, title) in sql_list:
                 cur.execute(sql)
                 if cur.description:
@@ -374,3 +378,5 @@ def watch_query(arg, **kwargs):
             # to print a line with the cursor positioned behind the prompt
             click.secho("", nl=True)
             raise StopIteration
+        finally:
+            set_pager_enabled(old_pager_enabled)

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -13,6 +13,7 @@ from . import export
 from .main import special_command, NO_QUERY, PARSED_QUERY
 from .favoritequeries import favoritequeries
 from .utils import handle_cd_command
+from ..prompt_utils import confirm_destructive_query
 
 TIMING_ENABLED = False
 use_expanded_output = False
@@ -354,6 +355,12 @@ def watch_query(arg, **kwargs):
     if not statement:
         yield (None, None, None, usage)
         raise StopIteration
+    destructive_prompt = confirm_destructive_query(statement)
+    if destructive_prompt is False:
+        click.secho("Wise choice!")
+        raise StopIteration
+    elif destructive_prompt is True:
+        click.secho("Your call!")
     cur = kwargs['cur']
     sql_list = [
         (sql.rstrip(';'), "> {0!s}".format(sql))

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -346,7 +346,7 @@ def watch_query(arg, **kwargs):
         raise StopIteration
     try:
         args = arg.split(' ')
-        seconds = int(args[0])
+        seconds = float(args[0])
         statement = " ".join(filter(None, args[1:])).strip()
     except ValueError:
         seconds = 5

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -118,7 +118,6 @@ class SQLExecute(object):
         # want to save them all together.
         if statement.startswith('\\fs'):
             components = [statement]
-
         else:
             components = sqlparse.split(statement)
 

--- a/test/features/fixture_data/help_commands.txt
+++ b/test/features/fixture_data/help_commands.txt
@@ -1,29 +1,29 @@
-+-------------+-----------------------+------------------------------------------------------------+
-| Command     | Shortcut              | Description                                                |
-+-------------+-----------------------+------------------------------------------------------------+
-| \G          | \G                    | Display current query results vertically.                  |
-| \dt         | \dt[+] [table]        | List or describe tables.                                   |
-| \e          | \e                    | Edit command with editor (uses $EDITOR).                   |
-| \f          | \f [name]             | List or execute favorite queries.                          |
-| \fd         | \fd [name]            | Delete a favorite query.                                   |
-| \fs         | \fs name query        | Save a favorite query.                                     |
-| \l          | \l                    | List databases.                                            |
-| \once       | \o [-o] filename      | Append next result to an output file (overwrite using -o). |
-| \timing     | \t                    | Toggle timing of commands.                                 |
-| connect     | \r                    | Reconnect to the database. Optional database argument.     |
-| exit        | \q                    | Exit.                                                      |
-| help        | \?                    | Show this help.                                            |
-| nopager     | \n                    | Disable pager, print to stdout.                            |
-| notee       | notee                 | Stop writing results to an output file.                    |
-| pager       | \P [command]          | Set PAGER. Print the query results via PAGER.              |
-| prompt      | \R                    | Change prompt format.                                      |
-| quit        | \q                    | Quit.                                                      |
-| rehash      | \#                    | Refresh auto-completions.                                  |
-| source      | \. filename           | Execute commands from file.                                |
-| status      | \s                    | Get status information from the server.                    |
-| system      | system [command]      | Execute a system shell commmand.                           |
-| tableformat | \T                    | Change the table format used to output results.            |
-| tee         | tee [-o] filename     | Append all results to an output file (overwrite using -o). |
-| use         | \u                    | Change to a new database.                                  |
-| watch       | watch [seconds] query | Executes the query every [seconds] seconds (by default 5). |
-+-------------+-----------------------+------------------------------------------------------------+
++-------------+----------------------------+------------------------------------------------------------+
+| Command     | Shortcut                   | Description                                                |
++-------------+----------------------------+------------------------------------------------------------+
+| \G          | \G                         | Display current query results vertically.                  |
+| \dt         | \dt[+] [table]             | List or describe tables.                                   |
+| \e          | \e                         | Edit command with editor (uses $EDITOR).                   |
+| \f          | \f [name]                  | List or execute favorite queries.                          |
+| \fd         | \fd [name]                 | Delete a favorite query.                                   |
+| \fs         | \fs name query             | Save a favorite query.                                     |
+| \l          | \l                         | List databases.                                            |
+| \once       | \o [-o] filename           | Append next result to an output file (overwrite using -o). |
+| \timing     | \t                         | Toggle timing of commands.                                 |
+| connect     | \r                         | Reconnect to the database. Optional database argument.     |
+| exit        | \q                         | Exit.                                                      |
+| help        | \?                         | Show this help.                                            |
+| nopager     | \n                         | Disable pager, print to stdout.                            |
+| notee       | notee                      | Stop writing results to an output file.                    |
+| pager       | \P [command]               | Set PAGER. Print the query results via PAGER.              |
+| prompt      | \R                         | Change prompt format.                                      |
+| quit        | \q                         | Quit.                                                      |
+| rehash      | \#                         | Refresh auto-completions.                                  |
+| source      | \. filename                | Execute commands from file.                                |
+| status      | \s                         | Get status information from the server.                    |
+| system      | system [command]           | Execute a system shell commmand.                           |
+| tableformat | \T                         | Change the table format used to output results.            |
+| tee         | tee [-o] filename          | Append all results to an output file (overwrite using -o). |
+| use         | \u                         | Change to a new database.                                  |
+| watch       | watch [seconds] [-c] query | Executes the query every [seconds] seconds (by default 5). |
++-------------+----------------------------+------------------------------------------------------------+

--- a/test/features/fixture_data/help_commands.txt
+++ b/test/features/fixture_data/help_commands.txt
@@ -1,28 +1,29 @@
-+-------------+-------------------+------------------------------------------------------------+
-| Command     | Shortcut          | Description                                                |
-+-------------+-------------------+------------------------------------------------------------+
-| \G          | \G                | Display current query results vertically.                  |
-| \dt         | \dt[+] [table]    | List or describe tables.                                   |
-| \e          | \e                | Edit command with editor (uses $EDITOR).                   |
-| \f          | \f [name]         | List or execute favorite queries.                          |
-| \fd         | \fd [name]        | Delete a favorite query.                                   |
-| \fs         | \fs name query    | Save a favorite query.                                     |
-| \l          | \l                | List databases.                                            |
-| \once       | \o [-o] filename  | Append next result to an output file (overwrite using -o). |
-| \timing     | \t                | Toggle timing of commands.                                 |
-| connect     | \r                | Reconnect to the database. Optional database argument.     |
-| exit        | \q                | Exit.                                                      |
-| help        | \?                | Show this help.                                            |
-| nopager     | \n                | Disable pager, print to stdout.                            |
-| notee       | notee             | Stop writing results to an output file.                    |
-| pager       | \P [command]      | Set PAGER. Print the query results via PAGER.              |
-| prompt      | \R                | Change prompt format.                                      |
-| quit        | \q                | Quit.                                                      |
-| rehash      | \#                | Refresh auto-completions.                                  |
-| source      | \. filename       | Execute commands from file.                                |
-| status      | \s                | Get status information from the server.                    |
-| system      | system [command]  | Execute a system shell commmand.                           |
-| tableformat | \T                | Change the table format used to output results.            |
-| tee         | tee [-o] filename | Append all results to an output file (overwrite using -o). |
-| use         | \u                | Change to a new database.                                  |
-+-------------+-------------------+------------------------------------------------------------+
++-------------+-----------------------+------------------------------------------------------------+
+| Command     | Shortcut              | Description                                                |
++-------------+-----------------------+------------------------------------------------------------+
+| \G          | \G                    | Display current query results vertically.                  |
+| \dt         | \dt[+] [table]        | List or describe tables.                                   |
+| \e          | \e                    | Edit command with editor (uses $EDITOR).                   |
+| \f          | \f [name]             | List or execute favorite queries.                          |
+| \fd         | \fd [name]            | Delete a favorite query.                                   |
+| \fs         | \fs name query        | Save a favorite query.                                     |
+| \l          | \l                    | List databases.                                            |
+| \once       | \o [-o] filename      | Append next result to an output file (overwrite using -o). |
+| \timing     | \t                    | Toggle timing of commands.                                 |
+| connect     | \r                    | Reconnect to the database. Optional database argument.     |
+| exit        | \q                    | Exit.                                                      |
+| help        | \?                    | Show this help.                                            |
+| nopager     | \n                    | Disable pager, print to stdout.                            |
+| notee       | notee                 | Stop writing results to an output file.                    |
+| pager       | \P [command]          | Set PAGER. Print the query results via PAGER.              |
+| prompt      | \R                    | Change prompt format.                                      |
+| quit        | \q                    | Quit.                                                      |
+| rehash      | \#                    | Refresh auto-completions.                                  |
+| source      | \. filename           | Execute commands from file.                                |
+| status      | \s                    | Get status information from the server.                    |
+| system      | system [command]      | Execute a system shell commmand.                           |
+| tableformat | \T                    | Change the table format used to output results.            |
+| tee         | tee [-o] filename     | Append all results to an output file (overwrite using -o). |
+| use         | \u                    | Change to a new database.                                  |
+| watch       | watch [seconds] query | Executes the query every [seconds] seconds (by default 5). |
++-------------+-----------------------+------------------------------------------------------------+

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -3,9 +3,7 @@ import os
 import click
 from click.testing import CliRunner
 
-from mycli.main import (MyCli, cli, confirm_destructive_query,
-                        is_destructive, query_starts_with, queries_start_with,
-                        thanks_picker, PACKAGE_ROOT)
+from mycli.main import MyCli, cli, thanks_picker, PACKAGE_ROOT
 from mycli.packages.special.main import COMMANDS as SPECIAL_COMMANDS
 from utils import USER, HOST, PORT, PASSWORD, dbtest, run
 
@@ -139,52 +137,6 @@ def test_batch_mode_csv(executor):
 
     assert result.exit_code == 0
     assert expected in "".join(result.output)
-
-
-@dbtest
-def test_query_starts_with(executor):
-    query = 'USE test;'
-    assert query_starts_with(query, ('use', )) is True
-
-    query = 'DROP DATABASE test;'
-    assert query_starts_with(query, ('use', )) is False
-
-
-@dbtest
-def test_query_starts_with_comment(executor):
-    query = '# comment\nUSE test;'
-    assert query_starts_with(query, ('use', )) is True
-
-
-@dbtest
-def test_queries_start_with(executor):
-    sql = (
-        '# comment\n'
-        'show databases;'
-        'use foo;'
-    )
-    assert queries_start_with(sql, ('show', 'select')) is True
-    assert queries_start_with(sql, ('use', 'drop')) is True
-    assert queries_start_with(sql, ('delete', 'update')) is False
-
-
-@dbtest
-def test_is_destructive(executor):
-    sql = (
-        'use test;\n'
-        'show databases;\n'
-        'drop database foo;'
-    )
-    assert is_destructive(sql) is True
-
-
-@dbtest
-def test_confirm_destructive_query_notty(executor):
-    stdin = click.get_text_stream('stdin')
-    assert stdin.isatty() is False
-
-    sql = 'drop database foo;'
-    assert confirm_destructive_query(sql) is None
 
 
 def test_thanks_picker_utf8():

--- a/test/test_prompt_utils.py
+++ b/test/test_prompt_utils.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+
+import click
+
+from mycli.packages.prompt_utils import confirm_destructive_query
+
+
+def test_confirm_destructive_query_notty():
+    stdin = click.get_text_stream('stdin')
+    assert stdin.isatty() is False
+
+    sql = 'drop database foo;'
+    assert confirm_destructive_query(sql) is None

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -150,16 +150,17 @@ def test_watch_query_full():
 
     * Returns the expected results.
     * Executes the defined times inside the given interval, in this case with
-      a 2 seconds wait, it should execute 2 times inside a 3 seconds interval.
+      a 0.3 seconds wait, it should execute 4 times inside a 1 seconds
+      interval.
     * Stops at Ctrl-C
 
     """
-    watch_seconds = 2
-    wait_interval = 3
+    watch_seconds = 0.3
+    wait_interval = 1
     expected_value = "1"
     query = "SELECT {0!s}".format(expected_value)
     expected_title = '> {0!s}'.format(query)
-    expected_results = 2
+    expected_results = 4
     ctrl_c_process = send_ctrl_c(wait_interval)
     with db_connection().cursor() as cur:
         results = list(

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,15 +1,22 @@
-from os import getenv
+# -*- coding: utf-8 -*-
+
+
+import os
+import time
+import signal
+import platform
+import multiprocessing
 
 import pymysql
 import pytest
 
 from mycli.main import special
 
-PASSWORD = getenv('PYTEST_PASSWORD')
-USER = getenv('PYTEST_USER', 'root')
-HOST = getenv('PYTEST_HOST', 'localhost')
-PORT = getenv('PYTEST_PORT', 3306)
-CHARSET = getenv('PYTEST_CHARSET', 'utf8')
+PASSWORD = os.getenv('PYTEST_PASSWORD')
+USER = os.getenv('PYTEST_USER', 'root')
+HOST = os.getenv('PYTEST_HOST', 'localhost')
+PORT = os.getenv('PYTEST_PORT', 3306)
+CHARSET = os.getenv('PYTEST_CHARSET', 'utf8')
 
 
 def db_connection(dbname=None):
@@ -60,3 +67,28 @@ def set_expanded_output(is_expanded):
 def is_expanded_output():
     """Pass-through for the tests."""
     return special.is_expanded_output()
+
+
+def send_ctrl_c_to_pid(pid, wait_seconds):
+    """Sends a Ctrl-C like signal to the given `pid` after `wait_seconds`
+    seconds."""
+    time.sleep(wait_seconds)
+    system_name = platform.system()
+    if system_name == "Windows":
+        os.kill(pid, signal.CTRL_C_EVENT)
+    else:
+        os.kill(pid, signal.SIGINT)
+
+
+def send_ctrl_c(wait_seconds):
+    """Create a process that sends a Ctrl-C like signal to the current process
+    after `wait_seconds` seconds.
+
+    Returns the `multiprocessing.Process` created.
+
+    """
+    ctrl_c_process = multiprocessing.Process(
+        target=send_ctrl_c_to_pid, args=(os.getpid(), wait_seconds)
+    )
+    ctrl_c_process.start()
+    return ctrl_c_process


### PR DESCRIPTION
## Description

Add a special `watch` command with the syntax `watch [seconds] query`, without shorthand.

The command executes a query every `[seconds]` seconds, 5 by default.

While it works, it have some bugs:
* The waiting time is added to the query execution time shown to the user.
* After the first execution of the query, the output have an extra newline at the beginning.

Also it probably have lots of edge cases that are not covered, like running a query that requires user intervention (e.g. a reconnect prompt).

The implementation it's... not really good 😅  but it's simple and fills the gap of a feature asked in 
#69, so maybe it's worth it for a merge. Sorry, but writing a better, more complete version would require a lot more of work.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [X] I've added this contribution to the `changelog.md`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
- [x] Add unit tests.
- [x] Accept float as interval.
- [x] Prevent the pager to force a pause between iterations.
- [x] Add the warning on destructive commands before the first iteration.
- [x] Add flag to clear the screen between query executions.
- [x] ~Bugfix: make it work for multi-query statements.~ Too complex, maybe will be done in a separate PR.

## Side notes

Sorry, I know the branch build is failing but honestly, I don't know why.

The only clue I found is this message at the end of the builds: `fatal: Not a valid object name master`.

Maybe some change in Travis broke the tests, or did I f****d it up at some point that I don't see?

**Edit**: Ok found the cause, I described in (maybe too much) detail in the issue #527.