### PR TITLE
don't auto-execute query after an editor session

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -22,6 +22,7 @@ import click
 import sqlparse
 from prompt_toolkit.completion import DynamicCompleter
 from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
+from prompt_toolkit.key_binding.bindings.named_commands import register as prompt_register
 from prompt_toolkit.shortcuts import PromptSession, CompleteStyle
 from prompt_toolkit.document import Document
 from prompt_toolkit.filters import HasFocus, IsDone
@@ -1276,6 +1277,14 @@ def thanks_picker(files=()):
         if m:
             contents.append(m.group(1))
     return choice(contents)
+
+
+@prompt_register('edit-and-execute-command')
+def edit_and_execute(event):
+    """Different from the prompt-toolkit default, we want to have a choice not
+    to execute a query after editing, hence validate_and_handle=False."""
+    buff = event.current_buffer
+    buff.open_in_editor(validate_and_handle=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
The default way prompt-toolkit handles external editors is to automatically execute the query after an editor session has ended. However, in mycli, it is often undesirable, for example:

- user didn't want to invoke the editor and just accidentally hit `v` in vim mode
- the editing result is not yet ready for execution, the user wanted to do something in the editor, and then continue to edit in mycli (to make use of completions etc)
- user decides to cancel the editor session

In practice it very often leads to unintentional execution of half-backed queries (and in the rare cases when they are semantically correct, there is a danger of accidentally corrupting data).

I suggest to disable auto-execution. The edited query simply appears on the prompt line and can be then run as usual.



<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ x ] I've added this contribution to the `changelog.md`.
- [ x ] I've added my name to the `AUTHORS` file (or it's already there).
