### PR TITLE
System variables cannot be SELECTed (e.g. @@version_comment)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ TBD
 Bug Fixes:
 ----------
 * Allow `FileNotFound` exception for SSH config files.
+* Fix Unknown system variable 'VERSION_COMMENT'.
 
 Features:
 ---------
@@ -825,6 +826,7 @@ Bug Fixes:
 [Phil Cohen]: https://github.com/phlipper
 [Terseus]: https://github.com/Terseus
 [William GARCIA]: https://github.com/willgarcia
+[Jeffrey Tse]: https://github.com/jeffreytse
 [Jonathan Slenders]: https://github.com/jonathanslenders
 [Casper Langemeijer]: https://github.com/langemeijer
 [Scrappy Soft]: https://github.com/scrappysoft

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -29,6 +29,7 @@ Contributors:
   * Phil Cohen
   * spacewander
   * Adam Chainz
+  * Jeffrey Tse
   * Johannes Hoff
   * Kacper Kwapisz
   * Lennart Weller

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -26,8 +26,11 @@ class SQLExecute(object):
 
     version_query = '''SELECT @@VERSION'''
 
+    # System variables cannot be SELECTed (e.g. @@version_comment)
+    # this MySQL bug was fixed on `5.0.22`
+    # Bug #15684 https://bugs.mysql.com/bug.php?id=15684
     version_comment_query = '''SELECT @@VERSION_COMMENT'''
-    version_comment_query_mysql4 = '''SHOW VARIABLES LIKE "version_comment"'''
+    version_comment_query_alter = '''SHOW VARIABLES LIKE "version_comment"'''
 
     show_candidates_query = '''SELECT name from mysql.help_topic WHERE name like "SHOW %"'''
 
@@ -280,10 +283,10 @@ class SQLExecute(object):
             _logger.debug('Version Query. sql: %r', self.version_query)
             cur.execute(self.version_query)
             version = cur.fetchone()[0]
-            if version[0] == '4':
+            if float(version[:3]) < 5.1:
                 _logger.debug('Version Comment. sql: %r',
-                              self.version_comment_query_mysql4)
-                cur.execute(self.version_comment_query_mysql4)
+                              self.version_comment_query_alter)
+                cur.execute(self.version_comment_query_alter)
                 version_comment = cur.fetchone()[1].lower()
                 if isinstance(version_comment, bytes):
                     # with python3 this query returns bytes

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -283,6 +283,16 @@ class SQLExecute(object):
             _logger.debug('Version Query. sql: %r', self.version_query)
             cur.execute(self.version_query)
             version = cur.fetchone()[0]
+
+            # It's better to use the precise version, but we also known,
+            # there are some versions have the alpha suffix, such as
+            # 5.0.18-nt, 5.0.20a and so on, new complexity will be
+            # introduced here, so here we use an imprecise method to check
+            # and determine the way to retrieve the VERSION_COMMENT, and
+            # the alternative query is also valid for the versions like
+            # 5.0.45b and so on, only when the version is >=5.1, we use
+            # the simple `SELECT @@VERSION_COMMENT`.
+
             if float(version[:3]) < 5.1:
                 _logger.debug('Version Comment. sql: %r',
                               self.version_comment_query_alter)


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Exactly, this MySQL bug was fixed on `5.0.22` [Bug #15684](https://bugs.mysql.com/bug.php?id=15684), otherwise we will catch an exception 1193, "Unknown system variable 'VERSION_COMMENT'")

This PR has fixed the issue #957.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
