### PR TITLE
fixed is_dropping_database() after sqlparse update

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ Bug Fixes:
 ----------
 
 * Allow \o command more than once per session (Thanks: [Georgy Frolov])
+* Fixed crash when the query dropping the current database starts with a comment (Thanks: [Georgy Frolov])
 
 1.20.1
 ======

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -20,6 +20,7 @@ from cli_helpers.tabular_output import preprocessors
 from cli_helpers.utils import strip_ansi
 import click
 import sqlparse
+from mycli.packages.parseutils import is_dropping_database
 from prompt_toolkit.completion import DynamicCompleter
 from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
 from prompt_toolkit.key_binding.bindings.named_commands import register as prompt_register
@@ -1215,29 +1216,6 @@ def need_completion_refresh(queries):
                 return True
         except Exception:
             return False
-
-
-def is_dropping_database(queries, dbname):
-    """Determine if the query is dropping a specific database."""
-    if dbname is None:
-        return False
-
-    def normalize_db_name(db):
-        return db.lower().strip('`"')
-
-    dbname = normalize_db_name(dbname)
-
-    for query in sqlparse.parse(queries):
-        if query.get_name() is None:
-            continue
-
-        first_token = query.token_first(skip_cm=True)
-        _, second_token = query.token_next(0, skip_cm=True)
-        database_name = normalize_db_name(query.get_name())
-        if (first_token.value.lower() == 'drop' and
-                second_token.value.lower() in ('database', 'schema') and
-                database_name == dbname):
-            return True
 
 
 def need_completion_reset(queries):

--- a/mycli/packages/parseutils.py
+++ b/mycli/packages/parseutils.py
@@ -238,3 +238,32 @@ def is_open_quote(sql):
 if __name__ == '__main__':
     sql = 'select * from (select t. from tabl t'
     print (extract_tables(sql))
+
+
+def is_dropping_database(queries, dbname):
+    """Determine if the query is dropping a specific database."""
+    if dbname is None:
+        return False
+
+    def normalize_db_name(db):
+        return db.lower().strip('`"')
+
+    dbname = normalize_db_name(dbname)
+
+    for query in sqlparse.parse(queries):
+        keywords = [t for t in query.tokens if t.is_keyword]
+        if len(keywords) < 2:
+            continue
+        if keywords[0].normalized == "DROP" and keywords[1].value.lower() in (
+            "database",
+            "schema",
+        ):
+            database_token = next(
+                (t for t in query.tokens if isinstance(t, Identifier)), None
+            )
+            return (
+                database_token is not None
+                and normalize_db_name(database_token.get_name()) == dbname
+            )
+    else:
+        return False


### PR DESCRIPTION
## Description
There were three problems with `is_dropping_database()` :

```python
def is_dropping_database(queries, dbname):
    """Determine if the query is dropping a specific database."""
    if dbname is None:
        return False

    def normalize_db_name(db):
        return db.lower().strip('`"')

    dbname = normalize_db_name(dbname)

    for query in sqlparse.parse(queries):
        if query.get_name() is None:    #  <--  (1) turns out to be incorrect usage of sqlparse
            continue

        first_token = query.token_first(skip_cm=True)
        _, second_token = query.token_next(0, skip_cm=True)   #  <-- (2) returns first token if query starts with comment
        database_name = normalize_db_name(query.get_name())
        if (first_token.value.lower() == 'drop' and
                second_token.value.lower() in ('database', 'schema') and
                database_name == dbname):
            return True
    # (3) returns None instead of False
```

(1) was revealed by the recent `sqlparse` update
(2) leads to the following crash:
```
\A > create database foo;                                                                                                                                                                                                                      
Query OK, 1 row affected
Time: 0.001s

\A > use foo;                                                                                                                                                                                                                                  
You are now connected to database "foo" as user "root"
Time: 0.001s

\A > -- let's drop foo 
     drop database foo;                                                                                                                                                                                                                        
You're about to run a destructive command.
Do you want to proceed? (y/n): y
Your call!
Query OK, 0 rows affected
Time: 0.003s

\A > create database bar;                                                                                                                                                                                                                      
Query OK, 1 row affected
Time: 0.001s
\A > Exception in thread completion_refresh:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.7/threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "/home/frolov/venvs/py37/lib/python3.7/site-packages/mycli/completion_refresher.py", line 55, in _bg_refresh
    e.ssh_password, e.ssh_key_filename)                                                                                                                                                                                                        
  File "/home/frolov/venvs/py37/lib/python3.7/site-packages/mycli/sqlexecute.py", line 62, in __init__
    self.connect()
  File "/home/frolov/venvs/py37/lib/python3.7/site-packages/mycli/sqlexecute.py", line 118, in connect
    defer_connect=defer_connect
  File "/home/frolov/venvs/py37/lib/python3.7/site-packages/pymysql/__init__.py", line 94, in Connect
    return Connection(*args, **kwargs)
  File "/home/frolov/venvs/py37/lib/python3.7/site-packages/pymysql/connections.py", line 325, in __init__
    self.connect()
  File "/home/frolov/venvs/py37/lib/python3.7/site-packages/pymysql/connections.py", line 599, in connect
    self._request_authentication()
  File "/home/frolov/venvs/py37/lib/python3.7/site-packages/pymysql/connections.py", line 861, in _request_authentication
    auth_packet = self._read_packet()
  File "/home/frolov/venvs/py37/lib/python3.7/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frolov/venvs/py37/lib/python3.7/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frolov/venvs/py37/lib/python3.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1049, "Unknown database 'foo'")

```

Also moved it to `packages.parseutils` and added a test
(3) is a matter of taste, I just like it when things type-check.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
