### PR TITLE
Add Python 3.9 and "on: pull_request" stanza to CI spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,7 @@
 name: mycli
 
 on:
-  push:
-    branches-ignore:
-      - 'master'
+  pull_request:
     paths-ignore:
       - '**.md'
 
@@ -14,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
 
@@ -48,10 +46,8 @@ jobs:
           ./setup.py test --pytest-args="--cov-report= --cov=mycli"
 
       - name: Lint
-        env:
-          GIT_BRANCH: ${{ github.ref }}
         run: |
-          ./setup.py lint --branch="$GIT_BRANCH"
+          ./setup.py lint --branch=HEAD
 
       - name: Coverage
         run: |


### PR DESCRIPTION
## Description
Add Python 3.9 to CI, ~~and originate the PR from my personal fork, to additionally find out whether CI fires correctly on that event.~~

Testing showed that CI wouldn't run without the "on: pull_request" stanza, also added in this PR.

(I don't understand why GitHub seems to require both "on-push" and "on-pull_request" events.  It seems wasteful.)

## Checklist
- ~[ ] I've added this contribution to the `changelog.md`.~ (no need, internal-facing)
- [x] I've added my name to the `AUTHORS` file (or it's already there).
