### PR TITLE
deprecate python mock

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,10 @@ Bug Fixes:
 ---------
 * Restore dependency on cryptography for the interactive password prompt
 
+Internal:
+---------
+* Deprecate Python mock
+
 
 1.24.0
 ======

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-mock
 pytest!=3.3.0
 pytest-cov==2.4.0
 tox

--- a/test/test_completion_refresher.py
+++ b/test/test_completion_refresher.py
@@ -1,6 +1,6 @@
 import time
 import pytest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 
 @pytest.fixture

--- a/test/test_naive_completion.py
+++ b/test/test_naive_completion.py
@@ -11,7 +11,7 @@ def completer():
 
 @pytest.fixture
 def complete_event():
-    from mock import Mock
+    from unittest.mock import Mock
     return Mock()
 
 

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import patch
+from unittest.mock import patch
 from prompt_toolkit.completion import Completion
 from prompt_toolkit.document import Document
 import mycli.packages.special.main as special
@@ -35,7 +35,7 @@ def completer():
 
 @pytest.fixture
 def complete_event():
-    from mock import Mock
+    from unittest.mock import Mock
     return Mock()
 
 

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -2,7 +2,7 @@ import os
 import stat
 import tempfile
 from time import time
-from mock import patch
+from unittest.mock import patch
 
 import pytest
 from pymysql import ProgrammingError


### PR DESCRIPTION
## Description
Deprecate Python mock, use unittest.mock instead.

`unittest.mock` has been available since py33.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).

PS. Hello everybody! :wave: 