### PR TITLE
remove unused function is_open_quote()

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,10 @@ Features:
 ---------
 * Add `-g` shortcut to option `--login-path`.
 
+Internal:
+---------
+* Remove unused function is_open_quote()
+
 
 1.23.2
 ===

--- a/mycli/clibuffer.py
+++ b/mycli/clibuffer.py
@@ -1,7 +1,6 @@
 from prompt_toolkit.enums import DEFAULT_BUFFER
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.application import get_app
-from .packages.parseutils import is_open_quote
 from .packages import special
 
 

--- a/mycli/packages/parseutils.py
+++ b/mycli/packages/parseutils.py
@@ -226,14 +226,6 @@ def is_destructive(queries):
     return False
 
 
-def is_open_quote(sql):
-    """Returns true if the query contains an unclosed quote."""
-
-    # parsed can contain one or more semi-colon separated commands
-    parsed = sqlparse.parse(sql)
-    return any(_parsed_is_open_quote(p) for p in parsed)
-
-
 if __name__ == '__main__':
     sql = 'select * from (select t. from tabl t'
     print (extract_tables(sql))


### PR DESCRIPTION
## Description
is_open_quote is a pgcli rudiment: there it is used to detect semicolons inside PL/pgSQL function definitions, but mycli handles it with the delimiter command. The function also did not work, see #907 :)



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
