### PR TITLE
Quieten test suite warnings

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -482,7 +482,7 @@ class MyCli(object):
             exit(1)
 
     def handle_editor_command(self, text):
-        """Editor command is any query that is prefixed or suffixed by a '\e'.
+        r"""Editor command is any query that is prefixed or suffixed by a '\e'.
         The reason for a while loop is because a user might edit a query
         multiple times. For eg:
 
@@ -513,7 +513,7 @@ class MyCli(object):
         return text
 
     def handle_clip_command(self, text):
-        """A clip command is any query that is prefixed or suffixed by a
+        r"""A clip command is any query that is prefixed or suffixed by a
         '\clip'.
 
         :param text: Document

--- a/mycli/packages/parseutils.py
+++ b/mycli/packages/parseutils.py
@@ -15,7 +15,7 @@ cleanup_regex = {
         }
 
 def last_word(text, include='alphanum_underscore'):
-    """
+    r"""
     Find the last word in a sentence.
 
     >>> last_word('abc')

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -181,7 +181,7 @@ def get_clip_query(sql):
 
     # The reason we can't simply do .strip('\clip') is that it strips characters,
     # not a substring. So it'll strip "c" in the end of the sql also!
-    pattern = re.compile('(^\\\clip|\\\clip$)')
+    pattern = re.compile(r'(^\\clip|\\clip$)')
     while pattern.search(sql):
         sql = pattern.sub('', sql)
 
@@ -257,7 +257,7 @@ def subst_favorite_query_args(query, args):
 
         query = query.replace(subst_var, val)
 
-    match = re.search('\\$\d+', query)
+    match = re.search(r'\$\d+', query)
     if match:
         return[None, 'missing substitution for ' + match.group(0) + ' in query:\n  ' + query]
 

--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -59,7 +59,7 @@ class SQLCompleter(Completer):
         self.reserved_words = set()
         for x in self.keywords:
             self.reserved_words.update(x.split())
-        self.name_pattern = compile("^[_a-z][_a-z0-9\$]*$")
+        self.name_pattern = compile(r"^[_a-z][_a-z0-9\$]*$")
 
         self.special_commands = []
         self.table_formats = supported_formats

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,7 +4,7 @@ from .utils import (HOST, USER, PASSWORD, PORT, CHARSET, create_db,
 import mycli.sqlexecute
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def connection():
     create_db('_test_db')
     connection = db_connection('_test_db')

--- a/test/test_sqlexecute.py
+++ b/test/test_sqlexecute.py
@@ -166,7 +166,7 @@ def test_favorite_query_expanded_output(executor):
     results = run(executor, "\\fs test-ae select * from test")
     assert_result_equal(results, status='Saved.')
 
-    results = run(executor, "\\f test-ae \G")
+    results = run(executor, "\\f test-ae \\G")
     assert is_expanded_output() is True
     assert_result_equal(results, title='> select * from test',
                         headers=['a'], rows=[('abc',)], auto_status=False)


### PR DESCRIPTION
## Description
Quieten test suite warnings
 * more careful backslash escapes/raw strings
 * use `@pytest.fixture()` instead of `@pytest.yield_fixture()`

## Checklist
- [ ] I've added this contribution to the `changelog.md`. (internal-facing: no need)
- [x] I've added my name to the `AUTHORS` file (or it's already there).
