### PR TITLE
removed stripping ANSI escapes from the first line

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -936,15 +936,15 @@ class MyCli(object):
                 formatted = formatted.splitlines()
             formatted = iter(formatted)
 
-            first_line = strip_ansi(next(formatted))
-            formatted = itertools.chain([first_line], formatted)
-
-            if (not expanded and max_width and headers and cur and
-                    len(first_line) > max_width):
-                formatted = self.formatter.format_output(
-                    cur, headers, format_name='vertical', column_types=column_types, **output_kwargs)
-                if isinstance(formatted, (text_type)):
-                    formatted = iter(formatted.splitlines())
+            if (not expanded and max_width and headers and cur):
+                first_line = next(formatted)
+                if len(strip_ansi(first_line)) > max_width:
+                    formatted = self.formatter.format_output(
+                        cur, headers, format_name='vertical', column_types=column_types, **output_kwargs)
+                    if isinstance(formatted, (text_type)):
+                        formatted = iter(formatted.splitlines())
+                else:
+                    formatted = itertools.chain([first_line], formatted)
 
             output = itertools.chain(output, formatted)
 


### PR DESCRIPTION
## Description
The first line of output is stripped of ANSI escape chars in order to calculate its width and determine if we need to switch to the vertical format. However

1. this only needs to be done if other conditions of format switching are met, and
2. after the width calculation there seems to be no reason to retain this stripped line in the output. 

<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.  -- don't know if this change is substantial enough to be included :)
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
