### PR TITLE
Do not use ConfigObj's list_values.

### DIFF
--- a/mycli/config.py
+++ b/mycli/config.py
@@ -37,6 +37,7 @@ def read_config_file(f, list_values=True):
     (e.g. 'a,b,c' -> ['a', 'b', 'c']. Additionally, the config values are
     not unquoted. We are disabling list_values when reading MySQL config files
     so we can correctly interpret commas in passwords.
+
     """
 
     if isinstance(f, basestring):
@@ -210,7 +211,9 @@ def str_to_bool(s):
 def strip_matching_quotes(s):
     """Remove matching, surrounding quotes from a string.
 
-    This is the same logic that ConfigObj uses when parsing config values.
+    This is the same logic that ConfigObj uses when parsing config
+    values.
+
     """
     if (isinstance(s, basestring) and len(s) >= 2 and
             s[0] == s[-1] and s[0] in ('"', "'")):

--- a/mycli/config.py
+++ b/mycli/config.py
@@ -30,7 +30,14 @@ def log(logger, level, message):
 
 
 def read_config_file(f, list_values=True):
-    """Read a config file."""
+    """Read a config file.
+
+    *list_values* set to `True` is the default behavior of ConfigObj.
+    Disabling it causes values to not be parsed for lists,
+    (e.g. 'a,b,c' -> ['a', 'b', 'c']. Additionally, the config values are
+    not unquoted. We are disabling list_values when reading MySQL config files
+    so we can correctly interpret commas in passwords.
+    """
 
     if isinstance(f, basestring):
         f = os.path.expanduser(f)
@@ -201,7 +208,10 @@ def str_to_bool(s):
 
 
 def strip_matching_quotes(s):
-    """Remove matching, surrounding quotes from a string."""
+    """Remove matching, surrounding quotes from a string.
+
+    This is the same logic that ConfigObj uses when parsing config values.
+    """
     if (isinstance(s, basestring) and len(s) >= 2 and
             s[0] == s[-1] and s[0] in ('"', "'")):
         s = s[1:-1]

--- a/mycli/config.py
+++ b/mycli/config.py
@@ -29,14 +29,15 @@ def log(logger, level, message):
         print(message, file=sys.stderr)
 
 
-def read_config_file(f):
+def read_config_file(f, list_values=True):
     """Read a config file."""
 
     if isinstance(f, basestring):
         f = os.path.expanduser(f)
 
     try:
-        config = ConfigObj(f, interpolation=False, encoding='utf8')
+        config = ConfigObj(f, interpolation=False, encoding='utf8',
+                           list_values=list_values)
     except ConfigObjError as e:
         log(logger, logging.ERROR, "Unable to parse line {0} of config file "
             "'{1}'.".format(e.line_number, f))
@@ -50,13 +51,13 @@ def read_config_file(f):
     return config
 
 
-def read_config_files(files):
+def read_config_files(files, list_values=True):
     """Read and merge a list of config files."""
 
-    config = ConfigObj()
+    config = ConfigObj(list_values=list_values)
 
     for _file in files:
-        _config = read_config_file(_file)
+        _config = read_config_file(_file, list_values=list_values)
         if bool(_config) is True:
             config.merge(_config)
             config.filename = _config.filename
@@ -197,6 +198,14 @@ def str_to_bool(s):
         return False
     else:
         raise ValueError('not a recognized boolean value: %s'.format(s))
+
+
+def strip_matching_quotes(s):
+    """Remove matching, surrounding quotes from a string."""
+    if (isinstance(s, basestring) and len(s) >= 2 and
+            s[0] == s[-1] and s[0] in ('"', "'")):
+        s = s[1:-1]
+    return s
 
 
 def _get_decryptor(key):

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -42,7 +42,8 @@ from .sqlexecute import FIELD_TYPES, SQLExecute
 from .clibuffer import cli_is_multiline
 from .completion_refresher import CompletionRefresher
 from .config import (write_default_config, get_mylogin_cnf_path,
-                     open_mylogin_cnf, read_config_files, str_to_bool)
+                     open_mylogin_cnf, read_config_files, str_to_bool,
+                     strip_matching_quotes)
 from .key_bindings import mycli_bindings
 from .encodingutils import utf8tounicode, text_type
 from .lexer import MyCliLexer
@@ -308,7 +309,7 @@ class MyCli(object):
         :param keys: list of keys to retrieve
         :returns: tuple, with None for missing keys.
         """
-        cnf = read_config_files(files)
+        cnf = read_config_files(files, list_values=False)
 
         sections = ['client']
         if self.login_path and self.login_path != 'client':
@@ -321,12 +322,7 @@ class MyCli(object):
             result = None
             for sect in cnf:
                 if sect in sections and key in cnf[sect]:
-                    result = cnf[sect][key]
-            # HACK: if result is a list, then ConfigObj() probably decoded from
-            # string by splitting on comma, so reconstruct string by joining on
-            # comma.
-            if isinstance(result, list):
-                result = ','.join(result)
+                    result = strip_matching_quotes(cnf[sect][key])
             return result
 
         return {x: get(x) for x in keys}

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -143,19 +143,19 @@ def test_str_to_bool():
 def test_read_config_file_list_values_default():
     """Test that reading a config file uses list_values by default."""
 
-    f = StringIO("[main]\nweather='cloudy with a chance of meatballs'\n")
+    f = StringIO(u"[main]\nweather='cloudy with a chance of meatballs'\n")
     config = read_config_file(f)
 
-    assert config['main']['weather'] == "cloudy with a chance of meatballs"
+    assert config['main']['weather'] == u"cloudy with a chance of meatballs"
 
 
 def test_read_config_file_list_values_off():
     """Test that you can disable list_values when reading a config file."""
 
-    f = StringIO("[main]\nweather='cloudy with a chance of meatballs'\n")
+    f = StringIO(u"[main]\nweather='cloudy with a chance of meatballs'\n")
     config = read_config_file(f, list_values=False)
 
-    assert config['main']['weather'] == "'cloudy with a chance of meatballs'"
+    assert config['main']['weather'] == u"'cloudy with a chance of meatballs'"
 
 
 def test_strip_quotes_with_matching_quotes():


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This is a follow-up to #742, #744, and #624.

This disables ConfigObj's `list_values` since it converts strings with commas in them into lists. This makes it impossible to have a password that uses a comma.

Instead, this approach turns `list_values` off when reading MySQL config files. By doing so, ConfigObj will not remove surrounding quotes, so we have to do that ourselves.

This allows a user to have a password with a comma. If a user has a password that starts or ends with a quote, they can simply surround their password in the config file with quotes.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [X] I've added this contribution to the `changelog.md`. (it's still there from Mike's PR)
- [X] I've added my name to the `AUTHORS` file (or it's already there).
