### PR TITLE
Respect empty string value for prompt_continuation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ Bug Fixes:
 ----------
 * Fixed compatibility with sqlparse 0.4 (Thanks: [mtorromeo]).
 *  Fixed iPython magic (Thanks: [mwcm]).
+* Respect `prompt_continuation = ''` in `.myclirc`
 
 1.22.2
 ======

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -78,6 +78,7 @@ Contributors:
   * bitkeen
   * Morgan Mitchell
   * Massimiliano Torromeo
+  * Roland Walker
 
 Creator:
 --------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -551,7 +551,9 @@ class MyCli(object):
             return [('class:prompt', prompt)]
 
         def get_continuation(width, *_):
-            if self.multiline_continuation_char:
+            if self.multiline_continuation_char == '':
+                continuation = ''
+            elif self.multiline_continuation_char:
                 left_padding = width - len(self.multiline_continuation_char)
                 continuation = " " * \
                     max((left_padding - 1), 0) + \


### PR DESCRIPTION
## Description
When `.myclirc` contains
```
prompt_continuation = ''
```

then the continuation string should be the empty string, as specified, not a single space.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
