### PR TITLE
Feature | Block users from using shell (bash, sh, tcsh, etc) with SYSTEM query

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Features:
 * Auto find alias dsn when `://` not in `database` (Thanks: [QiaoHou Peng]).
 * Mention URL encoding as escaping technique for special characters in connection DSN (Thanks: [Aljosha Papsch]).
 * Pressing Alt-Enter will introduce a line break. This is a way to break up the query into multiple lines without switching to multi-line mode. (Thanks: [Amjith Ramanujam]).
+* Disable shell commands (bash, sh, tcsh, etc) with SYSTEM query (Thanks: [Lucas Fraga]).
 
 Bug Fixes:
 ----------

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -66,6 +66,7 @@ Contributors:
   * Aljosha Papsch
   * Zane C. Bowers-Hadley
   * Mike Palandra
+  * Lucas Fraga
 
 Creator:
 --------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -134,6 +134,7 @@ class MyCli(object):
         self.wider_completion_menu = c['main'].as_bool('wider_completion_menu')
         c_dest_warning = c['main'].as_bool('destructive_warning')
         self.destructive_warning = c_dest_warning if warn is None else warn
+        self.disable_system_shell = c['main'].as_bool('disable_system_shell')
         self.login_path_as_host = c['main'].as_bool('login_path_as_host')
 
         # read from cli argument or user config file
@@ -577,6 +578,13 @@ class MyCli(object):
                 else:
                     self.echo('Wise choice!')
                     return
+
+            if self.disable_system_shell:
+	            for query in sqlparse.split(text):
+	                if query.split()[0].lower() == "system":
+		                click.secho("SYSTEM Shell not allowed",
+                                    err=True, fg='red')
+		                return
 
             # Keep track of whether or not the query is mutating. In case
             # of a multi-statement query, the overall query is considered

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -83,6 +83,9 @@ keyword_casing = auto
 # disabled pager on startup
 enable_pager = True
 
+# Disable shell commands (bash, sh, tcsh, etc) with SYSTEM query 
+disable_system_shell = False
+
 # Custom colors for the completion menu, toolbar, etc.
 [colors]
 completion-menu.completion.current = 'bg:#ffffff #000000'


### PR DESCRIPTION
## Description
When users have setup with MyCLI and Linux user custom shell (echo '/opt/mycli-script.sh' | chsh username) for access database directly with SSH and MyCLI, shell access is expected to be blocked

Added boolean parameter **disable_system_shell** for block SQL queries like "SYSTEM id" or "SYSTEM \<shell commands\>"

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
