### PR TITLE
Use unicode for special commands.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+TBD
+====
+
+Bug Fixes:
+----------
+
+* Fix the missing completion for special commands (Thanks: [Amjith Ramanujam]).
+
+
 1.19.0
 ======
 

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import logging
 import os
 import platform

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import os
 import re
 import locale

--- a/mycli/packages/special/main.py
+++ b/mycli/packages/special/main.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import logging
 from collections import namedtuple
 

--- a/test/test_naive_completion.py
+++ b/test/test_naive_completion.py
@@ -53,6 +53,7 @@ def test_column_name_completion(completer, complete_event):
         complete_event))
     assert result == set(map(Completion, completer.all_completions))
 
+
 def test_special_name_completion(completer, complete_event):
     text = '\\'
     position = len('\\')

--- a/test/test_naive_completion.py
+++ b/test/test_naive_completion.py
@@ -52,3 +52,12 @@ def test_column_name_completion(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert result == set(map(Completion, completer.all_completions))
+
+def test_special_name_completion(completer, complete_event):
+    text = '\\'
+    position = len('\\')
+    result = set(completer.get_completions(
+        Document(text=text, cursor_position=position),
+        complete_event))
+    # Special commands will NOT be suggested during naive completion mode.
+    assert result == set()

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -57,7 +57,8 @@ def test_empty_string_completion(completer, complete_event):
         completer.get_completions(
             Document(text=text, cursor_position=position),
             complete_event))
-    assert set(map(Completion, completer.keywords)) == result
+    assert set(map(Completion, completer.keywords +
+                   completer.special_commands)) == result
 
 
 def test_select_keyword_completion(completer, complete_event):

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -4,6 +4,7 @@ import pytest
 from mock import patch
 from prompt_toolkit.completion import Completion
 from prompt_toolkit.document import Document
+import mycli.packages.special.main as special
 
 metadata = {
     'users': ['id', 'email', 'first_name', 'last_name'],
@@ -29,6 +30,7 @@ def completer():
     comp.extend_schemata('test')
     comp.extend_relations(tables, kind='tables')
     comp.extend_columns(columns, kind='tables')
+    comp.extend_special_commands(special.COMMANDS)
 
     return comp
 
@@ -37,6 +39,14 @@ def completer():
 def complete_event():
     from mock import Mock
     return Mock()
+
+def test_special_name_completion(completer, complete_event):
+    text = '\\d'
+    position = len('\\d')
+    result = completer.get_completions(
+        Document(text=text, cursor_position=position),
+        complete_event)
+    assert result == [Completion(text='\\dt', start_position=-2)]
 
 
 def test_empty_string_completion(completer, complete_event):

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -40,6 +40,7 @@ def complete_event():
     from mock import Mock
     return Mock()
 
+
 def test_special_name_completion(completer, complete_event):
     text = '\\d'
     position = len('\\d')


### PR DESCRIPTION
## Description
Use unicode for the special commands. This is required by latest prompt-toolkit to show completions for special commands. 

Still working on some tests for this. So don't merge it just yet.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
