### PR TITLE
Allow --host without --port to make TCP connection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,11 @@
-TBD
+1.23.1
+===
+
+Bug Fixes:
+----------
+* Allow `--host` without `--port` to make a TCP connection.
+
+1.23.0
 ===
 
 Features:

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -391,7 +391,7 @@ class MyCli(object):
 
         database = database or cnf['database']
         # Socket interface not supported for SSH connections
-        if (port and host) or (ssh_host and ssh_port):
+        if port or (host and host != 'localhost') or (ssh_host and ssh_port):
             socket = ''
         else:
             socket = socket or cnf['socket'] or guess_socket_location()


### PR DESCRIPTION
## Description

Bugfix:  using `--host` was requiring using `--port` as well.  Fixes #941.

This makes us closer to what the official `mysql` CLI client accepts, and fixes the immediate issue.

However, we could do better: for example, an informative message when incompatible `--socket` and `--port` are mixed.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
