### PR TITLE
Make the tests more compatible with other environments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,19 @@ The default values are `localhost`, `root`, no password, `3306`, and `utf8`.
 You only need to set the values that differ from the defaults.
 
 
+### CLI Tests
+
+Some CLI tests expect the program `ex` to be a symbolic link to `vim`.
+
+In some systems (e.g. Archlinux) `ex` is a symbolic link to `vi`, which will
+change the output and therefore make some tests fail.
+
+You can check this by running:
+```bash
+$ readlink -f $(which ex)
+```
+
+
 ## Coding Style
 
 Mycli requires code submissions to adhere to

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Internal Changes:
 -----------------
 
 * Drop support for Python 3.3 (Thanks: [Thomas Roten]).
+* Make tests more compatible between different build environments. (Thanks: [David Caro])
 
 1.13.1:
 =======

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -64,11 +64,11 @@ wider_completion_menu = False
 # \s - Seconds of the current time
 # \t - Product type (Percona, MySQL, Mariadb)
 # \u - Username
-prompt = '\t \u@\h:\d> '
+prompt = '\u@\h:\d> '
 prompt_continuation = '-> '
 
 # Skip intro info on startup and outro info on exit
-less_chatty = False
+less_chatty = True
 
 # Use alias from --login-path instead of host name in prompt
 login_path_as_host = False

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -64,11 +64,11 @@ wider_completion_menu = False
 # \s - Seconds of the current time
 # \t - Product type (Percona, MySQL, Mariadb)
 # \u - Username
-prompt = '\u@\h:\d> '
+prompt = '\t \u@\h:\d> '
 prompt_continuation = '-> '
 
 # Skip intro info on startup and outro info on exit
-less_chatty = True
+less_chatty = False
 
 # Use alias from --login-path instead of host name in prompt
 login_path_as_host = False

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -18,6 +18,7 @@ def before_all(context):
     os.environ['LINES'] = "100"
     os.environ['COLUMNS'] = "100"
     os.environ['EDITOR'] = 'ex'
+    os.environ['LC_ALL'] = 'en_US.utf8'
 
     test_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
     login_path_file = os.path.join(test_dir, 'mylogin.cnf')
@@ -112,7 +113,7 @@ def after_scenario(context, _):
             host = context.conf['host']
             dbname = context.currentdb
             context.cli.expect_exact(
-                'mysql {0}@{1}:{2}> '.format(
+                '{0}@{1}:{2}> '.format(
                     user, host, dbname
                 ),
                 timeout=5

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -70,7 +70,7 @@ def before_all(context):
                 context.conf['pager_boundary'])
         )
     context.conf['defaults-file'] = my_cnf
-    context.conf['myclirc'] = os.path.join(context.package_root, 'mycli',
+    context.conf['myclirc'] = os.path.join(context.package_root, 'test',
                                            'myclirc')
 
     context.cn = dbutils.create_db(context.conf['host'], context.conf['user'],

--- a/test/features/steps/crud_database.py
+++ b/test/features/steps/crud_database.py
@@ -70,7 +70,7 @@ def step_see_prompt(context):
     user = context.conf['user']
     host = context.conf['host']
     dbname = context.currentdb
-    wrappers.expect_exact(context, 'mysql {0}@{1}:{2}> '.format(
+    wrappers.expect_exact(context, '{0}@{1}:{2}> '.format(
         user, host, dbname), timeout=5)
     context.atprompt = True
 
@@ -102,7 +102,7 @@ def step_see_db_dropped_no_default(context):
     context.currentdb = None
 
     wrappers.expect_exact(context, 'Query OK, 0 rows affected', timeout=2)
-    wrappers.expect_exact(context, 'mysql {0}@{1}:{2}> '.format(
+    wrappers.expect_exact(context, '{0}@{1}:{2}> '.format(
         user, host, database), timeout=5)
 
     context.atprompt = True

--- a/test/myclirc
+++ b/test/myclirc
@@ -1,0 +1,12 @@
+# vi: ft=dosini
+
+# This file is loaded after mycli/myclirc and should override only those
+# variables needed for testing.
+# To see what every variable does see mycli/myclirc
+
+[main]
+
+log_file = ~/.mycli.test.log
+log_level = DEBUG
+prompt = '\u@\h:\d> '
+less_chatty = True

--- a/test/myclirc
+++ b/test/myclirc
@@ -8,5 +8,5 @@
 
 log_file = ~/.mycli.test.log
 log_level = DEBUG
-prompt = '\u@\h:\d> '
+prompt = '\t \u@\h:\d> '
 less_chatty = True

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -17,7 +17,7 @@ except NameError:
 
 test_dir = os.path.abspath(os.path.dirname(__file__))
 project_dir = os.path.dirname(test_dir)
-default_config_file = os.path.join(project_dir, 'mycli', 'myclirc')
+default_config_file = os.path.join(project_dir, 'test', 'myclirc')
 login_path_file = os.path.join(test_dir, 'mylogin.cnf')
 
 os.environ['MYSQL_TEST_LOGIN_FILE'] = login_path_file


### PR DESCRIPTION
## Description

Some changes to make the tests work in different build environments.

Changes included:
* Tests doesn't expect the "chatty" prompt, so it's removed from the
  default config file.
* Omit the database engine name in the prompt to make them compatible
  with MariaDB.
* Force locale to en_US.utf8, as expected by the tests.
* Add a note in CONTRIBUTING.md with information about the `ex` command.

Also includes pep8 fixes in test/features/steps/wrappers.py


## Checklist
- [X] I've added this contribution to the `changelog.md`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).


## Notes

I made those changes after some frustrating tries to make all the tests pass in my machine (Archlinux).

Some of them are opinianted (like the removing of the database engine from the prompt) so it's open to discussion.