### PR TITLE
Changed paramiko usage to work with older versions

### DIFF
--- a/mycli/packages/paramiko_stub/__init__.py
+++ b/mycli/packages/paramiko_stub/__init__.py
@@ -1,0 +1,28 @@
+"""A module to import instead of paramiko when it is not available (to avoid
+checking for paramiko all over the place).
+
+When paramiko is first envoked, it simply shuts down mycli, telling
+user they either have to install paramiko or should not use SSH
+features.
+
+"""
+
+
+class Paramiko:
+    def __getattr__(self, name):
+        import sys
+        from textwrap import dedent
+        print(dedent("""
+            To enable certain SSH features you need to install paramiko:
+            
+               pip install paramiko
+               
+            It is required for the following configuration options:
+                --list-ssh-config
+                --ssh-config-host
+                --ssh-host
+        """))
+        sys.exit(1)
+
+
+paramiko = Paramiko()

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -8,8 +8,8 @@ from pymysql.converters import (convert_mysql_timestamp, convert_datetime,
                                 decoders)
 try:
     import paramiko
-except:
-    paramiko = False
+except ImportError:
+    from mycli.packages.paramiko_stub import paramiko
 
 _logger = logging.getLogger(__name__)
 
@@ -118,7 +118,7 @@ class SQLExecute(object):
             defer_connect=defer_connect
         )
 
-        if ssh_host and paramiko:
+        if ssh_host:
             client = paramiko.SSHClient()
             client.load_system_host_keys()
             client.set_missing_host_key_policy(paramiko.WarningPolicy())

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ class test(TestCommand):
 
     def run_tests(self):
         unit_test_errno = subprocess.call(
-            'pytest ' + self.pytest_args,
+            'pytest test/ ' + self.pytest_args,
             shell=True
         )
         cli_errno = subprocess.call(


### PR DESCRIPTION
## Description

Removed dependence of paramiko features that were introduced in version 2.7.

Plus a little refactoring: created a package to use when paramiko is not available. All it does is `sys.exit(1)` with a message. Instead of the idiom
```
if paramiko:
    paramiko.something()
else:
    exit with a message
```
 we can just code as if paramiko were always available.