### PR TITLE
Remove unnecessary use of python 2 compat type (Fixes sqlparse 0.4 breaking change)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,13 +6,17 @@ Features:
 
 * Add an option `--init-command` to execute SQL after connecting (Thanks: [KITAGAWA Yasutaka]).
 
+Bug Fixes:
+----------
+* Fixed compatibility with sqlparse 0.4 (Thanks: [mtorromeo]).
+
 1.22.2
 ======
 
 Bug Fixes:
 ----------
 
-*  Make the `pwd` module optional. 
+*  Make the `pwd` module optional.
 
 1.22.1
 ======
@@ -785,3 +789,4 @@ Bug Fixes:
 [Georgy Frolov]: https://github.com/pasenor
 [Zach DeCook]: https://zachdecook.com
 [laixintao]: https://github.com/laixintao
+[mtorromeo]: https://github.com/mtorromeo

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -75,6 +75,7 @@ Contributors:
   * Zach DeCook
   * kevinhwang91
   * KITAGAWA Yasutaka
+  * Massimiliano Torromeo
 
 Creator:
 --------

--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -2,7 +2,6 @@ import os
 import sys
 import sqlparse
 from sqlparse.sql import Comparison, Identifier, Where
-from sqlparse.compat import text_type
 from .parseutils import last_word, extract_tables, find_prev_keyword
 from .special import parse_special_command
 
@@ -55,7 +54,7 @@ def suggest_type(full_text, text_before_cursor):
         stmt_start, stmt_end = 0, 0
 
         for statement in parsed:
-            stmt_len = len(text_type(statement))
+            stmt_len = len(str(statement))
             stmt_start, stmt_end = stmt_end, stmt_end + stmt_len
 
             if stmt_end >= current_pos:


### PR DESCRIPTION
Since python 2 compat has been removed and sqlparse 0.4 also doesn't ship with the compat module anymore, there is no reason to use the text_type alias for str/unicode.

## Description
Fixed compatibility with sqlparse 0.4

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
