### PR TITLE
Fixes #669 -- Load favorites queries from and save to --myclirc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - ./setup.py test --pytest-args="--cov-report= --cov=mycli"
   - coverage combine
   - coverage report
-  - ./setup.py lint
+  - ./setup.py lint --branch=$TRAVIS_BRANCH
 
 after_success:
   - codecov

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Bug Fixes:
 ----------
 
 * Fix the missing completion for special commands (Thanks: [Amjith Ramanujam]).
+* Fix favorites queries being loaded/stored only from/in default config file and not --myclirc (Thanks: [Matheus Rosa])
 
 
 1.19.0

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -116,6 +116,9 @@ class MyCli(object):
         self.multi_line = c['main'].as_bool('multi_line')
         self.key_bindings = c['main']['key_bindings']
         special.set_timing_enabled(c['main'].as_bool('timing'))
+
+        special.set_favorite_queries(self.config)
+
         self.formatter = TabularOutputFormatter(
             format_name=c['main']['table_format'])
         sql_format.register_new_formatter(self.formatter)

--- a/mycli/packages/special/favoritequeries.py
+++ b/mycli/packages/special/favoritequeries.py
@@ -44,6 +44,7 @@ Examples:
         return self.config.get(self.section_name, {}).get(name, None)
 
     def save(self, name, query):
+        self.config.encoding = 'utf-8'
         if self.section_name not in self.config:
             self.config[self.section_name] = {}
         self.config[self.section_name][name] = query
@@ -56,6 +57,3 @@ Examples:
             return '%s: Not Found.' % name
         self.config.write()
         return '%s: Deleted' % name
-
-from ...config import read_config_file
-favoritequeries = FavoriteQueries(read_config_file('~/.myclirc'))

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -10,10 +10,11 @@ from time import sleep
 
 import click
 import sqlparse
+from configobj import ConfigObj
 
 from . import export
 from .main import special_command, NO_QUERY, PARSED_QUERY
-from .favoritequeries import favoritequeries
+from .favoritequeries import FavoriteQueries
 from .utils import handle_cd_command
 from mycli.packages.prompt_utils import confirm_destructive_query
 
@@ -22,6 +23,7 @@ use_expanded_output = False
 PAGER_ENABLED = True
 tee_file = None
 once_file = written_to_once_file = None
+favoritequeries = FavoriteQueries(ConfigObj())
 
 @export
 def set_timing_enabled(val):
@@ -32,6 +34,12 @@ def set_timing_enabled(val):
 def set_pager_enabled(val):
     global PAGER_ENABLED
     PAGER_ENABLED = val
+
+
+@export
+def set_favorite_queries(config):
+    global favoritequeries
+    favoritequeries = FavoriteQueries(config)
 
 @export
 def is_pager_enabled():

--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -8,7 +8,6 @@ from prompt_toolkit.completion import Completer, Completion
 
 from .packages.completion_engine import suggest_type
 from .packages.parseutils import last_word
-from .packages.special.favoritequeries import favoritequeries
 from .packages.filepaths import parse_path, complete_path, suggest_path
 
 _logger = logging.getLogger(__name__)
@@ -351,6 +350,7 @@ class SQLCompleter(Completer):
                                             fuzzy=False)
                 completions.extend(special)
             elif suggestion['type'] == 'favoritequery':
+                from .packages.special.iocommands import favoritequeries
                 queries = self.find_matches(word_before_cursor,
                                             favoritequeries.list(),
                                             start_only=False, fuzzy=True)

--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -9,6 +9,7 @@ from prompt_toolkit.completion import Completer, Completion
 from .packages.completion_engine import suggest_type
 from .packages.parseutils import last_word
 from .packages.filepaths import parse_path, complete_path, suggest_path
+from .packages.special.iocommands import favoritequeries
 
 _logger = logging.getLogger(__name__)
 
@@ -350,7 +351,6 @@ class SQLCompleter(Completer):
                                             fuzzy=False)
                 completions.extend(special)
             elif suggestion['type'] == 'favoritequery':
-                from .packages.special.iocommands import favoritequeries
                 queries = self.find_matches(word_before_cursor,
                                             favoritequeries.list(),
                                             start_only=False, fuzzy=True)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Favorite queries were being loaded from and save to the default configuration file (`~/.myclirc`) only. This PR fixes that issue by making sure that `FavoriteQueries` instance is created with the config loaded from `--myclirc` argument.

Fixes #669.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [X] I've added this contribution to the `changelog.md`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).