### PR TITLE
added --behave-args option to test runner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,18 +57,25 @@ class lint(Command):
 
 class test(TestCommand):
 
-    user_options = [('pytest-args=', 'a', 'Arguments to pass to pytest')]
+    user_options = [
+        ('pytest-args=', 'a', 'Arguments to pass to pytest'),
+        ('behave-args=', 'b', 'Arguments to pass to pytest')
+    ]
 
     def initialize_options(self):
         TestCommand.initialize_options(self)
         self.pytest_args = ''
+        self.behave_args = ''
 
     def run_tests(self):
         unit_test_errno = subprocess.call(
             'pytest ' + self.pytest_args,
             shell=True
         )
-        cli_errno = subprocess.call('behave test/features', shell=True)
+        cli_errno = subprocess.call(
+            'behave test/features ' + self.behave_args,
+            shell=True
+        )
         sys.exit(unit_test_errno or cli_errno)
 
 


### PR DESCRIPTION
## Description
added `--behave-args`, just like `--pytest-args`
To run a single fixture: 
    
    python setup.py test --behave-args="-n '<fixture name>'"


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
