### PR TITLE
Add pipe_once special command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Features:
 
 * Add an option `--init-command` to execute SQL after connecting (Thanks: [KITAGAWA Yasutaka]).
 * Use InputMode.REPLACE_SINGLE
+* Add a special command `\pipe_once` to pipe output to a subprocess.
 
 Bug Fixes:
 ----------

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -78,6 +78,7 @@ Contributors:
   * bitkeen
   * Morgan Mitchell
   * Massimiliano Torromeo
+  * Roland Walker
 
 Creator:
 --------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -654,6 +654,7 @@ class MyCli(object):
                     result_count += 1
                     mutating = mutating or destroy or is_mutating(status)
                 special.unset_once_if_written()
+                special.unset_pipe_once_if_written()
             except EOFError as e:
                 raise e
             except KeyboardInterrupt:
@@ -814,6 +815,7 @@ class MyCli(object):
                 self.log_output(line)
                 special.write_tee(line)
                 special.write_once(line)
+                special.write_pipe_once(line)
 
                 if fits or output_via_pager:
                     # buffering

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -23,6 +23,8 @@ PAGER_ENABLED = True
 tee_file = None
 once_file = None
 written_to_once_file = False
+pipe_once_process = None
+written_to_pipe_once_process = False
 delimiter_command = DelimiterCommand()
 
 
@@ -365,6 +367,53 @@ def unset_once_if_written():
     global once_file
     if written_to_once_file:
         once_file = None
+
+
+@special_command('\\pipe_once', '\\| command',
+                 'Send next result to a subprocess.',
+                 aliases=('\\|', ))
+def set_pipe_once(arg, **_):
+    global pipe_once_process, written_to_pipe_once_process
+    pipe_once_cmd = shlex.split(arg)
+    if len(pipe_once_cmd) == 0:
+        raise OSError("pipe_once requires a command")
+    written_to_pipe_once_process = False
+    pipe_once_process = subprocess.Popen(pipe_once_cmd,
+                                         stdin=subprocess.PIPE,
+                                         stdout=subprocess.PIPE,
+                                         stderr=subprocess.PIPE,
+                                         bufsize=1,
+                                         encoding='UTF-8',
+                                         universal_newlines=True)
+    return [(None, None, None, "")]
+
+
+@export
+def write_pipe_once(output):
+    global pipe_once_process, written_to_pipe_once_process
+    if output and pipe_once_process:
+        try:
+            click.echo(output, file=pipe_once_process.stdin, nl=False)
+            click.echo(u"\n", file=pipe_once_process.stdin, nl=False)
+        except (IOError, OSError) as e:
+            pipe_once_process.terminate()
+            raise OSError(
+                "Failed writing to pipe_once subprocess: {}".format(e.strerror))
+        written_to_pipe_once_process = True
+
+
+@export
+def unset_pipe_once_if_written():
+    """Unset the pipe_once cmd, if it has been written to."""
+    global pipe_once_process, written_to_pipe_once_process
+    if written_to_pipe_once_process:
+        (stdout_data, stderr_data) = pipe_once_process.communicate()
+        if len(stdout_data) > 0:
+            print(stdout_data.rstrip(u"\n"))
+        if len(stderr_data) > 0:
+            print(stderr_data.rstrip(u"\n"))
+        pipe_once_process = None
+        written_to_pipe_once_process = False
 
 
 @special_command(

--- a/test/features/fixture_data/help_commands.txt
+++ b/test/features/fixture_data/help_commands.txt
@@ -9,6 +9,7 @@
 | \fs         | \fs name query             | Save a favorite query.                                     |
 | \l          | \l                         | List databases.                                            |
 | \once       | \o [-o] filename           | Append next result to an output file (overwrite using -o). |
+| \pipe_once  | \| command                 | Send next result to a subprocess.                          |
 | \timing     | \t                         | Toggle timing of commands.                                 |
 | connect     | \r                         | Reconnect to the database. Optional database argument.     |
 | exit        | \q                         | Exit.                                                      |

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -109,6 +109,20 @@ def test_once_command():
         assert f.read() == b"hello world\n"
 
 
+def test_pipe_once_command():
+    with pytest.raises(IOError):
+        mycli.packages.special.execute(None, u"\\pipe_once")
+
+    with pytest.raises(OSError):
+        mycli.packages.special.execute(
+            None, u"\\pipe_once /proc/access-denied")
+
+    mycli.packages.special.execute(None, u"\\pipe_once wc")
+    mycli.packages.special.write_once(u"hello world")
+    mycli.packages.special.unset_pipe_once_if_written()
+    # how to assert on wc output?
+
+
 def test_parseargfile():
     """Test that parseargfile expands the user directory."""
     expected = {'file': os.path.join(os.path.expanduser('~'), 'filename'),


### PR DESCRIPTION
## Description
Add a `\pipe_once` special command, alias `\|`, which is modeled on `\once` but sends output to a subprocess.  Any output from the subprocess is presented after the query results.

One usecase I had in mind is creating gists:

```
mysql root@localhost:(none)> \| gist; show databases;
Time: 0.003s

+--------------------+
| Database           |
|--------------------|
| information_schema |
| mysql              |
| performance_schema |
+--------------------+
3 rows in set
Time: 0.011s
https://gist.github.com/0b9e651d00562ad527b0d4a765dcc292
mysql root@localhost:(none)>
```

The `command` argument is parsed with `shlex`, so options may be passed as well, example `\| gist -f filename.tsv`.

If the idea is acceptable I will happily work on tests.  So far I do not have the test suite fully operational.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
