### PR TITLE
Check error code, not message for OperationalError

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ TBD
 Bug Fixes:
 ----------
 * Allow `FileNotFound` exception for SSH config files.
+* Check error code rather than message for Access Denied error
 
 Features:
 ---------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -43,7 +43,7 @@ from .packages.special.favoritequeries import FavoriteQueries
 from .sqlcompleter import SQLCompleter
 from .clitoolbar import create_toolbar_tokens_func
 from .clistyle import style_factory, style_factory_output
-from .sqlexecute import FIELD_TYPES, SQLExecute
+from .sqlexecute import FIELD_TYPES, SQLExecute, ERROR_CODE_ACCESS_DENIED
 from .clibuffer import cli_is_multiline
 from .completion_refresher import CompletionRefresher
 from .config import (write_default_config, get_mylogin_cnf_path,
@@ -432,7 +432,7 @@ class MyCli(object):
                     ssh_password, ssh_key_filename, init_command
                 )
             except OperationalError as e:
-                if ('Access denied for user' in e.args[1]):
+                if e.args[0] == ERROR_CODE_ACCESS_DENIED:
                     new_passwd = click.prompt('Password', hide_input=True,
                                               show_default=False, type=str, err=True)
                     self.sqlexecute = SQLExecute(

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -17,6 +17,10 @@ FIELD_TYPES.update({
     FIELD_TYPE.NULL: type(None)
 })
 
+
+ERROR_CODE_ACCESS_DENIED = 1045
+
+
 class SQLExecute(object):
 
     databases_query = '''SHOW DATABASES'''

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -21,9 +21,9 @@ FIELD_TYPES.update({
 })
 
 
-<<<<<<< HEAD
 ERROR_CODE_ACCESS_DENIED = 1045
-=======
+
+
 class ServerSpecies(enum.Enum):
     MySQL = 'MySQL'
     MariaDB = 'MariaDB'
@@ -77,7 +77,6 @@ class ServerInfo:
             return f'{self.species.value} {self.version_str}'
         else:
             return self.version_str
->>>>>>> master
 
 
 class SQLExecute(object):


### PR DESCRIPTION
## Description
We check for ACCESS_DENIED by looking at the error message of the OperationalError, but it can be translated to other languages https://dev.mysql.com/doc/refman/8.0/en/error-message-language.html. It's safer to use the error code. 



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
