### PR TITLE
Don't try to connect via a unix socket on windows

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ Features:
 
 * Add DSN aliases to the config file (Thanks: [Frederic Aoustin]).
 
+Bug Fixes:
+----------
+
+* Do not try to connect to a unix socket on Windows (Thanks: [Thomas Roten]).
+
 1.15.0:
 =======
 

--- a/mycli/compat.py
+++ b/mycli/compat.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+"""Platform and Python version compatibility support."""
+
+import sys
+
+
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+WIN = sys.platform in ('win32', 'cygwin')

--- a/mycli/encodingutils.py
+++ b/mycli/encodingutils.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import sys
+from mycli.compat import PY2, PY3
 
-PY2 = sys.version_info[0] == 2
-PY3 = sys.version_info[0] == 3
 
 if PY2:
     text_type = unicode

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -45,6 +45,7 @@ from .key_bindings import mycli_bindings
 from .encodingutils import utf8tounicode, text_type
 from .lexer import MyCliLexer
 from .__init__ import __version__
+from mycli.compat import WIN
 
 import itertools
 
@@ -397,7 +398,7 @@ class MyCli(object):
                     raise e
 
         try:
-            if socket is host is port is None:
+            if (socket is host is port is None) and not WIN:
                 # Try a sensible default socket first (simplifies auth)
                 # If we get a connection error, try tcp/ip localhost
                 try:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Prevents mycli from attempting to connect to a unix socket on Windows. See https://github.com/dbcli/mycli/pull/536 for more information.

This address the problem in https://github.com/dbcli/mycli/issues/554.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
