### PR TITLE
Restore file test/myclirc from repository after test writes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ class test(TestCommand):
             'behave test/features ' + self.behave_args,
             shell=True
         )
+        subprocess.run(['git', 'checkout', '--', 'test/myclirc'], check=False)
         sys.exit(unit_test_errno or cli_errno)
 
 


### PR DESCRIPTION
## Description

This test
 https://github.com/dbcli/mycli/blob/4517f49efdcc167a672bce9fdb922bb7224ce5f5/test/test_special_iocommands.py#L83-L90

writes to `test/myclirc`, leaving it "modified" in the worktree, according to `git status`, after the test suite is run.

We can simply check out a fresh copy of the file after running the tests.  If the `git` executable is not present, or the code is not in a checked-out repository, the command will silently fail.

## Checklist
- ~[ ] I've added this contribution to the `changelog.md`.~ (no need, internal-facing)
- [x] I've added my name to the `AUTHORS` file (or it's already there).
