### PR TITLE
Bugfix/config values with comma

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ Bug Fixes:
 * Fix automatic vertical output with native syntax style (Thanks: [Thomas Roten]).
 * Update `cli_helpers` version, this will remove quotes from batch output like the official client (Thanks: [Dick Marinus])
 * Update `setup.py` to no longer require `sqlparse` to be less than 0.3.0 as that just came out and there are no notable changes. ([VVelox])
+* workaround for ConfigObj parsing strings containing "," as lists (Thanks: [Mike Palandra])
 
 Features:
 ---------

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -65,6 +65,7 @@ Contributors:
   * Angelo Lupo
   * Aljosha Papsch
   * Zane C. Bowers-Hadley
+  * Mike Palandra
 
 Creator:
 --------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -322,6 +322,11 @@ class MyCli(object):
             for sect in cnf:
                 if sect in sections and key in cnf[sect]:
                     result = cnf[sect][key]
+            # HACK: if result is a list, then ConfigObj() probably decoded from
+            # string by splitting on comma, so reconstruct string by joining on
+            # comma.
+            if isinstance(result, list):
+                result = ','.join(result)
             return result
 
         return {x: get(x) for x in keys}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
When a password is read from ~/.mylogin.cnf and contains a comma (,), mycli will terminate with error message  "object supporting the buffer API required".  Please note that the official mysql CLI client handles this case properly.

More detail:
1. In mycli/main.py (`MyCLI.connect()`): if keyword parameter `passwd=''` evaluates to false (it does by default), then a password will be parsed from config:
`cnf = self.read_my_cnf_files(self.cnf_files, cnf.keys())`
...
`passwd = passwd or cnf['password']`
2. In mycli/config.py (`read_config_file()`): a `configobj.ConfigObj()` object is initialized without explicit keyword parameter `list_values=True`, so its effective value will be `True`:
`config = ConfigObj(f, interpolation=False, encoding='utf8')`
This will cause any string value containing a "," to be parsed as a list which causes an exception somewhere (I didn't trace all the way through).

## Suggested Fix
Note that this is my first time looking at the source, so my advice may not be optimal.  Initially, I thought it would be more sensible to initialize `ConfigObj` with `list_values=False` but that just caused other problems since it preserves surrounding quotes whereas `list_values=True` strips them; see also:

[list_values](https://configobj.readthedocs.io/en/latest/configobj.html#list-values)
[ISSUES](https://configobj.readthedocs.io/en/latest/configobj.html#issues)

Instead, I have modified the nested `get()` function defined inside function `read_my_cnf_files()` in mycli/main.py.

This might close #624.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
