### PR TITLE
Downgraded sqlparse dependency, because version 0.3.1 introduced a br…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requirements = [
     'Pygments >= 1.6',
     'prompt_toolkit>=2.0.6,<3.0.0',
     'PyMySQL >= 0.9.2',
-    'sqlparse>=0.3.0,<0.4.0',
+    'sqlparse>=0.3.0,<0.3.1',
     'configobj >= 5.0.5',
     'cryptography >= 1.0.0',
     'cli_helpers[styles] > 1.1.0',


### PR DESCRIPTION
…eaking change to get_name() method

## Description

The latest release of sqlparse introduced a breaking change, probably a bug: https://github.com/andialbrecht/sqlparse/issues/536

We use `Statement.get_name()` to decide whether a `DROP DATABASE` query affects the currently selected database and completions there is need to update completions. Since this method now always returns None, the `completion_refresh` thread always crashes after dropping a database :(

