### PR TITLE
remove *.swp from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 .vagrant
 *.pyc
 *.deb
-*.swp
 .cache/
 .coverage
 .coverage.*

--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,7 @@ Internal:
 
 * Use fileinput (Thanks: [Dick Marinus]).
 * Enable tests for Python 3.7 (Thanks: [Thomas Roten]).
+* Remove `*.swp` from gitignore (Thanks: [Dick Marinus]).
 
 1.17.0:
 =======


### PR DESCRIPTION
## Description
remove `*.swp` from gitignore.

Vim uses `.swp` files as a file lock / temporary file when a file is opened, for me it's a good reminder when doing `git status` that I still have files open.

I've tried adding stuff to `.git/info/exclude` but I cannot find anything to override this in `.gitignore`. I don't know any other trick to get some alarm when files are still open in vim when juggling with git. (I'm open for suggestions here). I hope this can be merged and people will add this to their `.git/info/exclude` file when they think they need this.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
