### PR TITLE
Add `pager` option to `~/.myclirc`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 TBD
 ===
 
+Features:
+---------
+* Add `pager` option to `~/.myclirc`, for instance `pager = 'pspg --csv'` (Thanks: [BuonOmo])
+
 Internal:
 ---------
 * Pin `cryptography` to suppress `paramiko` warning, helping CI complete and presumably affecting some users.
@@ -890,6 +894,7 @@ Bug Fixes:
 
 [Amjith Ramanujam]: https://blog.amjith.com
 [Artem Bezsmertnyi]: https://github.com/mrdeathless
+[BuonOmo]: https://github.com/BuonOmo
 [Carlos Afonso]: https://github.com/afonsocarlos
 [Casper Langemeijer]: https://github.com/langemeijer
 [Daniel West]: http://github.com/danieljwest

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -24,6 +24,7 @@ Contributors:
   * Artem Bezsmertnyi
   * bitkeen
   * bjarnagin
+  * BuonOmo
   * caitinggui
   * Carlos Afonso
   * Casper Langemeijer

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -938,8 +938,9 @@ class MyCli(object):
             os.environ['LESS'] = '-RXF'
 
         cnf = self.read_my_cnf_files(self.cnf_files, ['pager', 'skip-pager'])
-        if cnf['pager']:
-            special.set_pager(cnf['pager'])
+        cnf_pager = cnf['pager'] or self.config['main']['pager']
+        if cnf_pager:
+            special.set_pager(cnf_pager)
             self.explicit_pager = True
         else:
             self.explicit_pager = False

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -89,6 +89,9 @@ keyword_casing = auto
 # disabled pager on startup
 enable_pager = True
 
+# Choose a specific pager
+pager = 'less'
+
 # Custom colors for the completion menu, toolbar, etc.
 [colors]
 completion-menu.completion.current = 'bg:#ffffff #000000'


### PR DESCRIPTION
## Description

Allow user to set a specific pager without the need of a `PAGER` env variable. Fixes https://github.com/dbcli/mycli/issues/881



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
