### PR TITLE
Make pwd module optional.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,13 @@ TBD
 
 Bug Fixes:
 ----------
+*  Make the `pwd` module optional. 
+
+1.22.1
+======
+
+Bug Fixes:
+----------
 * Fix the breaking change introduced in PyMySQL 0.10.0. (Thanks: [Amjith]).
 
 Features:

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -6,7 +6,10 @@ import threading
 import re
 import fileinput
 from collections import namedtuple
-from pwd import getpwuid
+try:
+    from pwd import getpwuid
+except ImportError:
+    pass
 from time import time
 from datetime import datetime
 from random import choice


### PR DESCRIPTION
## Description
Since `pwd` module is only available Unix systems, this change makes that module an optional import.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
