### PR TITLE
Ignore the paramiko_stub file while collecting pytests.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ignore=mycli/packages/paramiko_stub/__init__.py


### PR DESCRIPTION
## Description
Ignore the paramiko_stub file while collecting pytests.