### PR TITLE
Fix MariaDB case in config file

### DIFF
--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -62,7 +62,7 @@ wider_completion_menu = False
 # \R - The current time, in 24-hour military time (0–23)
 # \r - The current time, standard 12-hour time (1–12)
 # \s - Seconds of the current time
-# \t - Product type (Percona, MySQL, Mariadb)
+# \t - Product type (Percona, MySQL, MariaDB)
 # \u - Username
 prompt = '\t \u@\h:\d> '
 prompt_continuation = '-> '


### PR DESCRIPTION
## Description
MariaDB was spelled "Mariadb" in config file



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
