### PR TITLE
Add sql-update/insert output format

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+TBD
+=======
+
+Features:
+---------
+
+* Add sql-update/insert output format. (Thanks: [Dick Marinus]).
+
 1.14.0:
 =======
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -31,6 +31,7 @@ from pygments.token import Token
 
 from .packages.special.main import NO_QUERY
 from .packages.prompt_utils import confirm_destructive_query
+from .packages.tabular_output import sql_format
 import mycli.packages.special as special
 from .sqlcompleter import SQLCompleter
 from .clitoolbar import create_toolbar_tokens_func
@@ -110,6 +111,8 @@ class MyCli(object):
         special.set_timing_enabled(c['main'].as_bool('timing'))
         self.formatter = TabularOutputFormatter(
             format_name=c['main']['table_format'])
+        sql_format.register_new_formatter(self.formatter)
+        self.formatter.mycli = self
         self.syntax_style = c['main']['syntax_style']
         self.less_chatty = c['main'].as_bool('less_chatty')
         self.cli_style = c['colors']
@@ -547,6 +550,7 @@ class MyCli(object):
                 successful = False
                 start = time()
                 res = sqlexecute.run(document.text)
+                self.formatter.query = document.text
                 successful = True
                 result_count = 0
                 for title, cur, headers, status in res:
@@ -850,6 +854,7 @@ class MyCli(object):
         results = self.sqlexecute.run(query)
         for result in results:
             title, cur, headers, status = result
+            self.formatter.query = query
             output = self.format_output(title, cur, headers)
             for line in output:
                 click.echo(line, nl=new_line)

--- a/mycli/packages/tabular_output/sql_format.py
+++ b/mycli/packages/tabular_output/sql_format.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""Format adapter for sql."""
+
+from cli_helpers.utils import filter_dict_by_key
+from mycli.packages.parseutils import extract_tables
+
+supported_formats = ('sql-insert', 'sql-update', 'sql-update-1',
+                     'sql-update-2', )
+
+preprocessors = ()
+
+
+def adapter(data, headers, table_format=None, **kwargs):
+    tables = extract_tables(formatter.query)
+    if len(tables) > 0:
+        table = tables[0]
+        if table[0]:
+            table_name = "{}.{}".format(*table[:2])
+        else:
+            table_name = table[1]
+    else:
+        table_name = "`DUAL`"
+    escape = formatter.mycli.sqlexecute.conn.escape
+    if table_format == 'sql-insert':
+        h = "`, `".join(headers)
+        yield "INSERT INTO {} (`{}`) VALUES".format(table_name, h)
+        prefix = "  "
+        for d in data:
+            values = ", ".join(escape(v) for i, v in enumerate(d))
+            yield "{}({})".format(prefix, values)
+            if prefix == "  ":
+                prefix = ", "
+        yield ";"
+    if table_format.startswith('sql-update'):
+        s = table_format.split('-')
+        keys = 1
+        if len(s) > 2:
+            keys = int(s[-1])
+        for d in data:
+            yield "UPDATE {} SET".format(table_name)
+            prefix = "  "
+            for i, v in enumerate(d[keys:], keys):
+                yield "{}`{}` = {}".format(prefix, headers[i], escape(v))
+                if prefix == "  ":
+                    prefix = ", "
+            f = "`{}` = {}"
+            where = (f.format(headers[i], escape(d[i])) for i in range(keys))
+            yield "WHERE {};".format(" AND ".join(where))
+
+
+def register_new_formatter(TabularOutputFormatter):
+    global formatter
+    formatter = TabularOutputFormatter
+    for sql_format in supported_formats:
+        TabularOutputFormatter.register_new_formatter(
+            sql_format, adapter, preprocessors, {'table_format': sql_format})

--- a/test/test_tabular_output.py
+++ b/test/test_tabular_output.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""Test the sql output adapter."""
+
+from __future__ import unicode_literals
+from textwrap import dedent
+
+from mycli.packages.tabular_output import sql_format
+from cli_helpers.tabular_output import TabularOutputFormatter
+
+from utils import USER, PASSWORD, HOST, PORT
+
+import pytest
+import mycli.main
+
+
+@pytest.fixture
+def formatter():
+    formatter = TabularOutputFormatter(format_name='psql')
+    formatter.query = ""
+    formatter.mycli = mycli.main.MyCli()
+    formatter.mycli.connect(None, USER, PASSWORD, HOST, PORT, None)
+    return formatter
+
+
+def test_sql_output(formatter):
+    """Test the sql output adapter."""
+    sql_format.register_new_formatter(formatter)
+    headers = ['letters', 'number', 'optional']
+    data = [['abc', 1, None], ['d', 456, '1']]
+    column_types = [str, int, str]
+    # Test sql-update output format
+    output = formatter.format_output(
+        iter(data), headers, format_name='sql-update',
+        column_types=column_types
+    )
+    assert "\n".join(output) == dedent('''\
+            UPDATE `DUAL` SET
+              `number` = 1
+            , `optional` = NULL
+            WHERE `letters` = 'abc';
+            UPDATE `DUAL` SET
+              `number` = 456
+            , `optional` = '1'
+            WHERE `letters` = 'd';''')
+    # Test sql-update-2 output format
+    output = formatter.format_output(
+        iter(data), headers, format_name='sql-update-2',
+        column_types=column_types
+    )
+    assert "\n".join(output) == dedent('''\
+            UPDATE `DUAL` SET
+              `optional` = NULL
+            WHERE `letters` = 'abc' AND `number` = 1;
+            UPDATE `DUAL` SET
+              `optional` = '1'
+            WHERE `letters` = 'd' AND `number` = 456;''')
+    # Test sql-insert output format (without table name)
+    output = formatter.format_output(
+        iter(data), headers, format_name='sql-insert',
+        column_types=column_types
+    )
+    assert "\n".join(output) == dedent('''\
+            INSERT INTO `DUAL` (`letters`, `number`, `optional`) VALUES
+              ('abc', 1, NULL)
+            , ('d', 456, '1')
+            ;''')
+    # Test sql-insert output format (with table name)
+    formatter.query = "SELECT * FROM `table`"
+    output = formatter.format_output(
+        iter(data), headers, format_name='sql-insert',
+        column_types=column_types
+    )
+    assert "\n".join(output) == dedent('''\
+            INSERT INTO `table` (`letters`, `number`, `optional`) VALUES
+              ('abc', 1, NULL)
+            , ('d', 456, '1')
+            ;''')
+    # Test sql-insert output format (with database + table name)
+    formatter.query = "SELECT * FROM `database`.`table`"
+    output = formatter.format_output(
+        iter(data), headers, format_name='sql-insert',
+        column_types=column_types
+    )
+    assert "\n".join(output) == dedent('''\
+            INSERT INTO `database`.`table` (`letters`, `number`, `optional`) VALUES
+              ('abc', 1, NULL)
+            , ('d', 456, '1')
+            ;''')


### PR DESCRIPTION
## Description
New output formats sql-update and sql-insert.
TODO:
- [x] handle NULL
- [x] support composite primary keys (multiple columsn in WHERE) for sql-update

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
