### PR TITLE
Make linter fail the build.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,5 +8,5 @@ pexpect
 coverage==4.3.4
 codecov==2.0.9
 autopep8==1.3.3
-pep8radius
+git+https://github.com/hayd/pep8radius.git  # --error-status option not released
 click==6.7

--- a/setup.py
+++ b/setup.py
@@ -33,20 +33,25 @@ class lint(Command):
 
     user_options = [
         ('branch=', 'b', 'branch/revision to compare against (e.g. master)'),
-        ('fix', 'f', 'fix the violations in place')
+        ('fix', 'f', 'fix the violations in place'),
+        ('error-status', 'e', 'return an error code on failed PEP check'),
     ]
 
     def initialize_options(self):
         """Set the default options."""
         self.branch = 'master'
         self.fix = False
+        self.error_status = True
 
     def finalize_options(self):
         pass
 
     def run(self):
-        cmd = 'pep8radius {} {}'.format(
-            self.branch, '--in-place' if self.fix else '')
+        cmd = 'pep8radius {}'.format(self.branch)
+        if self.fix:
+            cmd += ' --in-place'
+        if self.error_status:
+            cmd += ' --error-status'
         sys.exit(subprocess.call(cmd, shell=True))
 
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

If `pep8radius` finds errors, it should fail the build. Right now it does not.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
