### PR TITLE
Stop test suite commands from leaking into user history

### DIFF
--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -18,6 +18,7 @@ def before_all(context):
     os.environ['EDITOR'] = 'ex'
     os.environ['LC_ALL'] = 'en_US.UTF-8'
     os.environ['PROMPT_TOOLKIT_NO_CPR'] = '1'
+    os.environ['MYCLI_HISTFILE'] = os.devnull
 
     test_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
     login_path_file = os.path.join(test_dir, 'mylogin.cnf')


### PR DESCRIPTION
## Description
Test suite commands were cluttering up `~/.mycli-history`, which is not nice.

## Checklist
- ~[ ] I've added this contribution to the `changelog.md`.~ (no need, internal-facing change)
- [x] I've added my name to the `AUTHORS` file (or it's already there).
