### PR TITLE
coverage.py is broken on python3.8, upgrade to the latest version.

### DIFF
--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -68,6 +68,7 @@ Contributors:
   * Mike Palandra
   * Georgy Frolov
   * Jonathan Lloyd
+  * laixintao
 
 Creator:
 --------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ tox
 twine==1.12.1
 behave
 pexpect
-coverage==4.3.4
+coverage==5.0.4
 codecov==2.0.9
 autopep8==1.3.3
 colorama==0.4.1


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

see https://github.com/dbcli/pgcli/pull/1158

https://github.com/nedbat/coveragepy/issues/714

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
