### PR TITLE
Allow fine-grained customization of Pygments SQL highlighting styles

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Features:
 
 * Add an option `--init-command` to execute SQL after connecting (Thanks: [KITAGAWA Yasutaka]).
 * Use InputMode.REPLACE_SINGLE
+* Allow customization of Pygments SQL syntax-highlighting styles.
 
 Bug Fixes:
 ----------

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -78,6 +78,7 @@ Contributors:
   * bitkeen
   * Morgan Mitchell
   * Massimiliano Torromeo
+  * Roland Walker
 
 Creator:
 --------

--- a/mycli/clistyle.py
+++ b/mycli/clistyle.py
@@ -44,6 +44,36 @@ PROMPT_STYLE_TO_TOKEN = {
     v: k for k, v in TOKEN_TO_PROMPT_STYLE.items()
 }
 
+# all tokens that the Pygments MySQL lexer can produce
+OVERRIDE_STYLE_TO_TOKEN = {
+    'sql.comment': Token.Comment,
+    'sql.comment.multi-line': Token.Comment.Multiline,
+    'sql.comment.single-line': Token.Comment.Single,
+    'sql.comment.optimizer-hint': Token.Comment.Special,
+    'sql.escape': Token.Error,
+    'sql.keyword': Token.Keyword,
+    'sql.datatype': Token.Keyword.Type,
+    'sql.literal': Token.Literal,
+    'sql.literal.date': Token.Literal.Date,
+    'sql.symbol': Token.Name,
+    'sql.quoted-schema-object': Token.Name.Quoted,
+    'sql.quoted-schema-object.escape': Token.Name.Quoted.Escape,
+    'sql.constant': Token.Name.Constant,
+    'sql.function': Token.Name.Function,
+    'sql.variable': Token.Name.Variable,
+    'sql.number': Token.Number,
+    'sql.number.binary': Token.Number.Bin,
+    'sql.number.float': Token.Number.Float,
+    'sql.number.hex': Token.Number.Hex,
+    'sql.number.integer': Token.Number.Integer,
+    'sql.operator': Token.Operator,
+    'sql.punctuation': Token.Punctuation,
+    'sql.string': Token.String,
+    'sql.string.double-quouted': Token.String.Double,
+    'sql.string.escape': Token.String.Escape,
+    'sql.string.single-quoted': Token.String.Single,
+    'sql.whitespace': Token.Text,
+}
 
 def parse_pygments_style(token_name, style_object, style_dict):
     """Parse token type and style string.
@@ -107,6 +137,9 @@ def style_factory_output(name, cli_style):
             style.update({token_type: style_value})
         elif token in PROMPT_STYLE_TO_TOKEN:
             token_type = PROMPT_STYLE_TO_TOKEN[token]
+            style.update({token_type: cli_style[token]})
+        elif token in OVERRIDE_STYLE_TO_TOKEN:
+            token_type = OVERRIDE_STYLE_TO_TOKEN[token]
             style.update({token_type: cli_style[token]})
         else:
             # TODO: cli helpers will have to switch to ptk.Style

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -41,6 +41,7 @@ table_format = ascii
 # friendly, monokai, paraiso, colorful, murphy, bw, pastie, paraiso, trac, default,
 # fruity.
 # Screenshots at http://mycli.net/syntax
+# Can be further modified in [colors]
 syntax_style = default
 
 # Keybindings: Possible values: emacs, vi.
@@ -112,6 +113,35 @@ output.header = "#00ff5f bold"
 output.odd-row = ""
 output.even-row = ""
 output.null = "#808080"
+
+# SQL syntax highlighting overrides
+# sql.comment = 'italic #408080'
+# sql.comment.multi-line = ''
+# sql.comment.single-line = ''
+# sql.comment.optimizer-hint = ''
+# sql.escape = 'border:#FF0000'
+# sql.keyword = 'bold #008000'
+# sql.datatype = 'nobold #B00040'
+# sql.literal = ''
+# sql.literal.date = ''
+# sql.symbol = ''
+# sql.quoted-schema-object = ''
+# sql.quoted-schema-object.escape = ''
+# sql.constant = '#880000'
+# sql.function = '#0000FF'
+# sql.variable = '#19177C'
+# sql.number = '#666666'
+# sql.number.binary = ''
+# sql.number.float = ''
+# sql.number.hex = ''
+# sql.number.integer = ''
+# sql.operator = '#666666'
+# sql.punctuation = ''
+# sql.string = '#BA2121'
+# sql.string.double-quouted = ''
+# sql.string.escape = 'bold #BB6622'
+# sql.string.single-quoted = ''
+# sql.whitespace = ''
 
 # Favorite queries.
 [favorite_queries]


### PR DESCRIPTION
## Description
Allows individual customization of each syntax-highlighting face that the Pygments MySQL lexer can produce.

Doesn't change any behavior by default.  The user would have to add/enable entries in `~/.myclirc`.

Populates the template `~/.myclirc` with commented-out entries matching `syntax_style = default`.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
