### PR TITLE
Unicode output to click for Python 2.7

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Features:
 Internal Changes:
 -----------------
 
+* Unicode output to click for Python 2.7 (Thanks: [Dick Marinus]).
 * Drop support for Python 3.3 (Thanks: [Thomas Roten]).
 
 1.13.1:

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -294,7 +294,7 @@ def no_tee(arg, **_):
 def write_tee(output):
     global tee_file
     if tee_file:
-        click.echo(output, file=tee_file, nl=False)
+        click.echo(u'%s' % output, file=tee_file, nl=False)
         click.echo(u'\n', file=tee_file, nl=False)
         tee_file.flush()
 


### PR DESCRIPTION
## Description
Unicode output to click for Python 2.7 (fixes failing behave tests in master)

I'm not sure if this is the right way for Python 2/3 compatibility

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
