### PR TITLE
Avoid open('/dev/tty') until absolutely necessary

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@ Bug Fixes:
 * Fix \once -o to overwrite output whole, instead of line-by-line.
 * Dispatch lines ending with `\e` or `\clip` on return, even in multiline mode.
 * Restore working local `--socket=<UDS>` (Thanks: [xeron]).
+* Avoid opening `/dev/tty` when `--no-warn` is given.
 
 1.22.2
 ======


### PR DESCRIPTION
## Description
In #899, a user is unable to run a non-interactive command, because `mycli` attempts to open `/dev/tty` in a situation where it is not available.

Setting `sys.stdin` looks like a shady thing to do anyway.

This PR defers `sys.stdin = open('/dev/tty')` until we are certain that interaction with the user is needed. `--warn` must be on, and the query being considered must contain destructive statements.  `is_destructive()` ends up being called twice in the destructive case, which I think is no big deal.

I believe that the code being replaced had a bug, in that `confirm_destructive_query()` could have been `None` in addition to `False`.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
