### PR TITLE
Fix autocompletion fail for multiple JOINs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -43,7 +43,7 @@ Internal:
 Bug Fixes:
 ----------
 * Ensure `--port` is always an int.
- 
+
 1.23.1
 ======
 
@@ -836,32 +836,31 @@ Bug Fixes:
 ----------
 * Fixed the installation issues with PyMySQL dependency on case-sensitive file systems.
 
-[Daniel West]: http://github.com/danieljwest
-[Irina Truong]: https://github.com/j-bennet
 [Amjith Ramanujam]: https://blog.amjith.com
-[Kacper Kwapisz]: https://github.com/KKKas
-[Martijn Engler]: https://github.com/martijnengler
-[Matheus Rosa]:  https://github.com/mdsrosa
-[Shoma Suzuki]: https://github.com/shoma
-[spacewander]: https://github.com/spacewander
-[Thomas Roten]: https://github.com/tsroten
 [Artem Bezsmertnyi]: https://github.com/mrdeathless
 [Carlos Afonso]: https://github.com/afonsocarlos
-[Mikhail Borisov]: https://github.com/borman
-[Casper Langemeijer]: Casper Langemeijer
-[Lennart Weller]: https://github.com/lhw
-[Phil Cohen]: https://github.com/phlipper
-[Terseus]: https://github.com/Terseus
-[William GARCIA]: https://github.com/willgarcia
-[Jonathan Slenders]: https://github.com/jonathanslenders
 [Casper Langemeijer]: https://github.com/langemeijer
-[Scrappy Soft]: https://github.com/scrappysoft
+[Daniel West]: http://github.com/danieljwest
 [Dick Marinus]: https://github.com/meeuw
 [François Pietka]: https://github.com/fpietka
 [Frederic Aoustin]: https://github.com/fraoustin
 [Georgy Frolov]: https://github.com/pasenor
-[Zach DeCook]: https://zachdecook.com
+[Irina Truong]: https://github.com/j-bennet
+[Jonathan Slenders]: https://github.com/jonathanslenders
+[Kacper Kwapisz]: https://github.com/KKKas
 [laixintao]: https://github.com/laixintao
+[Lennart Weller]: https://github.com/lhw
+[Martijn Engler]: https://github.com/martijnengler
+[Matheus Rosa]:  https://github.com/mdsrosa
+[Mikhail Borisov]: https://github.com/borman
 [mtorromeo]: https://github.com/mtorromeo
 [mwcm]: https://github.com/mwcm
+[Phil Cohen]: https://github.com/phlipper
+[Scrappy Soft]: https://github.com/scrappysoft
+[Shoma Suzuki]: https://github.com/shoma
+[spacewander]: https://github.com/spacewander
+[Terseus]: https://github.com/Terseus
+[Thomas Roten]: https://github.com/tsroten
+[William GARCIA]: https://github.com/willgarcia
 [xeron]: https://github.com/xeron
+[Zach DeCook]: https://zachdecook.com

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,9 @@
 TBD:
 ====
 
-* 
+Bug Fixes:
+---------
+* Fix autocompletion for more than one JOIN
 
 1.24.1:
 =======
@@ -844,6 +846,7 @@ Bug Fixes:
 [spacewander]: https://github.com/spacewander
 [Thomas Roten]: https://github.com/tsroten
 [Artem Bezsmertnyi]: https://github.com/mrdeathless
+[Carlos Afonso]: https://github.com/afonsocarlos
 [Mikhail Borisov]: https://github.com/borman
 [Casper Langemeijer]: Casper Langemeijer
 [Lennart Weller]: https://github.com/lhw

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -24,6 +24,7 @@ Contributors:
   * Casper Langemeijer
   * Jonathan Slenders
   * Artem Bezsmertnyi
+  * Carlos Afonso
   * Mikhail Borisov
   * Heath Naylor
   * Phil Cohen

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -15,77 +15,77 @@ Core Developers:
 Contributors:
 -------------
 
-  * Steve Robbins
-  * Shoma Suzuki
-  * Daniel West
-  * Scrappy Soft
-  * Daniel Black
-  * Jonathan Bruno
-  * Casper Langemeijer
-  * Jonathan Slenders
-  * Artem Bezsmertnyi
-  * Carlos Afonso
-  * Mikhail Borisov
-  * Heath Naylor
-  * Phil Cohen
-  * spacewander
-  * Adam Chainz
-  * Johannes Hoff
-  * Kacper Kwapisz
-  * Lennart Weller
-  * Martijn Engler
-  * Terseus
-  * Tyler Kuipers
-  * William GARCIA
-  * Yasuhiro Matsumoto
-  * bjarnagin
-  * jbruno
-  * mrdeathless
+  * 0xflotus
   * Abirami P
-  * John Sterling
-  * Jialong Liu
-  * Zhidong
-  * Daniël van Eeden
-  * zer09
-  * cxbig
-  * chainkite
-  * Michał Górny
-  * Terje Røsten
-  * Ryan Smith
-  * Klaus Wünschel
-  * François Pietka
-  * Colin Caine
-  * Frederic Aoustin
-  * caitinggui
-  * ushuz
-  * Zhaolong Zhu
-  * Zhongyang Guan
-  * Huachao Mao
-  * QiaoHou Peng
-  * Yang Zou
-  * Angelo Lupo
+  * Adam Chainz
   * Aljosha Papsch
-  * Zane C. Bowers-Hadley
-  * Mike Palandra
+  * Andy Teijelo Pérez
+  * Angelo Lupo
+  * Artem Bezsmertnyi
+  * bitkeen
+  * bjarnagin
+  * caitinggui
+  * Carlos Afonso
+  * Casper Langemeijer
+  * chainkite
+  * Colin Caine
+  * cxbig
+  * Daniel Black
+  * Daniel West
+  * Daniël van Eeden
+  * François Pietka
+  * Frederic Aoustin
   * Georgy Frolov
-  * Jonathan Lloyd
-  * Nathan Huang
+  * Heath Naylor
+  * Huachao Mao
   * Jakub Boukal
-  * Takeshi D. Itoh
-  * laixintao
-  * Zach DeCook
+  * jbruno
+  * Jerome Provensal
+  * Jialong Liu
+  * Johannes Hoff
+  * John Sterling
+  * Jonathan Bruno
+  * Jonathan Lloyd
+  * Jonathan Slenders
+  * Kacper Kwapisz
   * kevinhwang91
   * KITAGAWA Yasutaka
-  * Nicolas Palumbo
-  * Andy Teijelo Pérez
-  * bitkeen
-  * Morgan Mitchell
+  * Klaus Wünschel
+  * laixintao
+  * Lennart Weller
+  * Martijn Engler
   * Massimiliano Torromeo
+  * Michał Górny
+  * Mike Palandra
+  * Mikhail Borisov
+  * Morgan Mitchell
+  * mrdeathless
+  * Nathan Huang
+  * Nicolas Palumbo
+  * Phil Cohen
+  * QiaoHou Peng
   * Roland Walker
-  * xeron
-  * 0xflotus
+  * Ryan Smith
+  * Scrappy Soft
   * Seamile
-  * Jerome Provensal
+  * Shoma Suzuki
+  * spacewander
+  * Steve Robbins
+  * Takeshi D. Itoh
+  * Terje Røsten
+  * Terseus
+  * Tyler Kuipers
+  * ushuz
+  * William GARCIA
+  * xeron
+  * Yang Zou
+  * Yasuhiro Matsumoto
+  * Zach DeCook
+  * Zane C. Bowers-Hadley
+  * zer09
+  * Zhaolong Zhu
+  * Zhidong
+  * Zhongyang Guan
 
 Creator:
 --------

--- a/mycli/packages/parseutils.py
+++ b/mycli/packages/parseutils.py
@@ -81,6 +81,13 @@ def extract_from_part(parsed, stop_at_punctuation=True):
                     yield x
             elif stop_at_punctuation and item.ttype is Punctuation:
                 return
+            # Multiple JOINs in the same query won't work properly since
+            # "ON" is a keyword and will trigger the next elif condition.
+            # So instead of stooping the loop when finding an "ON" skip it
+            # eg: 'SELECT * FROM abc JOIN def ON abc.id = def.abc_id JOIN ghi'
+            elif item.ttype is Keyword and item.value.upper() == 'ON':
+                tbl_prefix_seen = False
+                continue
             # An incomplete nested select won't be recognized correctly as a
             # sub-select. eg: 'SELECT * FROM (SELECT id FROM user'. This causes
             # the second FROM to trigger this elif condition resulting in a

--- a/test/test_completion_engine.py
+++ b/test/test_completion_engine.py
@@ -393,6 +393,17 @@ def test_join_using_suggests_common_columns(col_list):
          'tables': [(None, 'abc', None), (None, 'def', None)],
          'drop_unique': True}]
 
+@pytest.mark.parametrize('sql', [
+    'SELECT * FROM abc a JOIN def d ON a.id = d.id JOIN ghi g ON g.',
+    'SELECT * FROM abc a JOIN def d ON a.id = d.id AND a.id2 = d.id2 JOIN ghi g ON d.id = g.id AND g.',
+])
+def test_two_join_alias_dot_suggests_cols1(sql):
+    suggestions = suggest_type(sql, sql)
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {'type': 'column', 'tables': [(None, 'ghi', 'g')]},
+        {'type': 'table', 'schema': 'g'},
+        {'type': 'view', 'schema': 'g'},
+        {'type': 'function', 'schema': 'g'}])
 
 def test_2_statements_2nd_current():
     suggestions = suggest_type('select * from a; select * from ',


### PR DESCRIPTION
## Description
Fix #567 by ignoring the keyword **ON** when extracting SQL tables. 
The next item after ON is still not treated as a table, but query extraction doesn't stop at "ON" anymore (which is useful for multiple JOINs i.e.)



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
