### PR TITLE
Strip ANSI escape codes for auto vertical output width calculations.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ Bug Fixes:
 
 * Fix the missing completion for special commands (Thanks: [Amjith Ramanujam]).
 * Fix favorites queries being loaded/stored only from/in default config file and not --myclirc (Thanks: [Matheus Rosa])
+* Fix automatic vertical output with native syntax style (Thanks: [Thomas Roten]).
 
 Features:
 ---------
@@ -34,7 +35,7 @@ Features:
 * Add Token.Prompt/Continuation (Thanks: [Dick Marinus]).
 * Don't reconnect when switching databases using use (Thanks: [Angelo Lupo]).
 * Handle MemoryErrors while trying to pipe in large files and exit gracefully with an error (Thanks: [Amjith Ramanujam])
- 
+
 Bug Fixes:
 ----------
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -17,6 +17,7 @@ from io import open
 from pymysql import OperationalError
 from cli_helpers.tabular_output import TabularOutputFormatter
 from cli_helpers.tabular_output import preprocessors
+from cli_helpers.utils import strip_ansi
 import click
 import sqlparse
 from prompt_toolkit.completion import DynamicCompleter
@@ -934,7 +935,7 @@ class MyCli(object):
                 formatted = formatted.splitlines()
             formatted = iter(formatted)
 
-            first_line = next(formatted)
+            first_line = strip_ansi(next(formatted))
             formatted = itertools.chain([first_line], formatted)
 
             if (not expanded and max_width and headers and cur and


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This fixes issue #716 by stripping ANSI escape codes from the first line of the output when calculating if the output can fit in the terminal window.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
