### PR TITLE
Add Token.Prompt/Continuation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@ Internal:
 * Add Python 3.7 trove classifier (Thanks: [Thomas Roten]).
 * Fix pytest in Fedora mock (Thanks: [Dick Marinus]).
 
+
+Features:
+---------
+
+* Add Token.Prompt/Continuation (Thanks: [Dick Marinus]).
+
 1.18.2
 ======
 

--- a/mycli/clistyle.py
+++ b/mycli/clistyle.py
@@ -36,6 +36,8 @@ TOKEN_TO_PROMPT_STYLE = {
     Token.Output.Header: 'output.header',
     Token.Output.OddRow: 'output.odd-row',
     Token.Output.EvenRow: 'output.even-row',
+    Token.Prompt: 'prompt',
+    Token.Continuation: 'continuation',
 }
 
 # reverse dict for cli_helpers, because they still expect Pygments tokens.


### PR DESCRIPTION
## Description

@mikedfunk
> Cool, is there a style string for the prompt so I can color it? I really like having some contrast in my command prompts so I can easily identify them.

With this PR you can use Token.Prompt and Token.Continuation to color the promps.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
