### PR TITLE
Add cli flag --ssl to enable ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ $ sudo apt-get install mycli # Only on debian or ubuntu
       --ssh-config-host TEXT        Host to connect to ssh server reading from ssh
                                     configuration.
 
+      --ssl                         Enable SSL for connection (automatically
+                                    enabled with other flags).
       --ssl-ca PATH                 CA file in PEM format.
       --ssl-capath TEXT             CA directory.
       --ssl-cert PATH               X509 cert in PEM format.

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 TBD
 ===
 
+Features:
+---------
+* Add `--ssl` flag to enable ssl/tls.
+
 Internal:
 ---------
 * Pin `cryptography` to suppress `paramiko` warning, helping CI complete and presumably affecting some users.

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -92,6 +92,7 @@ Contributors:
   * Zhongyang Guan
   * Arvind Mishra
   * Kevin Schmeichel
+  * Mel Dafert
 
 Created by:
 -----------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1089,6 +1089,8 @@ class MyCli(object):
 @click.option('--ssh-config-path', help='Path to ssh configuration.',
               default=os.path.expanduser('~') + '/.ssh/config')
 @click.option('--ssh-config-host', help='Host to connect to ssh server reading from ssh configuration.')
+@click.option('--ssl', 'ssl_enable', is_flag=True,
+        help='Enable SSL for connection (automatically enabled with other flags).')
 @click.option('--ssl-ca', help='CA file in PEM format.',
               type=click.Path(exists=True))
 @click.option('--ssl-capath', help='CA directory.')
@@ -1147,7 +1149,7 @@ class MyCli(object):
 def cli(database, user, host, port, socket, password, dbname,
         version, verbose, prompt, logfile, defaults_group_suffix,
         defaults_file, login_path, auto_vertical_output, local_infile,
-        ssl_ca, ssl_capath, ssl_cert, ssl_key, ssl_cipher,
+        ssl_enable, ssl_ca, ssl_capath, ssl_cert, ssl_key, ssl_cipher,
         ssl_verify_server_cert, table, csv, warn, execute, myclirc, dsn,
         list_dsn, ssh_user, ssh_host, ssh_port, ssh_password,
         ssh_key_filename, list_ssh_config, ssh_config_path, ssh_config_host,
@@ -1202,6 +1204,7 @@ def cli(database, user, host, port, socket, password, dbname,
     database = dbname or database
 
     ssl = {
+            'enable': ssl_enable,
             'ca': ssl_ca and os.path.expanduser(ssl_ca),
             'cert': ssl_cert and os.path.expanduser(ssl_cert),
             'key': ssl_key and os.path.expanduser(ssl_key),


### PR DESCRIPTION
## Description
The vanilla mysql client has a `--ssl` flag to enable ssl/tls without any other options.
This makes it possible to connect to servers that do not allow plaintext without needing to specify other options.

I needed this because I was trying to connect to a server with TLSv1.3.
It did not allow plaintext, so it failed when I didn't pass any options.
I tried using `--ssl-cipher=TLSv1.3`, but that failed with `('No cipher can be selected.',)`.
It worked if I downgraded to `--ssl-cipher=TLSv1.2`, however that was using a more insecure cipher than necessary.

It turns out `--ssl-cipher` does not work at all with TLSv1.3. The option is passed on to [SSLContext.set_ciphers()](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.set_ciphers), which notes that "TLS 1.3 cipher suites cannot be disabled with set_ciphers().", explaining the error.

Only after reading the code I figured out that passing any of the `--ssl-...` flags to mycli will enable ssl, so in my case `--ssl-verify-server-cert` would also have worked. However, that is rather unintuitive, and might not work if the server's hostname is not configured correctly. Having a separate flag like the vanilla mysql client does makes more sense here.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
