### PR TITLE
fix thanks_picker

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ Bug Fixes:
 * Unquote dsn username and password (Thanks: [Dick Marinus]).
 * Output `Password:` prompt to stderr (Thanks: [ushuz]).
 * Mark `alter` as a destructive query (Thanks: [Dick Marinus]).
+* Fix `thanks_picker` (Thanks: [Dick Marinus]).
 
 Internal:
 ---------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -61,6 +61,7 @@ except ImportError:
 from pymysql import OperationalError
 
 from collections import namedtuple
+import re
 
 # Query tuples are used for maintaining history
 Query = namedtuple('Query', ['query', 'successful', 'mutating'])
@@ -1181,11 +1182,14 @@ def is_select(status):
 
 
 def thanks_picker(files=()):
+    contents = []
     for filename in files:
         with open(filename, encoding='utf-8') as f:
-            contents = f.readlines()
-
-    return choice([x.split('*')[1].strip() for x in contents if x.startswith('*')])
+            for line in f:
+                m = re.match('^ *\* (.*)', line)
+                if m:
+                    contents.append(m.group(1))
+    return choice(contents)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Fix thanks_picker, only the last file was used (contents was assigned instead of appended).
Besides this only lines which started with `*` were used, in `mycli/AUTHORS` all names start with double spaces.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
