### PR TITLE
Add configurable beep to notify the user after long queries

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+Features:
+---------
+* Add `beep_after_seconds` option to `~/.myclirc`, to ring the terminal bell after long queries.
+
 1.24.4 (2022/03/30)
 ===================
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -138,6 +138,7 @@ class MyCli(object):
         self.multi_line = c['main'].as_bool('multi_line')
         self.key_bindings = c['main']['key_bindings']
         special.set_timing_enabled(c['main'].as_bool('timing'))
+        self.beep_after_seconds = float(c['main']['beep_after_seconds'] or 0)
 
         FavoriteQueries.instance = FavoriteQueries.from_config(self.config)
 
@@ -721,6 +722,8 @@ class MyCli(object):
                             self.output(formatted, status)
                         except KeyboardInterrupt:
                             pass
+                        if self.beep_after_seconds > 0 and t >= self.beep_after_seconds:
+                            self.echo('\a', err=True, nl=False)
                         if special.is_timing_enabled():
                             self.echo('Time: %0.03fs' % t)
                     except KeyboardInterrupt:

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -30,6 +30,9 @@ log_level = INFO
 # Timing of sql statments and table rendering.
 timing = True
 
+# Beep after long-running queries are completed; 0 to disable.
+beep_after_seconds = 0
+
 # Table format. Possible values: ascii, double, github,
 # psql, plain, simple, grid, fancy_grid, pipe, orgtbl, rst, mediawiki, html,
 # latex, latex_booktabs, textile, moinmoin, jira, vertical, tsv, csv.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Add `beep_after_seconds` option to `~/.myclirc`, defaulting to 0 (off), to ring the terminal bell after completing long queries of the configured number of seconds.

There are no additional tests.  I gave up trying to figure out how to test for output to STDERR, and my local setup is not perfect.  The `timing` option doesn't have tests either, most likely because it is nondeterministic.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
