### PR TITLE
Allow backtick quoting around the database argument to the `use` command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@ Bug Fixes:
 * Fix \once -o to overwrite output whole, instead of line-by-line.
 * Dispatch lines ending with `\e` or `\clip` on return, even in multiline mode.
 * Restore working local `--socket=<UDS>` (Thanks: [xeron]).
+* Allow backtick quoting around the database argument to the `use` command.
 
 1.22.2
 ======

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -239,6 +239,9 @@ class MyCli(object):
             )
             return
 
+        if arg.startswith('`') and arg.endswith('`'):
+            arg = re.sub(r'^`(.*)`$', r'\1', arg)
+            arg = re.sub(r'``', r'`', arg)
         self.sqlexecute.change_db(arg)
 
         yield (None, None, None, 'You are now connected to database "%s" as '

--- a/test/features/crud_database.feature
+++ b/test/features/crud_database.feature
@@ -16,6 +16,10 @@ Feature: manipulate databases:
       when we connect to dbserver
       then we see database connected
 
+  Scenario: connect and disconnect from quoted test database
+     When we connect to quoted test database
+      then we see database connected
+
   Scenario: create and drop default database
      When we create database
       then we see database created

--- a/test/features/steps/crud_database.py
+++ b/test/features/steps/crud_database.py
@@ -37,6 +37,14 @@ def step_db_connect_test(context):
     context.cli.sendline('use {0};'.format(db_name))
 
 
+@when('we connect to quoted test database')
+def step_db_connect_quoted_tmp(context):
+    """Send connect to database."""
+    db_name = context.conf['dbname']
+    context.currentdb = db_name
+    context.cli.sendline('use `{0}`;'.format(db_name))
+
+
 @when('we connect to tmp database')
 def step_db_connect_tmp(context):
     """Send connect to database."""


### PR DESCRIPTION
## Description

This quoting form should be legal:
```
use `database`;
```

Fixes #901.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
