### PR TITLE
Change tests to always use databases prefixed with 'mycli_' 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,67 +10,66 @@ You'll always get credit for your work.
 1. [Fork the repository](https://github.com/dbcli/mycli) on GitHub.
 
 2. Clone your fork locally:
-
-   ```bash
-   $ git clone <url-for-your-fork>
-   ```
+    ```bash
+    $ git clone <url-for-your-fork>
+    ```
 
 3. Add the official repository (`upstream`) as a remote repository:
-
-   ```bash
-   $ git remote add upstream git@github.com:dbcli/mycli.git
-   ```
+    ```bash
+    $ git remote add upstream git@github.com:dbcli/mycli.git
+    ```
 
 4. Set up a [virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs)
    for development:
 
-   ```bash
-   $ cd mycli
-   $ pip install virtualenv
-   $ virtualenv mycli_dev
-   ```
+    ```bash
+    $ cd mycli
+    $ pip install virtualenv
+    $ virtualenv mycli_dev
+    ```
 
-   We've just created a virtual environment that we'll use to install all the dependencies
-   and tools we need to work on mycli. Whenever you want to work on mycli, you
-   need to activate the virtual environment:
+    We've just created a virtual environment that we'll use to install all the dependencies
+    and tools we need to work on mycli. Whenever you want to work on mycli, you
+    need to activate the virtual environment:
 
-   ```bash
-   $ source mycli_dev/bin/activate
-   ```
+    ```bash
+    $ source mycli_dev/bin/activate
+    ```
 
-   When you're done working, you can deactivate the virtual environment:
+    When you're done working, you can deactivate the virtual environment:
 
-   ```bash
-   $ deactivate
-   ```
+    ```bash
+    $ deactivate
+    ```
 
 5. Install the dependencies and development tools:
 
-   ```bash
-   $ pip install -r requirements-dev.txt
-   $ pip install --editable .
-   ```
+    ```bash
+    $ pip install -r requirements-dev.txt
+    $ pip install --editable .
+    ```
 
 6. Create a branch for your bugfix or feature based off the `main` branch:
 
-   ```bash
-   $ git checkout -b <name-of-bugfix-or-feature> main
-   ```
+    ```bash
+    $ git checkout -b <name-of-bugfix-or-feature> main
+    ```
 
 7. While you work on your bugfix or feature, be sure to pull the latest changes from `upstream`. This ensures that your local codebase is up-to-date:
 
-   ```bash
-   $ git pull upstream main
-   ```
+    ```bash
+    $ git pull upstream main
+    ```
 
 8. When your work is ready for the mycli team to review it, push your branch to your fork:
 
-   ```bash
-   $ git push origin <name-of-bugfix-or-feature>
-   ```
+    ```bash
+    $ git push origin <name-of-bugfix-or-feature>
+    ```
 
 9. [Create a pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/)
    on GitHub.
+
 
 ## Running the Tests
 
@@ -87,6 +86,7 @@ Python by running tox:
 ```bash
 $ tox
 ```
+
 
 ### Test Database Credentials
 
@@ -121,10 +121,10 @@ In some systems (e.g. Arch Linux) `ex` is a symbolic link to `vi`, which will
 change the output and therefore make some tests fail.
 
 You can check this by running:
-
 ```bash
 $ readlink -f $(which ex)
 ```
+
 
 ## Coding Style
 
@@ -161,7 +161,7 @@ Options:
 
 To release a new version of the package:
 
-- Create and merge a PR to bump the version in the changelog ([example PR](https://github.com/dbcli/mycli/pull/1043)).
-- Pull `main` and bump the version number inside `mycli/__init__.py`. Do not check in - the release script will do that.
-- Make sure you have the dev requirements installed: `pip install -r requirements-dev.txt -U --upgrade-strategy only-if-needed`.
-- Finally, run the release script: `python release.py`.
+* Create and merge a PR to bump the version in the changelog ([example PR](https://github.com/dbcli/mycli/pull/1043)).
+* Pull `main` and bump the version number inside `mycli/__init__.py`. Do not check in - the release script will do that.
+* Make sure you have the dev requirements installed: `pip install -r requirements-dev.txt -U --upgrade-strategy only-if-needed`.
+* Finally, run the release script: `python release.py`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,66 +10,67 @@ You'll always get credit for your work.
 1. [Fork the repository](https://github.com/dbcli/mycli) on GitHub.
 
 2. Clone your fork locally:
-    ```bash
-    $ git clone <url-for-your-fork>
-    ```
+
+   ```bash
+   $ git clone <url-for-your-fork>
+   ```
 
 3. Add the official repository (`upstream`) as a remote repository:
-    ```bash
-    $ git remote add upstream git@github.com:dbcli/mycli.git
-    ```
+
+   ```bash
+   $ git remote add upstream git@github.com:dbcli/mycli.git
+   ```
 
 4. Set up a [virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs)
    for development:
 
-    ```bash
-    $ cd mycli
-    $ pip install virtualenv
-    $ virtualenv mycli_dev
-    ```
+   ```bash
+   $ cd mycli
+   $ pip install virtualenv
+   $ virtualenv mycli_dev
+   ```
 
-    We've just created a virtual environment that we'll use to install all the dependencies
-    and tools we need to work on mycli. Whenever you want to work on mycli, you
-    need to activate the virtual environment:
+   We've just created a virtual environment that we'll use to install all the dependencies
+   and tools we need to work on mycli. Whenever you want to work on mycli, you
+   need to activate the virtual environment:
 
-    ```bash
-    $ source mycli_dev/bin/activate
-    ```
+   ```bash
+   $ source mycli_dev/bin/activate
+   ```
 
-    When you're done working, you can deactivate the virtual environment:
+   When you're done working, you can deactivate the virtual environment:
 
-    ```bash
-    $ deactivate
-    ```
+   ```bash
+   $ deactivate
+   ```
 
 5. Install the dependencies and development tools:
 
-    ```bash
-    $ pip install -r requirements-dev.txt
-    $ pip install --editable .
-    ```
+   ```bash
+   $ pip install -r requirements-dev.txt
+   $ pip install --editable .
+   ```
 
 6. Create a branch for your bugfix or feature based off the `main` branch:
 
-    ```bash
-    $ git checkout -b <name-of-bugfix-or-feature> main
-    ```
+   ```bash
+   $ git checkout -b <name-of-bugfix-or-feature> main
+   ```
 
 7. While you work on your bugfix or feature, be sure to pull the latest changes from `upstream`. This ensures that your local codebase is up-to-date:
 
-    ```bash
-    $ git pull upstream main
-    ```
+   ```bash
+   $ git pull upstream main
+   ```
 
 8. When your work is ready for the mycli team to review it, push your branch to your fork:
 
-    ```bash
-    $ git push origin <name-of-bugfix-or-feature>
-    ```
+   ```bash
+   $ git push origin <name-of-bugfix-or-feature>
+   ```
 
 9. [Create a pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/)
    on GitHub.
-
 
 ## Running the Tests
 
@@ -87,7 +88,6 @@ Python by running tox:
 $ tox
 ```
 
-
 ### Test Database Credentials
 
 The tests require a database connection to work. You can tell the tests which
@@ -95,7 +95,7 @@ credentials to use by setting the applicable environment variables:
 
 ```bash
 $ export PYTEST_HOST=localhost
-$ export PYTEST_USER=user
+$ export PYTEST_USER=mycli
 $ export PYTEST_PASSWORD=myclirocks
 $ export PYTEST_PORT=3306
 $ export PYTEST_CHARSET=utf8
@@ -104,6 +104,14 @@ $ export PYTEST_CHARSET=utf8
 The default values are `localhost`, `root`, no password, `3306`, and `utf8`.
 You only need to set the values that differ from the defaults.
 
+If you would like to run the tests as a user with only the necessary privileges,
+create a `mycli` user and run the following grant statements.
+
+```sql
+GRANT ALL PRIVILEGES ON `mycli_%`.* TO 'mycli'@'localhost';
+GRANT SELECT ON mysql.* TO 'mycli'@'localhost';
+GRANT SELECT ON performance_schema.* TO 'mycli'@'localhost';
+```
 
 ### CLI Tests
 
@@ -113,10 +121,10 @@ In some systems (e.g. Arch Linux) `ex` is a symbolic link to `vi`, which will
 change the output and therefore make some tests fail.
 
 You can check this by running:
+
 ```bash
 $ readlink -f $(which ex)
 ```
-
 
 ## Coding Style
 
@@ -153,7 +161,7 @@ Options:
 
 To release a new version of the package:
 
-* Create and merge a PR to bump the version in the changelog ([example PR](https://github.com/dbcli/mycli/pull/1043)).
-* Pull `main` and bump the version number inside `mycli/__init__.py`. Do not check in - the release script will do that.
-* Make sure you have the dev requirements installed: `pip install -r requirements-dev.txt -U --upgrade-strategy only-if-needed`.
-* Finally, run the release script: `python release.py`.
+- Create and merge a PR to bump the version in the changelog ([example PR](https://github.com/dbcli/mycli/pull/1043)).
+- Pull `main` and bump the version number inside `mycli/__init__.py`. Do not check in - the release script will do that.
+- Make sure you have the dev requirements installed: `pip install -r requirements-dev.txt -U --upgrade-strategy only-if-needed`.
+- Finally, run the release script: `python release.py`.

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,13 @@
 Internal:
 ---------
 * Pin `cryptography` to suppress `paramiko` warning, helping CI complete and presumably affecting some users.
+* Upgrade some dev requirements
+* Change tests to always use databases prefixed with 'mycli_' for better security
 
 Bug Fixes:
 ----------
 * Support for some MySQL compatible databases, which may not implement connection_id().
+* Fix the status command to work with missing 'Flush_commands' (mariadb)
 
 1.25.0 (2022/04/02)
 ===================

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -89,6 +89,7 @@ Contributors:
   * Zhidong
   * Zhongyang Guan
   * Arvind Mishra
+  * Kevin Schmeichel
 
 Created by:
 -----------

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -34,6 +34,7 @@ def list_tables(cur, arg=None, arg_type=PARSED_QUERY, verbose=False):
 
     return [(None, tables, headers, status)]
 
+
 @special_command('\\l', '\\l', 'List databases.', arg_type=RAW_QUERY, case_sensitive=True)
 def list_databases(cur, **_):
     query = 'SHOW DATABASES'
@@ -44,6 +45,7 @@ def list_databases(cur, **_):
         return [(None, cur, headers, '')]
     else:
         return [(None, None, None, '')]
+
 
 @special_command('status', '\\s', 'Get status information from the server.',
                  arg_type=RAW_QUERY, aliases=('\\s', ), case_sensitive=True)
@@ -146,7 +148,8 @@ def status(cur, **_):
             stats.append('Queries: {0}'.format(status['Queries']))
         stats.append('Slow queries: {0}'.format(status['Slow_queries']))
         stats.append('Opens: {0}'.format(status['Opened_tables']))
-        stats.append('Flush tables: {0}'.format(status['Flush_commands']))
+        if 'Flush_commands' in status:
+            stats.append('Flush tables: {0}'.format(status['Flush_commands']))
         stats.append('Open tables: {0}'.format(status['Open_tables']))
         if 'Queries' in status:
             queries_per_second = int(status['Queries']) / int(status['Uptime'])

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,6 @@ colorama>=0.4.1
 git+https://github.com/hayd/pep8radius.git  # --error-status option not released
 click>=7.0
 paramiko==2.7.1
+pyperclip>=1.8.1
+importlib_resources>=5.0.0
+pyaes>=1.6.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ autopep8==1.3.3
 colorama>=0.4.1
 git+https://github.com/hayd/pep8radius.git  # --error-status option not released
 click>=7.0
-paramiko==2.7.1
+paramiko==2.11.0
 pyperclip>=1.8.1
 importlib_resources>=5.0.0
 pyaes>=1.6.1

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,8 +6,8 @@ import mycli.sqlexecute
 
 @pytest.fixture(scope="function")
 def connection():
-    create_db('_test_db')
-    connection = db_connection('_test_db')
+    create_db('mycli_test_db')
+    connection = db_connection('mycli_test_db')
     yield connection
 
     connection.close()
@@ -22,7 +22,7 @@ def cursor(connection):
 @pytest.fixture
 def executor(connection):
     return mycli.sqlexecute.SQLExecute(
-        database='_test_db', user=USER,
+        database='mycli_test_db', user=USER,
         host=HOST, password=PASSWORD, port=PORT, socket=None, charset=CHARSET,
         local_infile=False, ssl=None, ssh_user=SSH_USER, ssh_host=SSH_HOST,
         ssh_port=SSH_PORT, ssh_password=None, ssh_key_filename=None

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -25,7 +25,7 @@ os.environ['MYSQL_TEST_LOGIN_FILE'] = login_path_file
 CLI_ARGS = ['--user', USER, '--host', HOST, '--port', PORT,
             '--password', PASSWORD, '--myclirc', default_config_file,
             '--defaults-file', default_config_file,
-            '_test_db']
+            'mycli_test_db']
 
 
 @dbtest
@@ -305,19 +305,25 @@ def test_dsn(monkeypatch):
     # Setup classes to mock mycli.main.MyCli
     class Formatter:
         format_name = None
+
     class Logger:
         def debug(self, *args, **args_dict):
             pass
+
         def warning(self, *args, **args_dict):
             pass
+
     class MockMyCli:
         config = {'alias_dsn': {}}
+
         def __init__(self, **args):
             self.logger = Logger()
             self.destructive_warning = False
             self.formatter = Formatter()
+
         def connect(self, **args):
             MockMyCli.connect_args = args
+
         def run_query(self, query, new_line=True):
             pass
 

--- a/test/test_sqlexecute.py
+++ b/test/test_sqlexecute.py
@@ -71,7 +71,7 @@ def test_table_and_columns_query(executor):
 @dbtest
 def test_database_list(executor):
     databases = executor.databases()
-    assert '_test_db' in databases
+    assert 'mycli_test_db' in databases
 
 
 @dbtest

--- a/test/utils.py
+++ b/test/utils.py
@@ -41,8 +41,8 @@ dbtest = pytest.mark.skipif(
 def create_db(dbname):
     with db_connection().cursor() as cur:
         try:
-            cur.execute('''DROP DATABASE IF EXISTS _test_db''')
-            cur.execute('''CREATE DATABASE _test_db''')
+            cur.execute('''DROP DATABASE IF EXISTS mycli_test_db''')
+            cur.execute('''CREATE DATABASE mycli_test_db''')
         except:
             pass
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
* Upgrade some dev requirements
* Fix the status command to work with missing 'Flush_commands' (#1056)
* Change tests to always use databases prefixed with 'mycli_' (#1013)
## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
