### PR TITLE
Also complete aliases in WHERE

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+TBD
+=======
+
+Features:
+---------
+
+* Also complete aliases in WHERE. (Thanks: [Dick Marinus]).
+
 1.14.0:
 =======
 

--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -226,7 +226,7 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
                     {'type': 'view', 'schema': parent},
                     {'type': 'function', 'schema': parent}]
         else:
-            aliases = [t[2] or t[1] for t in tables]
+            aliases = [alias or table for (schema, table, alias) in tables]
             return [{'type': 'column', 'tables': tables},
                     {'type': 'function', 'schema': []},
                     {'type': 'alias', 'aliases': aliases},
@@ -272,7 +272,7 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
         else:
             # ON <suggestion>
             # Use table alias if there is one, otherwise the table name
-            aliases = [t[2] or t[1] for t in tables]
+            aliases = [alias or table for (schema, table, alias) in tables]
             suggest = [{'type': 'alias', 'aliases': aliases}]
 
             # The lists of 'aliases' could be empty if we're trying to complete

--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -218,16 +218,18 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
         # Check for a table alias or schema qualification
         parent = (identifier and identifier.get_parent_name()) or []
 
+        tables = extract_tables(full_text)
         if parent:
-            tables = extract_tables(full_text)
             tables = [t for t in tables if identifies(parent, *t)]
             return [{'type': 'column', 'tables': tables},
                     {'type': 'table', 'schema': parent},
                     {'type': 'view', 'schema': parent},
                     {'type': 'function', 'schema': parent}]
         else:
-            return [{'type': 'column', 'tables': extract_tables(full_text)},
+            aliases = [t[2] or t[1] for t in tables]
+            return [{'type': 'column', 'tables': tables},
                     {'type': 'function', 'schema': []},
+                    {'type': 'alias', 'aliases': aliases},
                     {'type': 'keyword'}]
     elif (token_v.endswith('join') and token.is_keyword) or (token_v in
             ('copy', 'from', 'update', 'into', 'describe', 'truncate',

--- a/test/test_completion_engine.py
+++ b/test/test_completion_engine.py
@@ -11,6 +11,7 @@ def sorted_dicts(dicts):
 def test_select_suggests_cols_with_visible_table_scope():
     suggestions = suggest_type('SELECT  FROM tabl', 'SELECT ')
     assert sorted_dicts(suggestions) == sorted_dicts([
+        {'type': 'alias', 'aliases': ['tabl']},
         {'type': 'column', 'tables': [(None, 'tabl', None)]},
         {'type': 'function', 'schema': []},
         {'type': 'keyword'},
@@ -20,6 +21,7 @@ def test_select_suggests_cols_with_visible_table_scope():
 def test_select_suggests_cols_with_qualified_table_scope():
     suggestions = suggest_type('SELECT  FROM sch.tabl', 'SELECT ')
     assert sorted_dicts(suggestions) == sorted_dicts([
+        {'type': 'alias', 'aliases': ['tabl']},
         {'type': 'column', 'tables': [('sch', 'tabl', None)]},
         {'type': 'function', 'schema': []},
         {'type': 'keyword'},
@@ -41,6 +43,7 @@ def test_select_suggests_cols_with_qualified_table_scope():
 def test_where_suggests_columns_functions(expression):
     suggestions = suggest_type(expression, expression)
     assert sorted_dicts(suggestions) == sorted_dicts([
+        {'type': 'alias', 'aliases': ['tabl']},
         {'type': 'column', 'tables': [(None, 'tabl', None)]},
         {'type': 'function', 'schema': []},
         {'type': 'keyword'},
@@ -54,6 +57,7 @@ def test_where_suggests_columns_functions(expression):
 def test_where_in_suggests_columns(expression):
     suggestions = suggest_type(expression, expression)
     assert sorted_dicts(suggestions) == sorted_dicts([
+        {'type': 'alias', 'aliases': ['tabl']},
         {'type': 'column', 'tables': [(None, 'tabl', None)]},
         {'type': 'function', 'schema': []},
         {'type': 'keyword'},
@@ -64,6 +68,7 @@ def test_where_equals_any_suggests_columns_or_keywords():
     text = 'SELECT * FROM tabl WHERE foo = ANY('
     suggestions = suggest_type(text, text)
     assert sorted_dicts(suggestions) == sorted_dicts([
+        {'type': 'alias', 'aliases': ['tabl']},
         {'type': 'column', 'tables': [(None, 'tabl', None)]},
         {'type': 'function', 'schema': []},
         {'type': 'keyword'}])
@@ -92,6 +97,7 @@ def test_operand_inside_function_suggests_cols2():
 def test_select_suggests_cols_and_funcs():
     suggestions = suggest_type('SELECT ', 'SELECT ')
     assert sorted_dicts(suggestions) == sorted_dicts([
+        {'type': 'alias', 'aliases': []},
         {'type': 'column', 'tables': []},
         {'type': 'function', 'schema': []},
         {'type': 'keyword'},
@@ -154,6 +160,7 @@ def test_distinct_suggests_cols():
 def test_col_comma_suggests_cols():
     suggestions = suggest_type('SELECT a, b, FROM tbl', 'SELECT a, b,')
     assert sorted_dicts(suggestions) == sorted_dicts([
+        {'type': 'alias', 'aliases': ['tbl']},
         {'type': 'column', 'tables': [(None, 'tbl', None)]},
         {'type': 'function', 'schema': []},
         {'type': 'keyword'},
@@ -196,6 +203,7 @@ def test_partially_typed_col_name_suggests_col_names():
     suggestions = suggest_type('SELECT * FROM tabl WHERE col_n',
                                'SELECT * FROM tabl WHERE col_n')
     assert sorted_dicts(suggestions) == sorted_dicts([
+        {'type': 'alias', 'aliases': ['tabl']},
         {'type': 'column', 'tables': [(None, 'tabl', None)]},
         {'type': 'function', 'schema': []},
         {'type': 'keyword'},
@@ -279,6 +287,7 @@ def test_sub_select_col_name_completion():
     suggestions = suggest_type('SELECT * FROM (SELECT  FROM abc',
                                'SELECT * FROM (SELECT ')
     assert sorted_dicts(suggestions) == sorted_dicts([
+        {'type': 'alias', 'aliases': ['abc']},
         {'type': 'column', 'tables': [(None, 'abc', None)]},
         {'type': 'function', 'schema': []},
         {'type': 'keyword'},
@@ -397,6 +406,7 @@ def test_2_statements_2nd_current():
     suggestions = suggest_type('select * from a; select  from b',
                                'select * from a; select ')
     assert sorted_dicts(suggestions) == sorted_dicts([
+        {'type': 'alias', 'aliases': ['b']},
         {'type': 'column', 'tables': [(None, 'b', None)]},
         {'type': 'function', 'schema': []},
         {'type': 'keyword'},
@@ -422,6 +432,7 @@ def test_2_statements_1st_current():
     suggestions = suggest_type('select  from a; select * from b',
                                'select ')
     assert sorted_dicts(suggestions) == sorted_dicts([
+        {'type': 'alias', 'aliases': ['a']},
         {'type': 'column', 'tables': [(None, 'a', None)]},
         {'type': 'function', 'schema': []},
         {'type': 'keyword'},
@@ -439,6 +450,7 @@ def test_3_statements_2nd_current():
     suggestions = suggest_type('select * from a; select  from b; select * from c',
                                'select * from a; select ')
     assert sorted_dicts(suggestions) == sorted_dicts([
+        {'type': 'alias', 'aliases': ['b']},
         {'type': 'column', 'tables': [(None, 'b', None)]},
         {'type': 'function', 'schema': []},
         {'type': 'keyword'},

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -93,6 +93,7 @@ def test_suggested_column_names(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
+        Completion(text='users', start_position=0),
         Completion(text='*', start_position=0),
         Completion(text='id', start_position=0),
         Completion(text='email', start_position=0),
@@ -181,6 +182,7 @@ def test_suggested_multiple_column_names(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
+        Completion(text='u', start_position=0),
         Completion(text='*', start_position=0),
         Completion(text='id', start_position=0),
         Completion(text='email', start_position=0),
@@ -301,6 +303,7 @@ def test_auto_escaped_col_names(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
+        Completion(text='`select`', start_position=0),
         Completion(text='*', start_position=0),
         Completion(text='id', start_position=0),
         Completion(text='`insert`', start_position=0),
@@ -316,6 +319,7 @@ def test_un_escaped_table_names(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
+        Completion(text='réveillé', start_position=0),
         Completion(text='*', start_position=0),
         Completion(text='id', start_position=0),
         Completion(text='`insert`', start_position=0),


### PR DESCRIPTION
## Description
Also complete aliases in WHERE.
This was a big annoyance for me. I often use JOIN's on tables which have common columns and these columns must be addressed by `tablename`.`column` or `aliasname`.`column`. With these changes the aliasses (and tablenames!) are suggested :tada:

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
