### PR TITLE
Add \clip special command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Features:
 
 * Add an option `--init-command` to execute SQL after connecting (Thanks: [KITAGAWA Yasutaka]).
 * Use InputMode.REPLACE_SINGLE
+* Add a `\clip` special command to copy queries to the system clipboard.
 
 Bug Fixes:
 ----------

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -78,6 +78,7 @@ Contributors:
   * bitkeen
   * Morgan Mitchell
   * Massimiliano Torromeo
+  * Roland Walker
 
 Creator:
 --------

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -8,6 +8,7 @@ from io import open
 from time import sleep
 
 import click
+import pyperclip
 import sqlparse
 
 from . import export
@@ -157,6 +158,47 @@ def open_external_editor(filename=None, sql=None):
         query = sql
 
     return (query, message)
+
+
+@export
+def clip_command(command):
+    """Is this a clip command?
+
+    :param command: string
+
+    """
+    # It is possible to have `\clip` or `SELECT * FROM \clip`. So we check
+    # for both conditions.
+    return command.strip().endswith('\\clip') or command.strip().startswith('\\clip')
+
+
+@export
+def get_clip_query(sql):
+    """Get the query part of a clip command."""
+    sql = sql.strip()
+
+    # The reason we can't simply do .strip('\clip') is that it strips characters,
+    # not a substring. So it'll strip "c" in the end of the sql also!
+    pattern = re.compile('(^\\\clip|\\\clip$)')
+    while pattern.search(sql):
+        sql = pattern.sub('', sql)
+
+    return sql
+
+
+@export
+def copy_query_to_clipboard(sql=None):
+    """Send query to the clipboard."""
+
+    sql = sql or ''
+    message = None
+
+    try:
+        pyperclip.copy(u'{sql}'.format(sql=sql))
+    except RuntimeError as e:
+        message = 'Error clipping query: %s.' % e.strerror
+
+    return message
 
 
 @special_command('\\f', '\\f [name [args..]]', 'List or execute favorite queries.', arg_type=PARSED_QUERY, case_sensitive=True)

--- a/mycli/packages/special/main.py
+++ b/mycli/packages/special/main.py
@@ -112,6 +112,8 @@ def quit(*_args):
 
 @special_command('\\e', '\\e', 'Edit command with editor (uses $EDITOR).',
                  arg_type=NO_QUERY, case_sensitive=True)
+@special_command('\\clip', '\\clip', 'Copy query to the system clipboard.',
+                 arg_type=NO_QUERY, case_sensitive=True)
 @special_command('\\G', '\\G', 'Display current query results vertically.',
                  arg_type=NO_QUERY, case_sensitive=True)
 def stub():

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ install_requirements = [
     'configobj >= 5.0.5',
     'cryptography >= 1.0.0',
     'cli_helpers[styles] >= 2.0.1',
+    'pyperclip >= 1.8.1'
 ]
 
 

--- a/test/features/fixture_data/help_commands.txt
+++ b/test/features/fixture_data/help_commands.txt
@@ -2,6 +2,7 @@
 | Command     | Shortcut                   | Description                                                |
 +-------------+----------------------------+------------------------------------------------------------+
 | \G          | \G                         | Display current query results vertically.                  |
+| \clip       | \clip                      | Copy query to the system clipboard.                        |
 | \dt         | \dt[+] [table]             | List or describe tables.                                   |
 | \e          | \e                         | Edit command with editor (uses $EDITOR).                   |
 | \f          | \f [name [args..]]         | List or execute favorite queries.                          |


### PR DESCRIPTION
## Description

A limitation of prompt-toolkit is that it [wraps the query text, making copy/paste difficult](https://github.com/prompt-toolkit/python-prompt-toolkit/issues/493#issuecomment-398894847).

But that can be worked around in mycli with a `\clip` special command. Example usage:

```sql
\clip LONG QUERY…
```

I didn't abbreviate `\clip` to `\c`, as that might also mean `\connect`.

This adds a dependency on `pyperclip`,

## Checklist

- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
