### PR TITLE
Undefined variable destroy

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,7 @@ Bug Fixes:
 ----------
 
 * Fix broken auto-completion for favorite queries (Thanks: [Amjith]).
-
+* Fix undefined variable exception when running with --no-warn (Thanks: [Georgy Frolov])
 
 1.21.0
 ======

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -587,6 +587,8 @@ class MyCli(object):
                 else:
                     self.echo('Wise choice!')
                     return
+            else:
+                destroy = True
 
             # Keep track of whether or not the query is mutating. In case
             # of a multi-statement query, the overall query is considered

--- a/test/features/crud_table.feature
+++ b/test/features/crud_table.feature
@@ -28,7 +28,8 @@ Feature: manipulate tables:
       then we see null selected
 
   Scenario: confirm destructive query
-     When we query "delete from foo;"
+     When we query "create table foo(x integer);"
+      and we query "delete from foo;"
       and we answer the destructive warning with "y"
       then we see text "Your call!"
 
@@ -36,6 +37,12 @@ Feature: manipulate tables:
      When we query "delete from foo;"
       and we answer the destructive warning with "n"
       then we see text "Wise choice!"
+
+   Scenario: no destructive warning if disabled in config
+     When we run dbcli with --no-warn
+      and we query "create table blabla(x integer);"
+      and we query "delete from blabla;"
+     Then we see text "Query OK"
 
   Scenario: confirm destructive query with invalid response
      When we query "delete from foo;"

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -8,6 +8,8 @@ import pexpect
 
 from steps.wrappers import run_cli, wait_prompt
 
+test_log_file = os.path.join(os.environ['HOME'], '.mycli.test.log')
+
 
 def before_all(context):
     """Set env parameters."""
@@ -95,12 +97,18 @@ def before_step(context, _):
 
 
 def before_scenario(context, _):
+    with open(test_log_file, 'w') as f:
+        f.write('')
     run_cli(context)
     wait_prompt(context)
 
 
 def after_scenario(context, _):
     """Cleans up after each test complete."""
+    with open(test_log_file) as f:
+        for line in f:
+            if 'error' in line.lower():
+                raise RuntimeError(f'Error in log file: {line}')
 
     if hasattr(context, 'cli') and not context.exit_sent:
         # Quit nicely.


### PR DESCRIPTION
## Description
#848 
I also added the following logic to behave scenarios: 

1. before each test, clear the log,
2. fail the test if there are errors in the log after it finished.

It assumes that no scenario should cause log errors, and that the test log (`~/.mycli.test.log`) has no other use, so there's no harm in deleting it frequently.

<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ x ] I've added this contribution to the `changelog.md`.
- [ x ] I've added my name to the `AUTHORS` file (or it's already there).
