### PR TITLE
when opening a file for execution, use the same encoding as in the da…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ TBD
 Bug Fixes:
 ----------
 * Allow `FileNotFound` exception for SSH config files.
+* When opening files for execution, use the same encoding as in the database connection
 
 Features:
 ---------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -257,7 +257,7 @@ class MyCli(object):
             message = 'Missing required argument, filename.'
             return [(None, None, None, message)]
         try:
-            with open(os.path.expanduser(arg)) as f:
+            with open(os.path.expanduser(arg), encoding=self.sqlexecute.charset) as f:
                 query = f.read()
         except IOError as e:
             return [(None, None, None, str(e))]


### PR DESCRIPTION
…tabase connector

## Description
Fixes #953 


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
