### PR TITLE
Support ANSI escape sequences in the prompt

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Features:
 
 * Add an option `--init-command` to execute SQL after connecting (Thanks: [KITAGAWA Yasutaka]).
 * Use InputMode.REPLACE_SINGLE
+* Add support for ANSI escape sequences for coloring the prompt.
 
 Bug Fixes:
 ----------

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -78,6 +78,7 @@ Contributors:
   * bitkeen
   * Morgan Mitchell
   * Massimiliano Torromeo
+  * Roland Walker
 
 Creator:
 --------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -28,6 +28,7 @@ from prompt_toolkit.key_binding.bindings.named_commands import register as promp
 from prompt_toolkit.shortcuts import PromptSession, CompleteStyle
 from prompt_toolkit.document import Document
 from prompt_toolkit.filters import HasFocus, IsDone
+from prompt_toolkit.formatted_text import ANSI
 from prompt_toolkit.layout.processors import (HighlightMatchingBracketProcessor,
                                               ConditionalProcessor)
 from prompt_toolkit.lexers import PygmentsLexer
@@ -548,7 +549,8 @@ class MyCli(object):
             prompt = self.get_prompt(self.prompt_format)
             if self.prompt_format == self.default_prompt and len(prompt) > self.max_len_prompt:
                 prompt = self.get_prompt('\\d> ')
-            return [('class:prompt', prompt)]
+            prompt = prompt.replace("\\x1b", "\x1b")
+            return ANSI(prompt)
 
         def get_continuation(width, *_):
             if self.multiline_continuation_char:

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -65,6 +65,7 @@ wider_completion_menu = False
 # \t - Product type (Percona, MySQL, MariaDB)
 # \A - DSN alias name (from the [alias_dsn] section)
 # \u - Username
+# \x1b[...m - insert ANSI escape sequence
 prompt = '\t \u@\h:\d> '
 prompt_continuation = '->'
 


### PR DESCRIPTION
## Description
A port of https://github.com/dbcli/pgcli/pull/1122, allowing colors and styles in the prompt via escape sequences.
xref #894

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
