### PR TITLE
Fix incompatibility with python-click >= 8.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9]
         include:
           - python-version: 3.6
-            os: ubuntu-16.04 # MySQL 5.7.32
+            os: ubuntu-18.04 # MySQL 5.7.32
           - python-version: 3.7
             os: ubuntu-18.04 # MySQL 5.7.32
           - python-version: 3.8

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+Internal:
+---------
+* Upgrade Ubuntu VM for runners as Github has deprecated it
+
+
 1.24.3 (2022/01/20)
 ===================
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,13 @@ Internal:
 ---------
 * Upgrade Ubuntu VM for runners as Github has deprecated it
 
+1.24.4 (2022/03/30)
+===================
+
+Bug Fixes:
+----------
+* Change in main.py - Replace the `click.get_terminal_size()` with `shutil.get_terminal_size()`
+
 
 1.24.3 (2022/01/20)
 ===================

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -87,6 +87,7 @@ Contributors:
   * Zhaolong Zhu
   * Zhidong
   * Zhongyang Guan
+  * Arvind Mishra
 
 Created by:
 -----------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from io import open
 import os
 import sys
+import shutil
 import traceback
 import logging
 import threading
@@ -1054,7 +1055,7 @@ class MyCli(object):
         """Get the number of lines to reserve for the completion menu."""
         reserved_space_ratio = .45
         max_reserved_space = 8
-        _, height = click.get_terminal_size()
+        _, height = shutil.get_terminal_size()
         return min(int(round(height * reserved_space_ratio)), max_reserved_space)
 
     def get_last_query(self):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 import click
 from click.testing import CliRunner
@@ -258,13 +259,13 @@ def test_reserved_space_is_integer():
     def stub_terminal_size():
         return (5, 5)
 
-    old_func = click.get_terminal_size
+    old_func = shutil.get_terminal_size
 
-    click.get_terminal_size = stub_terminal_size
+    shutil.get_terminal_size = stub_terminal_size
     mycli = MyCli()
     assert isinstance(mycli.get_reserved_space(), int)
 
-    click.get_terminal_size = old_func
+    shutil.get_terminal_size = old_func
 
 
 def test_list_dsn():


### PR DESCRIPTION
Fixes 1038
Fixes 1041

* Fixes for `python-click`>= 8.1.0 
* Change CI VM from 16.04 to 18.04 as Github no longer supports 16.04


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
