### PR TITLE
Enable Python 3.7 tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ python:
   - "3.5"
   - "3.6"
 
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
+
 install:
   - pip install -r requirements-dev.txt
   - pip install -e .

--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@ Internal:
 ---------
 
 * Use fileinput (Thanks: [Dick Marinus]).
+* Enable tests for Python 3.7 (Thanks: [Thomas Roten]).
 
 1.17.0:
 =======

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py27, py34, py35, py36, py37
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

This enables Python 3.7 tests in Travis (through a short workaround). It also enables them for tox.



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
