### PR TITLE
Make the test suite respect the $PYTEST_PORT environment variable

### DIFF
--- a/test/features/db_utils.py
+++ b/test/features/db_utils.py
@@ -1,11 +1,12 @@
 import pymysql
 
 
-def create_db(hostname='localhost', username=None, password=None,
-              dbname=None):
+def create_db(hostname='localhost', port=3306, username=None,
+              password=None, dbname=None):
     """Create test database.
 
     :param hostname: string
+    :param port: int
     :param username: string
     :param password: string
     :param dbname: string
@@ -14,6 +15,7 @@ def create_db(hostname='localhost', username=None, password=None,
     """
     cn = pymysql.connect(
         host=hostname,
+        port=port,
         user=username,
         password=password,
         charset='utf8mb4',
@@ -26,14 +28,15 @@ def create_db(hostname='localhost', username=None, password=None,
 
     cn.close()
 
-    cn = create_cn(hostname, password, username, dbname)
+    cn = create_cn(hostname, port, password, username, dbname)
     return cn
 
 
-def create_cn(hostname, password, username, dbname):
+def create_cn(hostname, port, password, username, dbname):
     """Open connection to database.
 
     :param hostname:
+    :param port:
     :param password:
     :param username:
     :param dbname: string
@@ -42,6 +45,7 @@ def create_cn(hostname, password, username, dbname):
     """
     cn = pymysql.connect(
         host=hostname,
+        port=port,
         user=username,
         password=password,
         db=dbname,
@@ -52,11 +56,12 @@ def create_cn(hostname, password, username, dbname):
     return cn
 
 
-def drop_db(hostname='localhost', username=None, password=None,
-            dbname=None):
+def drop_db(hostname='localhost', port=3306, username=None,
+            password=None, dbname=None):
     """Drop database.
 
     :param hostname: string
+    :param port: int
     :param username: string
     :param password: string
     :param dbname: string
@@ -64,6 +69,7 @@ def drop_db(hostname='localhost', username=None, password=None,
     """
     cn = pymysql.connect(
         host=hostname,
+        port=port,
         user=username,
         password=password,
         db=dbname,

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -42,6 +42,10 @@ def before_all(context):
             'my_test_host',
             os.getenv('PYTEST_HOST', 'localhost')
         ),
+        'port': context.config.userdata.get(
+            'my_test_port',
+            int(os.getenv('PYTEST_PORT', '3306'))
+        ),
         'user': context.config.userdata.get(
             'my_test_user',
             os.getenv('PYTEST_USER', 'root')
@@ -72,7 +76,8 @@ def before_all(context):
     context.conf['myclirc'] = os.path.join(context.package_root, 'test',
                                            'myclirc')
 
-    context.cn = dbutils.create_db(context.conf['host'], context.conf['user'],
+    context.cn = dbutils.create_db(context.conf['host'], context.conf['port'],
+                                   context.conf['user'],
                                    context.conf['pass'],
                                    context.conf['dbname'])
 
@@ -82,8 +87,9 @@ def before_all(context):
 def after_all(context):
     """Unset env parameters."""
     dbutils.close_cn(context.cn)
-    dbutils.drop_db(context.conf['host'], context.conf['user'],
-                    context.conf['pass'], context.conf['dbname'])
+    dbutils.drop_db(context.conf['host'], context.conf['port'],
+                    context.conf['user'], context.conf['pass'],
+                    context.conf['dbname'])
 
     # Restore env vars.
     #for k, v in context.pgenv.items():


### PR DESCRIPTION
## Description

This was already documented in [CONTRIBUTING.md](https://github.com/dbcli/mycli/blob/RW/respect-pytest-port/CONTRIBUTING.md#test-database-credentials), but did not work.  It would be needed in order to use a [`services:` stanza](https://github.com/dbcli/pgcli/pull/1231/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR16) in GitHub Actions to start the MySQL service.

xref #927.

## Checklist

- ~[ ] I've added this contribution to the `changelog.md`.~ (no need, internal-facing)
- [x] I've added my name to the `AUTHORS` file (or it's already there).
