### PR TITLE
Convert `sql_format` to unicode strings for py27 compatibility

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@ Features:
 
 * Display server version in welcome message (Thanks: [Irina Truong]).
 
+Bug Fixes:
+----------
+* Convert `sql_format` to unicode strings for py27 compatibility (Thanks: [Dick Marinus]).
+
 Internal:
 ---------
 

--- a/mycli/packages/tabular_output/sql_format.py
+++ b/mycli/packages/tabular_output/sql_format.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Format adapter for sql."""
 
+from __future__ import unicode_literals
 from cli_helpers.utils import filter_dict_by_key
 from mycli.packages.parseutils import extract_tables
 


### PR DESCRIPTION
## Description
Convert `sql_format` to unicode strings for py27 compatibility
Fix for https://github.com/dbcli/mycli/issues/631


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
