### PR TITLE
fixed version of colorama (pep8radius dependency)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,5 +8,6 @@ pexpect
 coverage==4.3.4
 codecov==2.0.9
 autopep8==1.3.3
+colorama==0.4.1
 git+https://github.com/hayd/pep8radius.git  # --error-status option not released
 click>=7.0


### PR DESCRIPTION
## Description
pep8radius just stopped building on python 3.4 after the release of [colorama 0.4.3](https://pypi.org/project/colorama/#history). 
I suggest just fixing the old version, since we don't do anything fancy with it anyway.

