### PR TITLE
Restore working local --socket=<UDS>

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ Bug Fixes:
 * Send "Connecting to socket" message to the standard error.
 * Respect empty string for prompt_continuation via `prompt_continuation = ''` in `.myclirc`
 * Fix \once -o to overwrite output whole, instead of line-by-line.
+* Restore working local `--socket=<UDS>` (Thanks: [xeron]).
 
 1.22.2
 ======
@@ -801,3 +802,4 @@ Bug Fixes:
 [laixintao]: https://github.com/laixintao
 [mtorromeo]: https://github.com/mtorromeo
 [mwcm]: https://github.com/mwcm
+[xeron]: https://github.com/xeron

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -79,6 +79,7 @@ Contributors:
   * Morgan Mitchell
   * Massimiliano Torromeo
   * Roland Walker
+  * xeron
 
 Creator:
 --------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -388,7 +388,7 @@ class MyCli(object):
 
         database = database or cnf['database']
         # Socket interface not supported for SSH connections
-        if port or host or ssh_host or ssh_port:
+        if (port and host) or (ssh_host and ssh_port):
             socket = ''
         else:
             socket = socket or cnf['socket'] or guess_socket_location()


### PR DESCRIPTION
## Description
Native SSH support broke local socket support, fixed by @xeron [here](https://github.com/macports/macports-ports/pull/8671).

Fixes #887.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added xeron's name to the `AUTHORS` file (or it's already there).
