### PR TITLE
switch to pyaes for password decoding

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
-TODO
-====
+TBD
+===
 
 Bug Fixes:
 ----------
@@ -15,7 +15,7 @@ Internal:
 ---------
 * Remove unused function is_open_quote()
 * Test various host-port combinations in command line arguments
-
+* switched from Cryptography to pyaes for decrypting mylogin.cnf
 
 1.23.2
 ===

--- a/mycli/config.py
+++ b/mycli/config.py
@@ -9,8 +9,7 @@ import sys
 from typing import Union
 
 from configobj import ConfigObj, ConfigObjError
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-from cryptography.hazmat.backends import default_backend
+import pyaes
 
 try:
     basestring
@@ -200,11 +199,9 @@ def read_and_decrypt_mylogin_cnf(f):
             return None
     rkey = struct.pack('16B', *rkey)
 
-    # Create a decryptor object using the key.
-    decryptor = _get_decryptor(rkey)
-
     # Create a bytes buffer to hold the plaintext.
     plaintext = BytesIO()
+    aes = pyaes.AESModeOfOperationECB(rkey)
 
     while True:
         # Read the length of the ciphertext.
@@ -215,7 +212,9 @@ def read_and_decrypt_mylogin_cnf(f):
 
         # Read cipher_len bytes from the file and decrypt.
         cipher = f.read(cipher_len)
-        plain = _remove_pad(decryptor.update(cipher))
+        plain = _remove_pad(
+            b''.join([aes.decrypt(cipher[i: i + 16]) for i in range(0, cipher_len, 16)])
+        )
         if plain is False:
             continue
         plaintext.write(plain)
@@ -257,12 +256,6 @@ def strip_matching_quotes(s):
             s[0] == s[-1] and s[0] in ('"', "'")):
         s = s[1:-1]
     return s
-
-
-def _get_decryptor(key):
-    """Get the AES decryptor."""
-    c = Cipher(algorithms.AES(key), modes.ECB(), backend=default_backend())
-    return c.decryptor()
 
 
 def _remove_pad(line):

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,9 @@ install_requirements = [
     'PyMySQL >= 0.9.2',
     'sqlparse>=0.3.0,<0.4.0',
     'configobj >= 5.0.5',
-    'cryptography >= 1.0.0',
     'cli_helpers[styles] >= 2.0.1',
-    'pyperclip >= 1.8.1'
+    'pyperclip >= 1.8.1',
+    'pyaes >= 1.6.1'
 ]
 
 


### PR DESCRIPTION
## Description



removed the Cryptography dependency in favor of [pyaes](https://github.com/ricmoo/pyaes). Cryptography was used in only one place: to decrypt the `mylogin.cnf` file. 

This is a first step towards #950: Cryptography is a pain to package because it relies on a lot of data files. It can be done, but either there will be a large useless memory footprint (those files need to be loaded into ram), or it will require a lot of hacking into the guts of Cryptography to get rid of the parts we don't need. I don't think it's worth the effort. 



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
