### PR TITLE
fix vscode test discover failed with pytest

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,6 @@
 import pytest
-from utils import (HOST, USER, PASSWORD, PORT, CHARSET, create_db,
-                   db_connection, SSH_USER, SSH_HOST, SSH_PORT)
+from .utils import (HOST, USER, PASSWORD, PORT, CHARSET, create_db,
+                    db_connection, SSH_USER, SSH_HOST, SSH_PORT)
 import mycli.sqlexecute
 
 

--- a/test/test_dbspecial.py
+++ b/test/test_dbspecial.py
@@ -1,5 +1,5 @@
 from mycli.packages.completion_engine import suggest_type
-from test_completion_engine import sorted_dicts
+from .test_completion_engine import sorted_dicts
 from mycli.packages.special.utils import format_uptime
 
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 
 from mycli.main import MyCli, cli, thanks_picker, PACKAGE_ROOT
 from mycli.packages.special.main import COMMANDS as SPECIAL_COMMANDS
-from utils import USER, HOST, PORT, PASSWORD, dbtest, run
+from .utils import USER, HOST, PORT, PASSWORD, dbtest, run
 
 from textwrap import dedent
 from collections import namedtuple
@@ -388,7 +388,7 @@ def test_dsn(monkeypatch):
         MockMyCli.connect_args["port"] == 5 and \
         MockMyCli.connect_args["database"] == "arg_database"
 
-    # Use a DNS without password
+    # Use a DSN without password
     result = runner.invoke(mycli.main.cli, args=[
         "mysql://dsn_user@dsn_host:6/dsn_database"]
     )

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -12,7 +12,7 @@ from pymysql import ProgrammingError
 
 import mycli.packages.special
 
-from utils import dbtest, db_connection, send_ctrl_c
+from .utils import dbtest, db_connection, send_ctrl_c
 
 
 def test_set_get_pager():

--- a/test/test_sqlexecute.py
+++ b/test/test_sqlexecute.py
@@ -5,7 +5,7 @@ import os
 import pytest
 import pymysql
 
-from utils import run, dbtest, set_expanded_output, is_expanded_output
+from .utils import run, dbtest, set_expanded_output, is_expanded_output
 
 
 def assert_result_equal(result, title=None, rows=None, headers=None,

--- a/test/test_tabular_output.py
+++ b/test/test_tabular_output.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 from mycli.packages.tabular_output import sql_format
 from cli_helpers.tabular_output import TabularOutputFormatter
 
-from utils import USER, PASSWORD, HOST, PORT, dbtest
+from .utils import USER, PASSWORD, HOST, PORT, dbtest
 
 import pytest
 from mycli.main import MyCli


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
vscode failed to discover tests, due to the import errors. The PR just fix the import errors and a typo. I haven't verified in Python2.x.
https://code.visualstudio.com/docs/python/testing#_test-discovery


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
