### PR TITLE
Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10

### DIFF
--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -85,6 +85,7 @@ Contributors:
   * 0xflotus
   * Seamile
   * Jerome Provensal
+  * Karthikeyan Singaravelan
 
 Creator:
 --------

--- a/mycli/completion_refresher.py
+++ b/mycli/completion_refresher.py
@@ -36,7 +36,7 @@ class CompletionRefresher(object):
                 target=self._bg_refresh,
                 args=(executor, callbacks, completer_options),
                 name='completion_refresh')
-            self._completer_thread.setDaemon(True)
+            self._completer_thread.daemon = True
             self._completer_thread.start()
             return [(None, None, None,
                      'Auto-completion refresh started in the background.')]


### PR DESCRIPTION
## Description

Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10. This was deprecated since Python 2 but the message was added in Python 3.10


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).

Fixes #982 
