### PR TITLE
Catch click prompt/confirm abort exception

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,9 @@ TBD:
 
 Features:
 ----------
+
 * Add `CONCAT` to SQLCompleter and remove unused code (Thanks: [caitinggui])
+* Do not quit when aborting a confirmation prompt (Thanks: [Thomas Roten]).
 
 Bug Fixes:
 ----------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -30,7 +30,7 @@ from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from pygments.token import Token
 
 from .packages.special.main import NO_QUERY
-from .packages.prompt_utils import confirm_destructive_query
+from .packages.prompt_utils import confirm, confirm_destructive_query, prompt
 from .packages.tabular_output import sql_format
 import mycli.packages.special as special
 from .sqlcompleter import SQLCompleter
@@ -563,7 +563,7 @@ class MyCli(object):
                             cur and cur.rowcount > threshold):
                         self.echo('The result set has more than {} rows.'.format(
                             threshold), fg='red')
-                        if not click.confirm('Do you want to continue?'):
+                        if not confirm('Do you want to continue?'):
                             self.echo("Aborted!", err=True, fg='red')
                             break
 

--- a/mycli/packages/prompt_utils.py
+++ b/mycli/packages/prompt_utils.py
@@ -18,4 +18,20 @@ def confirm_destructive_query(queries):
     prompt_text = ("You're about to run a destructive command.\n"
                    "Do you want to proceed? (y/n)")
     if is_destructive(queries) and sys.stdin.isatty():
-        return click.prompt(prompt_text, type=bool)
+        return prompt(prompt_text, type=bool)
+
+
+def confirm(*args, **kwargs):
+    """Prompt for confirmation (yes/no) and handle any abort exceptions."""
+    try:
+        return click.confirm(*args, **kwargs)
+    except click.Abort:
+        return False
+
+
+def prompt(*args, **kwargs):
+    """Prompt the user for input and handle any abort exceptions."""
+    try:
+        return click.prompt(*args, **kwargs)
+    except click.Abort:
+        return False

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,6 @@ behave
 pexpect
 coverage==4.3.4
 codecov==2.0.9
-git+https://github.com/hayd/pep8radius.git@c8aebd0e1d272160896124e104773b97a6249c3e#egg=pep8radius
+autopep8==1.3.3
+pep8radius
 click==6.7


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
See https://github.com/dbcli/mycli/issues/517. Makes it so when you cancel a confirmation, mycli won't quit.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
