### PR TITLE
Restrict destructive command confirmation to ('yes', 'y')

### DIFF
--- a/mycli/packages/prompt_utils.py
+++ b/mycli/packages/prompt_utils.py
@@ -7,6 +7,26 @@ import click
 from .parseutils import is_destructive
 
 
+class ConfirmBoolParamType(click.ParamType):
+    name = 'confirmation'
+
+    def convert(self, value, param, ctx):
+        if isinstance(value, bool):
+            return bool(value)
+        value = value.lower()
+        if value in ('yes', 'y'):
+            return True
+        elif value in ('no', 'n'):
+            return False
+        self.fail('%s is not a valid boolean' % value, param, ctx)
+
+    def __repr__(self):
+        return 'BOOL'
+
+
+BOOLEAN_TYPE = ConfirmBoolParamType()
+
+
 def confirm_destructive_query(queries):
     """Check if the query is destructive and prompts the user to confirm.
 
@@ -19,7 +39,7 @@ def confirm_destructive_query(queries):
     prompt_text = ("You're about to run a destructive command.\n"
                    "Do you want to proceed? (y/n)")
     if is_destructive(queries) and sys.stdin.isatty():
-        return prompt(prompt_text, type=bool)
+        return prompt(prompt_text, type=BOOLEAN_TYPE)
 
 
 def confirm(*args, **kwargs):

--- a/test/features/crud_table.feature
+++ b/test/features/crud_table.feature
@@ -26,3 +26,17 @@ Feature: manipulate tables:
       then we see database connected
       when we select null
       then we see null selected
+
+  Scenario: confirm destructive query
+     When we query "delete from foo;"
+      and we answer the destructive warning with "y"
+      then we see text "Your call!"
+
+  Scenario: decline destructive query
+     When we query "delete from foo;"
+      and we answer the destructive warning with "n"
+      then we see text "Wise choice!"
+
+  Scenario: confirm destructive query with invalid response
+     When we query "delete from foo;"
+      then we answer the destructive warning with invalid "1" and see text "is not a valid boolean"

--- a/test/features/steps/basic_commands.py
+++ b/test/features/steps/basic_commands.py
@@ -73,9 +73,30 @@ def step_see_found(context):
         ''') + context.conf['pager_boundary'],
         timeout=5
     )
+
+
 @then(u'we confirm the destructive warning')
 def step_confirm_destructive_command(context):
     """Confirm destructive command."""
     wrappers.expect_exact(
         context, 'You\'re about to run a destructive command.\r\nDo you want to proceed? (y/n):', timeout=2)
     context.cli.sendline('y')
+
+
+@when(u'we answer the destructive warning with "{confirmation}"')
+def step_confirm_destructive_command(context, confirmation):
+    """Confirm destructive command."""
+    wrappers.expect_exact(
+        context, 'You\'re about to run a destructive command.\r\nDo you want to proceed? (y/n):', timeout=2)
+    context.cli.sendline(confirmation)
+
+
+@then(u'we answer the destructive warning with invalid "{confirmation}" and see text "{text}"')
+def step_confirm_destructive_command(context, confirmation, text):
+    """Confirm destructive command."""
+    wrappers.expect_exact(
+        context, 'You\'re about to run a destructive command.\r\nDo you want to proceed? (y/n):', timeout=2)
+    context.cli.sendline(confirmation)
+    wrappers.expect_exact(context, text, timeout=2)
+    # we must exit the Click loop, or the feature will hang
+    context.cli.sendline('n')

--- a/test/features/steps/specials.py
+++ b/test/features/steps/specials.py
@@ -17,6 +17,11 @@ def step_refresh_completions(context):
     context.cli.sendline('rehash')
 
 
+@then('we see text "{text}"')
+def step_see_text(context, text):
+    """Wait to see given text message."""
+    wrappers.expect_exact(context, text, timeout=2)
+
 @then('we see completions refresh started')
 def step_see_refresh_started(context):
     """Wait to see refresh output."""

--- a/test/features/steps/wrappers.py
+++ b/test/features/steps/wrappers.py
@@ -85,11 +85,13 @@ def run_cli(context, run_args=None):
     context.currentdb = context.conf['dbname']
 
 
-def wait_prompt(context):
+def wait_prompt(context, prompt=None):
     """Make sure prompt is displayed."""
-    user = context.conf['user']
-    host = context.conf['host']
-    dbname = context.currentdb
-    expect_exact(context, '{0}@{1}:{2}> '.format(
-        user, host, dbname), timeout=5)
+    if prompt is None:
+        user = context.conf['user']
+        host = context.conf['host']
+        dbname = context.currentdb
+        prompt = '{0}@{1}:{2}> '.format(
+            user, host, dbname),
+    expect_exact(context, prompt, timeout=5)
     context.atprompt = True


### PR DESCRIPTION

## Description
Issue #758 
The default boolean converter in Click evaluates "t", "true" and "1" to `True`. Added a custom one.



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
