### PR TITLE
docs: Fix a few typos

### DIFF
--- a/mycli/completion_refresher.py
+++ b/mycli/completion_refresher.py
@@ -47,7 +47,7 @@ class CompletionRefresher(object):
     def _bg_refresh(self, sqlexecute, callbacks, completer_options):
         completer = SQLCompleter(**completer_options)
 
-        # Create a new pgexecute method to popoulate the completions.
+        # Create a new pgexecute method to populate the completions.
         e = sqlexecute
         executor = SQLExecute(e.dbname, e.user, e.password, e.host, e.port,
                               e.socket, e.charset, e.local_infile, e.ssl,

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -447,7 +447,7 @@ class MyCli(object):
         if not any(v for v in ssl.values()):
             ssl = None
 
-        # if the passwd is not specfied try to set it using the password_file option
+        # if the passwd is not specified try to set it using the password_file option
         password_from_file = self.get_password_from_file(password_file)
         passwd = passwd or password_from_file
 


### PR DESCRIPTION
There are small typos in:
- mycli/completion_refresher.py
- mycli/main.py

Fixes:
- Should read `specified` rather than `specfied`.
- Should read `populate` rather than `popoulate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md