### PR TITLE
fix login with ~/.my.cnf and ~/.mylogin.cnf

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Bug Fixes:
 * Allow `FileNotFound` exception for SSH config files.
 * Fix startup error on MySQL < 5.0.22
 * Check error code rather than message for Access Denied error
+* Fix login with ~/.my.cnf files
 
 Features:
 ---------

--- a/test/features/connection.feature
+++ b/test/features/connection.feature
@@ -21,3 +21,15 @@ Feature: connect to a database:
     When we run mycli without arguments "host port"
       When we query "status"
       Then status contains "via UNIX socket"
+
+  Scenario: run mycli with my.cnf configuration
+    When we create my.cnf file
+    When we run mycli without arguments "host port user pass defaults_file"
+      Then we are logged in
+
+  Scenario: run mycli with mylogin.cnf configuration
+    When we create mylogin.cnf file
+    When we run mycli with arguments "login_path=test_login_path" without arguments "host port user pass defaults_file"
+      Then we are logged in
+
+

--- a/test/features/steps/connection.py
+++ b/test/features/steps/connection.py
@@ -1,8 +1,18 @@
+import io
+import os
 import shlex
+
 from behave import when, then
+import pexpect
 
 import wrappers
 from test.features.steps.utils import parse_cli_args_to_dict
+from test.features.environment import MY_CNF_PATH, MYLOGIN_CNF_PATH, get_db_name_from_context
+from test.utils import HOST, PORT, USER, PASSWORD
+from mycli.config import encrypt_mylogin_cnf
+
+
+TEST_LOGIN_PATH = 'test_login_path'
 
 
 @when('we run mycli with arguments "{exact_args}" without arguments "{excluded_args}"')
@@ -25,3 +35,37 @@ def status_contains(context, expression):
     context.cli.expect_exact('>')
     context.atprompt = True
 
+
+@when('we create my.cnf file')
+def step_create_my_cnf_file(context):
+    my_cnf = (
+        '[client]\n'
+        f'host = {HOST}\n'
+        f'port = {PORT}\n'
+        f'user = {USER}\n'
+        f'password = {PASSWORD}\n'
+    )
+    with open(MY_CNF_PATH, 'w') as f:
+        f.write(my_cnf)
+
+
+@when('we create mylogin.cnf file')
+def step_create_mylogin_cnf_file(context):
+    os.environ.pop('MYSQL_TEST_LOGIN_FILE', None)
+    mylogin_cnf = (
+        f'[{TEST_LOGIN_PATH}]\n'
+        f'host = {HOST}\n'
+        f'port = {PORT}\n'
+        f'user = {USER}\n'
+        f'password = {PASSWORD}\n'
+    )
+    with open(MYLOGIN_CNF_PATH, 'wb') as f:
+        input_file = io.StringIO(mylogin_cnf)
+        f.write(encrypt_mylogin_cnf(input_file).read())
+
+
+@then('we are logged in')
+def we_are_logged_in(context):
+    db_name = get_db_name_from_context(context)
+    context.cli.expect_exact(f'{db_name}>', timeout=5)
+    context.atprompt = True

--- a/test/features/steps/wrappers.py
+++ b/test/features/steps/wrappers.py
@@ -14,7 +14,7 @@ def expect_exact(context, expected, timeout):
     timedout = False
     try:
         context.cli.expect_exact(expected, timeout=timeout)
-    except pexpect.exceptions.TIMEOUT:
+    except pexpect.TIMEOUT:
         timedout = True
     if timedout:
         # Strip color codes out of the output.
@@ -77,6 +77,8 @@ def run_cli(context, run_args=None, exclude_args=None):
         add_arg('defaults_file', '--defaults-file', conf['defaults-file'])
     if conf.get('myclirc', None):
         add_arg('myclirc', '--myclirc', conf['myclirc'])
+    if conf.get('login_path'):
+        add_arg('login_path', '--login-path', conf['login_path'])
 
     for arg_name, arg_value in conf.items():
         if arg_name.startswith('-'):


### PR DESCRIPTION
## Description
The login sequence is messed up: login with `~/.mylogin.cnf` is broken, and login  with `~/.my.cnf` doesn't work for some users.

~/.my.cnf issue: #897 
~/.mylogin.cnf issue: #967 


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
