### PR TITLE
Drop Python 3.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ hasn't broken any existing functionality. To run the tests, just type in:
 $ ./setup.py test
 ```
 
-Mycli supports Python 2.7 and 3.3+. You can test against multiple versions of
+Mycli supports Python 2.7 and 3.4+. You can test against multiple versions of
 Python by running:
 
 ```bash

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+TBD:
+=======
+
+Internal Changes:
+-----------------
+
+* Drop support for Python 3.3 (Thanks: [Thomas Roten]).
+
 1.13.1:
 =======
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36
+envlist = py27, py34, py35, py36
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Python 3.3 was recently end-of-lifed. This removes it from mycli.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
