### PR TITLE
Stop editor test from creating file "select"

### DIFF
--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -49,7 +49,8 @@ def test_editor_command():
     assert mycli.packages.special.get_filename(r'\e filename') == "filename"
 
     os.environ['EDITOR'] = 'true'
-    mycli.packages.special.open_external_editor(r'select 1') == "select 1"
+    os.environ['VISUAL'] = 'true'
+    mycli.packages.special.open_external_editor(sql=r'select 1') == "select 1"
 
 
 def test_tee_command():


### PR DESCRIPTION
 
## Description
 * `open_external_editor()` was ignoring the `$EDITOR` environment variable when `$VISUAL` was set
 * the "select" in "select 1" was interpreted as a filename when the string was passed as a positional parameter

So, when `$VISUAL` was set, the editor was opened on a file named `select`, which may create the file, depending on the editor.

## Checklist

- ~[ ] I've added this contribution to the `changelog.md`.~ (no need, internal-facing)
- [x] I've added my name to the `AUTHORS` file (or it's already there).
