### PR TITLE
added python_requires to setup.py to prevent installation on python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
         'console_scripts': ['mycli = mycli.main:cli'],
     },
     cmdclass={'lint': lint, 'test': test},
+    python_requires=">=3.6",
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
## Description
#861 
Version 1.21.1 keeps being installed on python2 systems (I assumed removing Python::2 classifier to be sufficient, but it is not). 

Running `pip install -e .` in mycli root should produce an error
```
ERROR: Package 'mycli' requires a different Python: 2.7.17 not in '>=3.6'
```

I think this warrants a bugfix release




## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
