### PR TITLE
Pin `cryptography` to suppress Blowfish warning from `paramiko`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+Internal:
+---------
+* Pin `cryptography` to suppress `paramiko` warning, helping CI complete and presumably affecting some users.
+
+
 1.25.0 (2022/04/02)
 ===================
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,9 @@ description = 'CLI for MySQL Database. With auto-completion and syntax highlight
 
 install_requirements = [
     'click >= 7.0',
-    'cryptography >= 1.0.0',
+    # Temporary to suppress paramiko Blowfish warning which breaks CI.
+    # Pinning cryptography should not be needed after paramiko 2.11.0.
+    'cryptography == 36.0.2',
     # 'Pygments>=1.6,<=2.11.1',
     'Pygments>=1.6',
     'prompt_toolkit>=3.0.6,<4.0.0',


### PR DESCRIPTION
## Description

The paramiko warning appears to break CI.  See #1054 .


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
