### PR TITLE
Fix condition in change_db (resolve SyntaxWarning)

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -223,7 +223,7 @@ class MyCli(object):
             yield (None, None, None, msg)
 
     def change_db(self, arg, **_):
-        if arg is '':
+        if not arg:
             click.secho(
                 "No database selected",
                 err=True, fg="red"


### PR DESCRIPTION
```
$ mycli
/usr/local/Cellar/mycli/1.20.1_3/libexec/lib/python3.8/site-packages/mycli/main.py:224: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if arg is '':
```