### PR TITLE
Default to unix socket connection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features:
 ---------
 
 * Add `watch [seconds] query` command to repeat a query every [seconds] seconds (by default 5). (Thanks: [David Caro](https://github.com/Terseus))
+* Default to unix socket connection if host and port are unspecified. This simplifies authentication on some systems and matches mysql behaviour.
 
 Internal Changes:
 -----------------

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -53,6 +53,7 @@ Contributors:
   * Ryan Smith
   * Klaus Wünschel
   * François Pietka
+  * Colin Caine
 
 Creator:
 --------


### PR DESCRIPTION


## Description

Default to unix socket connection if host and port are unspecified.

 - Local users can be identified by UID without passwords
 - Matches mysql behaviour


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
