### PR TITLE
[refs #518] add support for positional arguments for favorite queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A command line client for MySQL that can do auto-completion and syntax highlighting.
 
-HomePage: [http://mycli.net](http://mycli.net)  
+HomePage: [http://mycli.net](http://mycli.net)
 Documentation: [http://mycli.net/docs](http://mycli.net/docs)
 
 ![Completion](screenshots/tables.png)
@@ -96,11 +96,8 @@ Features
     - `SELECT * FROM <tab>` will only show table names.
     - `SELECT * FROM users WHERE <tab>` will only show column names.
 * Support for multiline queries.
-* Favorite queries. Save a query using `\fs alias query` and execute it with `\f alias` whenever you need.
-    - Also supports optional positional parameters of the form `$N` in the query
-    - Arguments are given after the name, with shell word and quoting rules
-    - `\fs user_by_name select * from users where name = '$1'`
-    - `\f user_by_name "Skelly McDermott"`
+* Favorite queries with optional positional parameters. Save a query using
+  `\fs alias query` and execute it with `\f alias` whenever you need.
 * Timing of sql statments and table rendering.
 * Config file is automatically created at ``~/.myclirc`` at first launch.
 * Log every query and its results to a file (disabled by default).

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ Features
     - `SELECT * FROM users WHERE <tab>` will only show column names.
 * Support for multiline queries.
 * Favorite queries. Save a query using `\fs alias query` and execute it with `\f alias` whenever you need.
+    - Also supports optional positional parameters of the form `$N` in the query
+    - Arguments are given after the name, with shell word and quoting rules
+    - `\fs user_by_name select * from users where name = '$1'`
+    - `\f user_by_name "Skelly McDermott"`
 * Timing of sql statments and table rendering.
 * Config file is automatically created at ``~/.myclirc`` at first launch.
 * Log every query and its results to a file (disabled by default).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A command line client for MySQL that can do auto-completion and syntax highlighting.
 
-HomePage: [http://mycli.net](http://mycli.net)
+HomePage: [http://mycli.net](http://mycli.net)  
 Documentation: [http://mycli.net/docs](http://mycli.net/docs)
 
 ![Completion](screenshots/tables.png)

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Features:
 ---------
 
 * Add `watch [seconds] query` command to repeat a query every [seconds] seconds (by default 5). (Thanks: [David Caro](https://github.com/Terseus))
+* Add support for positional parameters to favorite queries
 
 Internal Changes:
 -----------------

--- a/test/features/fixture_data/help_commands.txt
+++ b/test/features/fixture_data/help_commands.txt
@@ -4,7 +4,7 @@
 | \G          | \G                         | Display current query results vertically.                  |
 | \dt         | \dt[+] [table]             | List or describe tables.                                   |
 | \e          | \e                         | Edit command with editor (uses $EDITOR).                   |
-| \f          | \f [name]                  | List or execute favorite queries.                          |
+| \f          | \f [name [args..]]         | List or execute favorite queries.                          |
 | \fd         | \fd [name]                 | Delete a favorite query.                                   |
 | \fs         | \fs name query             | Save a favorite query.                                     |
 | \l          | \l                         | List databases.                                            |

--- a/test/features/named_queries.feature
+++ b/test/features/named_queries.feature
@@ -6,5 +6,19 @@ Feature: named queries:
       then we see database connected
       when we save a named query
       then we see the named query saved
+      when we use a named query
+      then we see the named query executed
       when we delete a named query
       then we see the named query deleted
+
+  Scenario: save, use and delete named queries with parameters
+     When we connect to test database
+      then we see database connected
+      when we save a named query with parameters
+      then we see the named query saved
+      when we use named query with parameters
+      then we see the named query with parameters executed
+      when we use named query with too few parameters
+      then we see the named query with parameters fail with missing parameters
+      when we use named query with too many parameters
+      then we see the named query with parameters fail with extra parameters

--- a/test/features/steps/named_queries.py
+++ b/test/features/steps/named_queries.py
@@ -13,19 +13,19 @@ from behave import when, then
 
 @when('we save a named query')
 def step_save_named_query(context):
-    """Send \ns command."""
+    """Send \fs command."""
     context.cli.sendline('\\fs foo SELECT 12345')
 
 
 @when('we use a named query')
 def step_use_named_query(context):
-    """Send \n command."""
+    """Send \f command."""
     context.cli.sendline('\\f foo')
 
 
 @when('we delete a named query')
 def step_delete_named_query(context):
-    """Send \nd command."""
+    """Send \fd command."""
     context.cli.sendline('\\fd foo')
 
 
@@ -38,11 +38,52 @@ def step_see_named_query_saved(context):
 @then('we see the named query executed')
 def step_see_named_query_executed(context):
     """Wait to see select output."""
-    wrappers.expect_exact(context, '12345', timeout=1)
-    wrappers.expect_exact(context, 'SELECT 1', timeout=1)
+    wrappers.expect_exact(context, 'SELECT 12345', timeout=1)
 
 
 @then('we see the named query deleted')
 def step_see_named_query_deleted(context):
     """Wait to see query deleted."""
     wrappers.expect_exact(context, 'foo: Deleted', timeout=1)
+
+
+@when('we save a named query with parameters')
+def step_save_named_query_with_parameters(context):
+    """Send \fs command for query with parameters."""
+    context.cli.sendline('\\fs foo_args SELECT $1, "$2", "$3"')
+
+
+@when('we use named query with parameters')
+def step_use_named_query_with_parameters(context):
+    """Send \f command with parameters."""
+    context.cli.sendline('\\f foo_args 101 second "third value"')
+
+
+@then('we see the named query with parameters executed')
+def step_see_named_query_with_parameters_executed(context):
+    """Wait to see select output."""
+    wrappers.expect_exact(context, 'SELECT 101, "second", "third value"', timeout=1)
+
+
+@when('we use named query with too few parameters')
+def step_use_named_query_with_too_few_parameters(context):
+    """Send \f command with missing parameters."""
+    context.cli.sendline('\\f foo_args 101')
+
+
+@then('we see the named query with parameters fail with missing parameters')
+def step_see_named_query_with_parameters_fail_with_missing_parameters(context):
+    """Wait to see select output."""
+    wrappers.expect_exact(context, 'missing substitution for $2 in query:', timeout=1)
+
+
+@when('we use named query with too many parameters')
+def step_use_named_query_with_too_many_parameters(context):
+    """Send \f command with extra parameters."""
+    context.cli.sendline('\\f foo_args 101 102 103 104')
+
+
+@then('we see the named query with parameters fail with extra parameters')
+def step_see_named_query_with_parameters_fail_with_extra_parameters(context):
+    """Wait to see select output."""
+    wrappers.expect_exact(context, 'query does not have substitution parameter $4:', timeout=1)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Add support for positional parameters in favorite queries.

Variables are referenced by positional number similar to shell variables.  Example:

`\fs user_by_name select * from users where name = '$1'`

Values are passed at invocation by position, with shell word and quoting rules.  Example:

`\f user_by_name "Skelly McDermott"`

Errors are presented if too few or too many arguments are given.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
