### PR TITLE
Mark alter as a destructive query

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@ Bug Fixes:
 * Don't crash if the log/history file directories don't exist (Thanks: [Thomas Roten]).
 * Unquote dsn username and password (Thanks: [Dick Marinus]).
 * Output `Password:` prompt to stderr (Thanks: [ushuz]).
+* Mark `alter` as a destructive query (Thanks: [Dick Marinus]).
 
 
 1.16.0:

--- a/mycli/packages/parseutils.py
+++ b/mycli/packages/parseutils.py
@@ -205,7 +205,7 @@ def queries_start_with(queries, prefixes):
 
 def is_destructive(queries):
     """Returns if any of the queries in *queries* is destructive."""
-    keywords = ('drop', 'shutdown', 'delete', 'truncate')
+    keywords = ('drop', 'shutdown', 'delete', 'truncate', 'alter')
     return queries_start_with(queries, keywords)
 
 


### PR DESCRIPTION
## Description
Mark alter as a destructive query (fixes #594)

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).