### PR TITLE
myclirc: Mention escaping of special characters in DSN.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ TBD
 Features:
 ----------
 * Auto find alias dsn when `://` not in `database` (Thanks: [QiaoHou Peng]).
+* Mention URL encoding as escaping technique for special characters in connection DSN (Thanks: [Aljosha Papsch]).
 
 Bug Fixes:
 ----------

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -63,6 +63,7 @@ Contributors:
   * QiaoHou Peng
   * Yang Zou
   * Angelo Lupo
+  * Aljosha Papsch
 
 Creator:
 --------

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -115,5 +115,6 @@ output.even-row = ""
 [favorite_queries]
 
 # Use the -d option to reference a DSN.
+# Special characters in passwords and other strings can be escaped with URL encoding.
 [alias_dsn]
 # example_dsn = mysql://[user[:password]@][host][:port][/dbname]


### PR DESCRIPTION
It is possible to use URL encoding for special characters,
because unquote from urlparse is used on parts of the DSN.

One can guess this from the exception message but a notice in the sample file is more helpful.

## Checklist

- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).

(This seems a bit much for a one line change that is a comment)