### PR TITLE
 Use `return` to terminate a generator

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Features:
 
 * Display server version in welcome message (Thanks: [Irina Truong]).
 * Set `program_name` connection attribute (Thanks: [Dick Marinus]).
+* Use `return` to terminate a generator (Thanks: [Zhongyang Guan]).
 
 Bug Fixes:
 ----------

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -58,6 +58,7 @@ Contributors:
   * caitinggui
   * ushuz
   * Zhaolong Zhu
+  * Zhongyang Guan
 
 Creator:
 --------

--- a/mycli/packages/parseutils.py
+++ b/mycli/packages/parseutils.py
@@ -80,7 +80,7 @@ def extract_from_part(parsed, stop_at_punctuation=True):
                 for x in extract_from_part(item, stop_at_punctuation):
                     yield x
             elif stop_at_punctuation and item.ttype is Punctuation:
-                raise StopIteration
+                return
             # An incomplete nested select won't be recognized correctly as a
             # sub-select. eg: 'SELECT * FROM (SELECT id FROM user'. This causes
             # the second FROM to trigger this elif condition resulting in a
@@ -92,7 +92,7 @@ def extract_from_part(parsed, stop_at_punctuation=True):
             elif item.ttype is Keyword and (
                     not item.value.upper() == 'FROM') and (
                     not item.value.upper().endswith('JOIN')):
-                raise StopIteration
+                return
             else:
                 yield item
         elif ((item.ttype is Keyword or item.ttype is Keyword.DML) and

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -374,7 +374,7 @@ def watch_query(arg, **kwargs):
 """
     if not arg:
         yield (None, None, None, usage)
-        raise StopIteration
+        return
     seconds = 5
     clear_screen = False
     statement = None
@@ -383,7 +383,7 @@ def watch_query(arg, **kwargs):
         if not arg:
             # Oops, we parsed all the arguments without finding a statement
             yield (None, None, None, usage)
-            raise StopIteration
+            return
         (current_arg, _, arg) = arg.partition(' ')
         try:
             seconds = float(current_arg)
@@ -397,7 +397,7 @@ def watch_query(arg, **kwargs):
     destructive_prompt = confirm_destructive_query(statement)
     if destructive_prompt is False:
         click.secho("Wise choice!")
-        raise StopIteration
+        return
     elif destructive_prompt is True:
         click.secho("Your call!")
     cur = kwargs['cur']
@@ -425,6 +425,6 @@ def watch_query(arg, **kwargs):
             # This prints the Ctrl-C character in its own line, which prevents
             # to print a line with the cursor positioned behind the prompt
             click.secho("", nl=True)
-            raise StopIteration
+            return
         finally:
             set_pager_enabled(old_pager_enabled)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -169,7 +169,7 @@ def test_command_descriptions_end_with_periods():
 def output(monkeypatch, terminal_size, testdata, explicit_pager, expect_pager):
     global clickoutput
     clickoutput = ""
-    m = MyCli()
+    m = MyCli(myclirc=default_config_file)
 
     class TestOutput():
         def get_size(self):

--- a/test/test_sqlexecute.py
+++ b/test/test_sqlexecute.py
@@ -202,14 +202,15 @@ def test_system_command_not_found(executor):
 
 @dbtest
 def test_system_command_output(executor):
-    test_file_path = os.path.join(os.path.abspath('.'), 'test', 'test.txt')
+    test_dir = os.path.abspath(os.path.dirname(__file__))
+    test_file_path = os.path.join(test_dir, 'test.txt')
     results = run(executor, 'system cat {0}'.format(test_file_path))
     assert_result_equal(results, status='mycli rocks!\n')
 
 
 @dbtest
 def test_cd_command_current_dir(executor):
-    test_path = os.path.join(os.path.abspath('.'), 'test')
+    test_path = os.path.abspath(os.path.dirname(__file__))
     run(executor, 'system cd {0}'.format(test_path))
     assert os.getcwd() == test_path
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

According to [PEP479](https://www.python.org/dev/peps/pep-0479) (which has been enabled for all code in Python 3.7), `return` is the proper way to terminate a generator. This PR addresses the proposal and should fix #619. However, since Python 3.7 isn't officially supported by Travis CI, the PR hasn't been fully tested.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
