### PR TITLE
fix "AttributeError: type object 'Connection' has no attribute 'get'" in mycli iPython magic

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ Bug Fixes:
 ----------
 
 *  Make the `pwd` module optional. 
+*  Fixed iPython magic
 
 1.22.1
 ======

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -75,7 +75,7 @@ Contributors:
   * Zach DeCook
   * kevinhwang91
   * KITAGAWA Yasutaka
-	* Morgan Mitchell
+  * Morgan Mitchell
 
 Creator:
 --------

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -75,6 +75,7 @@ Contributors:
   * Zach DeCook
   * kevinhwang91
   * KITAGAWA Yasutaka
+	* Morgan Mitchell
 
 Creator:
 --------

--- a/mycli/magic.py
+++ b/mycli/magic.py
@@ -19,7 +19,7 @@ def load_ipython_extension(ipython):
 def mycli_line_magic(line):
     _logger.debug('mycli magic called: %r', line)
     parsed = sql.parse.parse(line, {})
-    conn = sql.connection.Connection.get(parsed['connection'])
+    conn = sql.connection.Connection(parsed['connection'])
 
     try:
         # A corresponding mycli object already exists


### PR DESCRIPTION
## Description
The mycli iPython magic currently breaks with the below error on trying to connect within iPython
`AttributeError: type object 'Connection' has no attribute 'get'`

Was fixed for pgcli here by @j-bennet
https://github.com/dbcli/pgcli/commit/bde601102d90e05b042eeabfd2a003a05d7d00c5


Just copying over the same fix to mycli


## Checklist
- [ x] I've added this contribution to the `changelog.md`.
- [x ] I've added my name to the `AUTHORS` file (or it's already there).
