### PR TITLE
Output password prompt to stderr

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,8 @@ Bug Fixes:
 * Mark `test_sql_output` as a dbtest (Thanks: [Dick Marinus]).
 * Don't crash if the log/history file directories don't exist (Thanks: [Thomas Roten]).
 * Unquote dsn username and password (Thanks: [Dick Marinus]).
+* Output `Password:` prompt to stderr (Thanks: [ushuz]).
+
 
 1.16.0:
 =======

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -56,6 +56,7 @@ Contributors:
   * Colin Caine
   * Frederic Aoustin
   * caitinggui
+  * ushuz
 
 Creator:
 --------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -398,7 +398,7 @@ class MyCli(object):
             except OperationalError as e:
                 if ('Access denied for user' in e.args[1]):
                     new_passwd = click.prompt('Password', hide_input=True,
-                                              show_default=False, type=str)
+                                              show_default=False, type=str, err=True)
                     self.sqlexecute = SQLExecute(database, user, new_passwd, host, port,
                                                  socket, charset, local_infile, ssl)
                 else:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Output `Password:` prompt to stderr, so that `Password:` prompt won't end up in the result file when we redirect mycli output into a file, e.g. `mycli -h some-server-require-password -e 'xxx' > result.txt`

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
