### PR TITLE
Fix startup error with some MySQL API compatible databases.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@ Internal:
 ---------
 * Pin `cryptography` to suppress `paramiko` warning, helping CI complete and presumably affecting some users.
 
+Bug Fixes:
+----------
+* Support for some MySQL compatible databases, which may not implement connection_id().
 
 1.25.0 (2022/04/02)
 ===================

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -81,6 +81,7 @@ Contributors:
   * xeron
   * Yang Zou
   * Yasuhiro Matsumoto
+  * Yuanchun Shang
   * Zach DeCook
   * Zane C. Bowers-Hadley
   * zer09

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -739,19 +739,23 @@ class MyCli(object):
             except KeyboardInterrupt:
                 # get last connection id
                 connection_id_to_kill = sqlexecute.connection_id
-                logger.debug("connection id to kill: %r", connection_id_to_kill)
-                # Restart connection to the database
-                sqlexecute.connect()
-                try:
-                    for title, cur, headers, status in sqlexecute.run('kill %s' % connection_id_to_kill):
-                        status_str = str(status).lower()
-                        if status_str.find('ok') > -1:
-                            logger.debug("cancelled query, connection id: %r, sql: %r",
-                                         connection_id_to_kill, text)
-                            self.echo("cancelled query", err=True, fg='red')
-                except Exception as e:
-                    self.echo('Encountered error while cancelling query: {}'.format(e),
-                              err=True, fg='red')
+                # some mysql compatible databases may not implemente connection_id()
+                if connection_id_to_kill > 0:
+                    logger.debug("connection id to kill: %r", connection_id_to_kill)
+                    # Restart connection to the database
+                    sqlexecute.connect()
+                    try:
+                        for title, cur, headers, status in sqlexecute.run('kill %s' % connection_id_to_kill):
+                            status_str = str(status).lower()
+                            if status_str.find('ok') > -1:
+                                logger.debug("cancelled query, connection id: %r, sql: %r",
+                                             connection_id_to_kill, text)
+                                self.echo("cancelled query", err=True, fg='red')
+                    except Exception as e:
+                        self.echo('Encountered error while cancelling query: {}'.format(e),
+                                  err=True, fg='red')
+                else:
+                  logger.debug("Did not get a connection id, skip cancelling query")
             except NotImplementedError:
                 self.echo('Not Yet Implemented.', fg="yellow")
             except OperationalError as e:

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -338,9 +338,12 @@ class SQLExecute(object):
     def reset_connection_id(self):
         # Remember current connection id
         _logger.debug('Get current connection id')
-        res = self.run('select connection_id()')
-        for title, cur, headers, status in res:
-            self.connection_id = cur.fetchone()[0]
+        try:
+            res = self.run('select connection_id()')
+            for title, cur, headers, status in res:
+                self.connection_id = cur.fetchone()[0]
+        except Exception as e:
+            _logger.error('Failed to get connection id: %s', e)
         _logger.debug('Current connection id: %s', self.connection_id)
 
     def change_db(self, db):

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -343,6 +343,8 @@ class SQLExecute(object):
             for title, cur, headers, status in res:
                 self.connection_id = cur.fetchone()[0]
         except Exception as e:
+            # See #1054
+            self.connection_id = -1
             _logger.error('Failed to get connection id: %s', e)
         else:
             _logger.debug('Current connection id: %s', self.connection_id)

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -344,7 +344,8 @@ class SQLExecute(object):
                 self.connection_id = cur.fetchone()[0]
         except Exception as e:
             _logger.error('Failed to get connection id: %s', e)
-        _logger.debug('Current connection id: %s', self.connection_id)
+        else:
+            _logger.debug('Current connection id: %s', self.connection_id)
 
     def change_db(self, db):
         self.conn.select_db(db)


### PR DESCRIPTION
e.g. https://github.com/datafuselabs/databend which does not have connection_id().

## Description
Some MySQL compatible databases, may not implemented connection_id() function, on startup, mycli will give error and exit:
```
(1105, 'Code: 2602, displayText = Unknown Function connection_id (while in analyze select projection).')
```

But this is not a fatal error, so we can catch it and continue.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
