### PR TITLE
Use unix CSV dialect.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ Bug Fixes:
 * Unquote dsn username and password (Thanks: [Dick Marinus]).
 * Output `Password:` prompt to stderr (Thanks: [ushuz]).
 * Mark `alter` as a destructive query (Thanks: [Dick Marinus]).
+* Quote CSV fields (Thanks: [Thomas Roten]).
 
 Internal:
 ---------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -882,6 +882,7 @@ class MyCli(object):
         output = []
 
         output_kwargs = {
+            'dialect': 'unix',
             'disable_numparse': True,
             'preserve_whitespace': True,
             'preprocessors': (preprocessors.align_decimals, ),

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -40,14 +40,14 @@ def test_execute_arg(executor):
     result = runner.invoke(cli, args=CLI_ARGS + ['-e', sql])
 
     assert result.exit_code == 0
-    assert 'abc' in result.output
+    assert '"abc"' in result.output
 
     result = runner.invoke(cli, args=CLI_ARGS + ['--execute', sql])
 
     assert result.exit_code == 0
-    assert 'abc' in result.output
+    assert '"abc"' in result.output
 
-    expected = 'a\nabc\n'
+    expected = '"a"\n"abc"\n'
 
     assert expected in result.output
 
@@ -74,7 +74,7 @@ def test_execute_arg_with_csv(executor):
     sql = 'select * from test;'
     runner = CliRunner()
     result = runner.invoke(cli, args=CLI_ARGS + ['-e', sql] + ['--csv'])
-    expected = 'a\nabc\n'
+    expected = '"a"\n"abc"\n'
 
     assert result.exit_code == 0
     assert expected in "".join(result.output)
@@ -94,7 +94,7 @@ def test_batch_mode(executor):
     result = runner.invoke(cli, args=CLI_ARGS, input=sql)
 
     assert result.exit_code == 0
-    assert 'count(*)\n3\na\nabc\n' in "".join(result.output)
+    assert '"count(*)"\n"3"\n"a"\n"abc"\n' in "".join(result.output)
 
 
 @dbtest
@@ -129,14 +129,15 @@ def test_batch_mode_table(executor):
 @dbtest
 def test_batch_mode_csv(executor):
     run(executor, '''create table test(a text, b text)''')
-    run(executor, '''insert into test (a, b) values('abc', 'def'), ('ghi', 'jkl')''')
+    run(executor,
+        '''insert into test (a, b) values('abc', 'de\nf'), ('ghi', 'jkl')''')
 
     sql = 'select * from test;'
 
     runner = CliRunner()
     result = runner.invoke(cli, args=CLI_ARGS + ['--csv'], input=sql)
 
-    expected = 'a,b\nabc,def\nghi,jkl\n'
+    expected = '"a","b"\n"abc","de\nf"\n"ghi","jkl"\n'
 
     assert result.exit_code == 0
     assert expected in "".join(result.output)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This uses the `unix` CSV dialect so we don't have to worry about breaking the CSV output with line terminators and delimiters since it quotes every field.

Addresses https://github.com/dbcli/mycli/issues/601


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
