### PR TITLE
Bump cli_helpers version to 1.0.1.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requirements = [
     'sqlparse>=0.2.2,<0.3.0',
     'configobj >= 5.0.5',
     'cryptography >= 1.0.0',
-    'cli_helpers[styles] >= 0.2.3',
+    'cli_helpers[styles] >= 1.0.1',
 ]
 
 setup(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
CLI Helpers 1.0.1 fixes a Python 2.7 bug.
