### PR TITLE
test host-port argument combinations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Pytest / behave
         env:
           PYTEST_PASSWORD: root
+          PYTEST_HOST: 127.0.0.1
         run: |
           ./setup.py test --pytest-args="--cov-report= --cov=mycli"
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+TODO
+====
+
+Internal:
+---------
+
+* Test various host-port combinations in command line arguments
+
+
 1.23.2
 ===
 

--- a/test/features/connection.feature
+++ b/test/features/connection.feature
@@ -1,0 +1,23 @@
+Feature: connect to a database:
+
+  @requires_local_db
+  Scenario: run mycli on localhost without port
+    When we run mycli with arguments "host=localhost" without arguments "port"
+      When we query "status"
+      Then status contains "via UNIX socket"
+
+  Scenario: run mycli on TCP host without port
+    When we run mycli without arguments "port"
+      When we query "status"
+      Then status contains "via TCP/IP"
+
+  Scenario: run mycli with port but without host
+    When we run mycli without arguments "host"
+      When we query "status"
+      Then status contains "via TCP/IP"
+
+  @requires_local_db
+  Scenario: run mycli without host and port
+    When we run mycli without arguments "host port"
+      When we query "status"
+      Then status contains "via UNIX socket"

--- a/test/features/steps/auto_vertical.py
+++ b/test/features/steps/auto_vertical.py
@@ -3,11 +3,12 @@ from textwrap import dedent
 from behave import then, when
 
 import wrappers
+from utils import parse_cli_args_to_dict
 
 
 @when('we run dbcli with {arg}')
 def step_run_cli_with_arg(context, arg):
-    wrappers.run_cli(context, run_args=arg.split('='))
+    wrappers.run_cli(context, run_args=parse_cli_args_to_dict(arg))
 
 
 @when('we execute a small query')

--- a/test/features/steps/connection.py
+++ b/test/features/steps/connection.py
@@ -1,0 +1,27 @@
+import shlex
+from behave import when, then
+
+import wrappers
+from test.features.steps.utils import parse_cli_args_to_dict
+
+
+@when('we run mycli with arguments "{exact_args}" without arguments "{excluded_args}"')
+@when('we run mycli without arguments "{excluded_args}"')
+def step_run_cli_without_args(context, excluded_args, exact_args=''):
+    wrappers.run_cli(
+        context,
+        run_args=parse_cli_args_to_dict(exact_args),
+        exclude_args=parse_cli_args_to_dict(excluded_args).keys()
+    )
+
+
+@then('status contains "{expression}"')
+def status_contains(context, expression):
+    wrappers.expect_exact(context, f'{expression}', timeout=5)
+
+    # Normally, the shutdown after scenario waits for the prompt.
+    # But we may have changed the prompt, depending on parameters,
+    # so let's wait for its last character
+    context.cli.expect_exact('>')
+    context.atprompt = True
+

--- a/test/features/steps/utils.py
+++ b/test/features/steps/utils.py
@@ -1,0 +1,12 @@
+import shlex
+
+
+def parse_cli_args_to_dict(cli_args: str):
+    args_dict = {}
+    for arg in shlex.split(cli_args):
+        if '=' in arg:
+            key, value = arg.split('=')
+            args_dict[key] = value
+        else:
+            args_dict[arg] = None
+    return args_dict

--- a/test/features/steps/wrappers.py
+++ b/test/features/steps/wrappers.py
@@ -3,6 +3,7 @@ import pexpect
 import sys
 import textwrap
 
+
 try:
     from StringIO import StringIO
 except ImportError:
@@ -46,21 +47,41 @@ def expect_pager(context, expected, timeout):
         context.conf['pager_boundary'], expected), timeout=timeout)
 
 
-def run_cli(context, run_args=None):
+def run_cli(context, run_args=None, exclude_args=None):
     """Run the process using pexpect."""
-    run_args = run_args or []
-    if context.conf.get('host', None):
-        run_args.extend(('-h', context.conf['host']))
-    if context.conf.get('user', None):
-        run_args.extend(('-u', context.conf['user']))
-    if context.conf.get('pass', None):
-        run_args.extend(('-p', context.conf['pass']))
-    if context.conf.get('dbname', None):
-        run_args.extend(('-D', context.conf['dbname']))
-    if context.conf.get('defaults-file', None):
-        run_args.extend(('--defaults-file', context.conf['defaults-file']))
-    if context.conf.get('myclirc', None):
-        run_args.extend(('--myclirc', context.conf['myclirc']))
+    run_args = run_args or {}
+    rendered_args = []
+    exclude_args = set(exclude_args) if exclude_args else set()
+
+    conf = dict(**context.conf)
+    conf.update(run_args)
+
+    def add_arg(name, key, value):
+        if name not in exclude_args:
+            if value is not None:
+                rendered_args.extend((key, value))
+            else:
+                rendered_args.append(key)
+
+    if conf.get('host', None):
+        add_arg('host', '-h', conf['host'])
+    if conf.get('user', None):
+        add_arg('user', '-u', conf['user'])
+    if conf.get('pass', None):
+        add_arg('pass', '-p', conf['pass'])
+    if conf.get('port', None):
+        add_arg('port', '-P', str(conf['port']))
+    if conf.get('dbname', None):
+        add_arg('dbname', '-D', conf['dbname'])
+    if conf.get('defaults-file', None):
+        add_arg('defaults_file', '--defaults-file', conf['defaults-file'])
+    if conf.get('myclirc', None):
+        add_arg('myclirc', '--myclirc', conf['myclirc'])
+
+    for arg_name, arg_value in conf.items():
+        if arg_name.startswith('-'):
+            add_arg(arg_name, arg_name, arg_value)
+
     try:
         cli_cmd = context.conf['cli_command']
     except KeyError:
@@ -73,7 +94,7 @@ def run_cli(context, run_args=None):
             '"'
         ).format(sys.executable)
 
-    cmd_parts = [cli_cmd] + run_args
+    cmd_parts = [cli_cmd] + rendered_args
     cmd = ' '.join(cmd_parts)
     context.cli = pexpect.spawnu(cmd, cwd=context.package_root)
     context.logfile = StringIO()


### PR DESCRIPTION
## Description
Added tests for combinations of `--host` and `--port`
They obviously require the database server to be installed locally, se they are marked with the tag `requires_local_db` that can be used to exclude the new tests from a run: 
```
    behave test/features --no-capture --tag="not requires_local_db"
```



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
