### PR TITLE
Send diagnostic "Connecting to socket" message to STDERR

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ Bug Fixes:
 ----------
 * Fixed compatibility with sqlparse 0.4 (Thanks: [mtorromeo]).
 *  Fixed iPython magic (Thanks: [mwcm]).
+* Send "Connecting to socket" message to the standard error.
 
 1.22.2
 ======

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -78,6 +78,7 @@ Contributors:
   * bitkeen
   * Morgan Mitchell
   * Massimiliano Torromeo
+  * Roland Walker
 
 Creator:
 --------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -438,7 +438,7 @@ class MyCli(object):
             if not WIN and socket:
                 socket_owner = getpwuid(os.stat(socket).st_uid).pw_name
                 self.echo(
-                    f"Connecting to socket {socket}, owned by user {socket_owner}")
+                    f"Connecting to socket {socket}, owned by user {socket_owner}", err=True)
                 try:
                     _connect()
                 except OperationalError as e:


### PR DESCRIPTION
## Description
The message `Connecting to socket {socket}…` is diagnostic in nature, and should be directed to the standard error.

Otherwise it will be captured in an invocation of the form
```
mycli --execute <query> > output.tsv
```

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
