### PR TITLE
Make Alt-Enter context-sensitive, depending on multi-line or single-line mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Bug Fixes:
 Features:
 ---------
 * Add `-g` shortcut to option `--login-path`.
+* Alt-Enter dispatches the command in multi-line mode.
 
 Internal:
 ---------

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -78,8 +78,12 @@ def mycli_bindings(mycli):
 
     @kb.add('escape', 'enter')
     def _(event):
-        """Introduces a line break regardless of multi-line mode or not."""
+        """Introduces a line break in multi-line mode, or dispatches the
+        command in single-line mode."""
         _logger.debug('Detected alt-enter key.')
-        event.app.current_buffer.insert_text('\n')
+        if mycli.multi_line:
+            event.app.current_buffer.validate_and_handle()
+        else:
+            event.app.current_buffer.insert_text('\n')
 
     return kb


### PR DESCRIPTION
## Description

xref #748

Make <kbd>Alt-Enter</kbd> context-sensitive, inserting a linefeed in single-line mode, but dispatching the command in multi-line mode.

In short, <kbd>Alt-Enter</kbd> mostly inverts the expected action of <kbd>Enter</kbd>.

Motivation: I can't find another way to dispatch a command like
```
SELECT * from TABLE WHERE \e
```
in multi-line mode.

Also, make <kbd>Control-j</kbd> unconditionally insert linefeed in Emacs mode.  Rationale: preserves an easy "unconditional insert" feature.  Happy to remove this part, which may be debatable. Edit: and, the Control-j binding may break the assumptions of the test suite.

Note that it was always possible to unconditionally insert linefeeds via quoted-insert (Emacs mode <kbd>Control-q</kbd> <kbd>Control-j</kbd>, Vi mode <kbd>Control-v</kbd> <kbd>Control-j</kbd>).

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
