### PR TITLE
Fix \once -o to overwrite output whole, instead of overwriting line-by-line

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ Bug Fixes:
 ----------
 * Fixed compatibility with sqlparse 0.4 (Thanks: [mtorromeo]).
 *  Fixed iPython magic (Thanks: [mwcm]).
+* Fix \once -o to overwrite output whole, instead of line-by-line.
 
 1.22.2
 ======

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -78,6 +78,7 @@ Contributors:
   * bitkeen
   * Morgan Mitchell
   * Massimiliano Torromeo
+  * Roland Walker
 
 Creator:
 --------

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -93,9 +93,8 @@ def test_once_command():
     with pytest.raises(TypeError):
         mycli.packages.special.execute(None, u"\\once")
 
-    mycli.packages.special.execute(None, u"\\once /proc/access-denied")
     with pytest.raises(OSError):
-        mycli.packages.special.write_once(u"hello world")
+        mycli.packages.special.execute(None, u"\\once /proc/access-denied")
 
     mycli.packages.special.write_once(u"hello world")  # write without file set
     with tempfile.NamedTemporaryFile() as f:
@@ -104,9 +103,10 @@ def test_once_command():
         assert f.read() == b"hello world\n"
 
         mycli.packages.special.execute(None, u"\\once -o " + f.name)
-        mycli.packages.special.write_once(u"hello world")
+        mycli.packages.special.write_once(u"hello world line 1")
+        mycli.packages.special.write_once(u"hello world line 2")
         f.seek(0)
-        assert f.read() == b"hello world\n"
+        assert f.read() == b"hello world line 1\nhello world line 2\n"
 
 
 def test_parseargfile():


### PR DESCRIPTION
## Description
Since `\once -o filename.txt` was overwriting on a line-by-line basis, `filename.txt` would only contain the last line of the result, such as 

```
+--------------------+
```

Instead the filehandle should be kept open, and the entire result sent to the open handle.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
