### PR TITLE
Fix printf-style format string

### DIFF
--- a/mycli/config.py
+++ b/mycli/config.py
@@ -244,7 +244,7 @@ def str_to_bool(s):
     elif s.lower() in false_values:
         return False
     else:
-        raise ValueError('not a recognized boolean value: %s'.format(s))
+        raise ValueError('not a recognized boolean value: {0}'.format(s))
 
 
 def strip_matching_quotes(s):


### PR DESCRIPTION
## Description
A printf-style format string was mistakenly used.

## Checklist
- [ ] ~I've added this contribution to the `changelog.md`.~ no need
- [x] I've added my name to the `AUTHORS` file (or it's already there).
