### PR TITLE
Fix login path with command-line database name.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+1.20.1
+======
+
+Bug Fixes:
+----------
+
+* Fix an error when using login paths with an explicit database name (Thanks: [Thomas Roten]).
+
 1.20.0
 ======
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1085,21 +1085,22 @@ def cli(database, user, host, port, socket, password, dbname,
 
     dsn_uri = None
 
-    if database and '://' not in database and not any([user, password, host, port]):
-        dsn = database
-        database = ''
+    # Treat the database argument as a DSN alias if we're missing
+    # other connection information.
+    if (mycli.config['alias_dsn'] and database and '://' not in database
+            and not any([user, password, host, port, login_path])):
+        dsn, database = database, ''
 
     if database and '://' in database:
-        dsn_uri = database
-        database = ''
+        dsn_uri, database = database, ''
 
-    if dsn is not '':
+    if dsn:
         try:
             dsn_uri = mycli.config['alias_dsn'][dsn]
-        except KeyError as err:
-            click.secho('Invalid DSNs found in the config file. '
-                        'Please check the "[alias_dsn]" section in myclirc.',
-                        err=True, fg='red')
+        except KeyError:
+            click.secho('Could not find the specified DSN in the config file. '
+                        'Please check the "[alias_dsn]" section in your '
+                        'myclirc.', err=True, fg='red')
             exit(1)
 
     if dsn_uri:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This fixes #768. 

The DSN code was checking for login credentials and if they didn't exist, it interpreted the database argument as a DSN alias (a [super handy feature](https://github.com/dbcli/mycli/pull/699)!). But, it didn't recognize the login path as part of the credentials. So, the database name was being interpreted as a DSN alias, when it shouldn't have been.

This pull request adds in a check for login path. It also only treats the database argument as the DSN alias when the user's config file defines DSN aliases.

Additionally, I reworded the error message to provide more specific information (not found vs. invalid).

I've included a version bump in the changelog with this PR so we can release this fix after it's merged.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
