### PR TITLE
Added clearer error message when failing to connect to default socket

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,8 +5,8 @@ Features:
 ---------
 * Added DSN alias name as a format specifier to the prompt (Thanks: [Georgy Frolov]).
 * Mark `update` without `where`-clause as destructive query (Thanks: [Klaus Wünschel]).
-
 * Added DELIMITER command (Thanks: [Georgy Frolov])
+* Added clearer error message when failing to connect to the default socket.
 
 
 1.20.1

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -67,6 +67,7 @@ Contributors:
   * Zane C. Bowers-Hadley
   * Mike Palandra
   * Georgy Frolov
+  * Jonathan Lloyd
 
 Creator:
 --------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -438,9 +438,11 @@ class MyCli(object):
                         self.logger.error(
                             "traceback: %r", traceback.format_exc())
                         self.logger.debug('Retrying over TCP/IP')
+                        self.echo(
+                                "Failed to connect to local MySQL server through socket '{}':".format(socket))
                         self.echo(str(e), err=True)
                         self.echo(
-                            'Failed to connect by socket, retrying over TCP/IP', err=True)
+                            'Retrying over TCP/IP', err=True)
 
                         # Else fall back to TCP/IP localhost
                         socket = ""

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -439,7 +439,7 @@ class MyCli(object):
                             "traceback: %r", traceback.format_exc())
                         self.logger.debug('Retrying over TCP/IP')
                         self.echo(
-                                "Failed to connect to local MySQL server through socket '{}':".format(socket))
+                            "Failed to connect to local MySQL server through socket '{}':".format(socket))
                         self.echo(str(e), err=True)
                         self.echo(
                             'Retrying over TCP/IP', err=True)


### PR DESCRIPTION
Fixes #572

## Description
Added a reference to the default socket path when failing to connect, should help when trying to debug why the connection is failing



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
