### PR TITLE
sqlparse 0.3.0 is out and does not have any notable changes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ Bug Fixes:
 * Fix favorites queries being loaded/stored only from/in default config file and not --myclirc (Thanks: [Matheus Rosa])
 * Fix automatic vertical output with native syntax style (Thanks: [Thomas Roten]).
 * Update `cli_helpers` version, this will remove quotes from batch output like the official client (Thanks: [Dick Marinus])
+* Update `setup.py` to no longer require `sqlparse` to be less than 0.3.0 as that just came out and there are no notable changes. ([VVelox])
 
 Features:
 ---------

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -64,6 +64,7 @@ Contributors:
   * Yang Zou
   * Angelo Lupo
   * Aljosha Papsch
+  * Zane C. Bowers-Hadley
 
 Creator:
 --------

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requirements = [
     'Pygments >= 1.6',
     'prompt_toolkit>=2.0.6',
     'PyMySQL >= 0.9.2',
-    'sqlparse>=0.2.2,<0.3.0',
+    'sqlparse>=0.2.2',
     'configobj >= 5.0.5',
     'cryptography >= 1.0.0',
     'cli_helpers[styles] > 1.1.0',


### PR DESCRIPTION
## Description

The requirement for sqlparse to be less than 0.3.0 breaks this given the recent release of sqlparse 0.3.0 recently.

https://github.com/andialbrecht/sqlparse/blob/master/CHANGELOG


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
