### PR TITLE
Dsn alias prompt

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+TBD
+===
+
+Features:
+---------
+* Added DSN alias name as a format specifier to the prompt (Thanks: [Georgy Frolov]).
+
+
 1.20.1
 ======
 
@@ -5,6 +13,7 @@ Bug Fixes:
 ----------
 
 * Fix an error when using login paths with an explicit database name (Thanks: [Thomas Roten]).
+
 
 1.20.0
 ======

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -66,6 +66,7 @@ Contributors:
   * Aljosha Papsch
   * Zane C. Bowers-Hadley
   * Mike Palandra
+  * Georgy Frolov
 
 Creator:
 --------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -121,6 +121,7 @@ class MyCli(object):
 
         special.set_favorite_queries(self.config)
 
+        self.dsn_alias = None
         self.formatter = TabularOutputFormatter(
             format_name=c['main']['table_format'])
         sql_format.register_new_formatter(self.formatter)
@@ -885,6 +886,7 @@ class MyCli(object):
         string = string.replace('\\r', now.strftime('%I'))
         string = string.replace('\\s', now.strftime('%S'))
         string = string.replace('\\p', str(sqlexecute.port))
+        string = string.replace('\\A', self.dsn_alias or '(none)')
         string = string.replace('\\_', ' ')
         return string
 
@@ -1102,6 +1104,8 @@ def cli(database, user, host, port, socket, password, dbname,
                         'Please check the "[alias_dsn]" section in your '
                         'myclirc.', err=True, fg='red')
             exit(1)
+        else:
+            mycli.dsn_alias = dsn
 
     if dsn_uri:
         uri = urlparse(dsn_uri)

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -63,6 +63,7 @@ wider_completion_menu = False
 # \r - The current time, standard 12-hour time (1–12)
 # \s - Seconds of the current time
 # \t - Product type (Percona, MySQL, MariaDB)
+# \A - DSN alias name (from the [alias_dsn] section)
 # \u - Username
 prompt = '\t \u@\h:\d> '
 prompt_continuation = '-> '


### PR DESCRIPTION
## Description
Added a format specifier `\A` to include the DSN alias name into the prompt



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
