### PR TITLE
Fix warnings for running tests on Python 3.7

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Internal:
 ---------
 
 * Update Twine version to 1.12.1 (Thanks: [Thomas Roten]).
+* Fix warnings for running tests on Python 3.7 (Thanks: [Dick Marinus]).
 
 1.18.1
 ======

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -92,19 +92,19 @@ def test_favorite_query():
 
 def test_once_command():
     with pytest.raises(TypeError):
-        mycli.packages.special.execute(None, u"\once")
+        mycli.packages.special.execute(None, u"\\once")
 
-    mycli.packages.special.execute(None, u"\once /proc/access-denied")
+    mycli.packages.special.execute(None, u"\\once /proc/access-denied")
     with pytest.raises(OSError):
         mycli.packages.special.write_once(u"hello world")
 
     mycli.packages.special.write_once(u"hello world")  # write without file set
     with tempfile.NamedTemporaryFile() as f:
-        mycli.packages.special.execute(None, u"\once " + f.name)
+        mycli.packages.special.execute(None, u"\\once " + f.name)
         mycli.packages.special.write_once(u"hello world")
         assert f.read() == b"hello world\n"
 
-        mycli.packages.special.execute(None, u"\once -o " + f.name)
+        mycli.packages.special.execute(None, u"\\once -o " + f.name)
         mycli.packages.special.write_once(u"hello world")
         f.seek(0)
         assert f.read() == b"hello world\n"


### PR DESCRIPTION
## Description
Fix warnings for running tests on Python 3.7


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
