### PR TITLE
Enable suspend using C-Z.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,11 @@ Features:
 
 * Add Token.Prompt/Continuation (Thanks: [Dick Marinus]).
 * Don't reconnect when switching databases using use (Thanks: [Angelo Lupo]).
+* 
+Bug Fixes:
+----------
+
+* Enable Ctrl-Z to suspend the app (Thanks: [Amjith Ramanujam]).
 
 1.18.2
 ======
@@ -655,6 +660,7 @@ Bug Fixes:
 
 [Daniel West]: http://github.com/danieljwest
 [Irina Truong]: https://github.com/j-bennet
+[Amjith Ramanujam]: https://blog.amjith.com
 [Kacper Kwapisz]: https://github.com/KKKas
 [Martijn Engler]: https://github.com/martijnengler
 [Matheus Rosa]:  https://github.com/mdsrosa

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -730,6 +730,7 @@ class MyCli(object):
                 key_bindings=key_bindings,
                 enable_open_in_editor=True,
                 enable_system_prompt=True,
+                enable_suspend=True,
                 editing_mode=editing_mode,
                 search_ignore_case=True
             )


### PR DESCRIPTION
## Description
In the new version of prompt-toolkit C-Z was not suspending the app. It is now fixed. Addresses #688. 


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
