### PR TITLE
Amjith/alt enter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features:
 ----------
 * Auto find alias dsn when `://` not in `database` (Thanks: [QiaoHou Peng]).
 * Mention URL encoding as escaping technique for special characters in connection DSN (Thanks: [Aljosha Papsch]).
+* Pressing Alt-Enter will introduce a line break. This is a way to break up the query into multiple lines without switching to multi-line mode. (Thanks: [Amjith Ramanujam]).
 
 Bug Fixes:
 ----------

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -77,4 +77,10 @@ def mycli_bindings(mycli):
         b = event.app.current_buffer
         b.complete_state = None
 
+    @kb.add('escape', 'enter')
+    def _(event):
+        """Introduces a line break regardless of multi-line mode or not."""
+        _logger.debug('Detected alt-enter key.')
+        event.app.current_buffer.insert_text('\n')
+
     return kb


### PR DESCRIPTION
## Description
Use Alt-Enter to insert a multi-line statement without switching to multi-line mode.

Requested in #738 

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
