### PR TITLE
DSN without password

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ Bug Fixes:
 ----------
 
 * When DSN is used allow overrides from mycli arguments (Thanks: [Dick Marinus]).
+* A DSN without password should be allowed (Thanks: [Dick Marinus])
 
 Bug Fixes:
 ----------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1074,7 +1074,7 @@ def cli(database, user, host, port, socket, password, dbname,
             database = uri.path[1:]  # ignore the leading fwd slash
         if not user:
             user = unquote(uri.username)
-        if not password:
+        if not password and uri.password is not None:
             password = unquote(uri.password)
         if not host:
             host = uri.hostname

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -386,3 +386,15 @@ def test_dsn(monkeypatch):
         MockMyCli.connect_args["host"] == "arg_host" and \
         MockMyCli.connect_args["port"] == 5 and \
         MockMyCli.connect_args["database"] == "arg_database"
+
+    # Use a DNS without password
+    result = runner.invoke(mycli.main.cli, args=[
+        "mysql://dsn_user@dsn_host:6/dsn_database"]
+    )
+    assert result.exit_code == 0, result.output + " " + str(result.exception)
+    assert \
+        MockMyCli.connect_args["user"] == "dsn_user" and \
+        MockMyCli.connect_args["passwd"] is None and \
+        MockMyCli.connect_args["host"] == "dsn_host" and \
+        MockMyCli.connect_args["port"] == 6 and \
+        MockMyCli.connect_args["database"] == "dsn_database"


### PR DESCRIPTION
## Description
it should be allowed to omit the password from a DSN



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
