### PR TITLE
Prefer raw strings for regular expressions

### DIFF
--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -78,6 +78,7 @@ Contributors:
   * bitkeen
   * Morgan Mitchell
   * Massimiliano Torromeo
+  * Roland Walker
 
 Creator:
 --------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1291,7 +1291,7 @@ def is_select(status):
 def thanks_picker(files=()):
     contents = []
     for line in fileinput.input(files=files):
-        m = re.match('^ *\* (.*)', line)
+        m = re.match(r'^ *\* (.*)', line)
         if m:
             contents.append(m.group(1))
     return choice(contents)

--- a/mycli/packages/parseutils.py
+++ b/mycli/packages/parseutils.py
@@ -11,7 +11,7 @@ cleanup_regex = {
         # This matches everything except spaces, parens, colon, comma, and period
         'most_punctuations': re.compile(r'([^\.():,\s]+)$'),
         # This matches everything except a space.
-        'all_punctuations': re.compile('([^\s]+)$'),
+        'all_punctuations': re.compile(r'([^\s]+)$'),
         }
 
 def last_word(text, include='alphanum_underscore'):

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -115,7 +115,7 @@ def get_editor_query(sql):
     # The reason we can't simply do .strip('\e') is that it strips characters,
     # not a substring. So it'll strip "e" in the end of the sql also!
     # Ex: "select * from style\e" -> "select * from styl".
-    pattern = re.compile('(^\\\e|\\\e$)')
+    pattern = re.compile(r'(^\\e|\\e$)')
     while pattern.search(sql):
         sql = pattern.sub('', sql)
 


### PR DESCRIPTION
## Description
Raw strings are better for regular expressions; fewer backslashes are needed.

Arguably the whole codebase could be made clearer by replacing non-regex strings like `'\\u'` with `r'\u'`.

## Checklist
- [ ] I've added this contribution to the `changelog.md`. (so minor I did not)
- [x] I've added my name to the `AUTHORS` file (or it's already there).
