### PR TITLE
Prettify / unprettify current statement using sqlglot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,8 @@ jobs:
   linux:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         include:
-          - python-version: 3.6
-            os: ubuntu-18.04 # MySQL 5.7.32
           - python-version: 3.7
             os: ubuntu-18.04 # MySQL 5.7.32
           - python-version: 3.8

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Features
 * Log every query and its results to a file (disabled by default).
 * Pretty prints tabular data (with colors!)
 * Support for SSL connections
+* Some features are only exposed as [key bindings](doc/key_bindings.rst)
 
 Contributions:
 --------------
@@ -219,7 +220,7 @@ Thanks to [PyMysql](https://github.com/PyMySQL/PyMySQL) for a pure python adapte
 
 ### Compatibility
 
-Mycli is tested on macOS and Linux.
+Mycli is tested on macOS and Linux, and requires Python 3.7 or better.
 
 **Mycli is not tested on Windows**, but the libraries used in this app are Windows-compatible.
 This means it should work without any modifications. If you're unable to run it

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ Features:
 
 * Add `--ssl` flag to enable ssl/tls.
 * Add `pager` option to `~/.myclirc`, for instance `pager = 'pspg --csv'` (Thanks: [BuonOmo])
+* Add prettify/unprettify keybindings to format the current statement using `sqlglot`.
 
 
 Internal:

--- a/doc/key_bindings.rst
+++ b/doc/key_bindings.rst
@@ -1,0 +1,65 @@
+*************
+Key Bindings:
+*************
+
+Most key bindings are simply inherited from `prompt-toolkit <https://python-prompt-toolkit.readthedocs.io/en/master/index.html>`_ .
+
+The following key bindings are special to mycli:
+
+###
+F2
+###
+
+Enable/Disable SmartCompletion Mode.
+
+###
+F3
+###
+
+Enable/Disable Multiline Mode.
+
+###
+F4
+###
+
+Toggle between Vi and Emacs mode.
+
+###
+Tab
+###
+
+Force autocompletion at cursor.
+
+#######
+C-space
+#######
+
+Initialize autocompletion at cursor.
+
+If the autocompletion menu is not showing, display it with the appropriate completions for the context.
+
+If the menu is showing, select the next completion.
+
+#########
+ESC Enter
+#########
+
+Introduce a line break in multi-line mode, or dispatch the command in single-line mode.
+
+The sequence ESC-Enter is often sent by Alt-Enter.
+
+#################################
+C-x p (Emacs-mode) or > (Vi-mode)
+#################################
+
+Prettify and indent current statement, usually into multiple lines.
+
+Only accepts buffers containing single SQL statements.
+
+#################################
+C-x u (Emacs-mode) or < (Vi-mode)
+#################################
+
+Unprettify and dedent current statement, usually into one line.
+
+Only accepts buffers containing single SQL statements.

--- a/mycli/clitoolbar.py
+++ b/mycli/clitoolbar.py
@@ -30,6 +30,11 @@ def create_toolbar_tokens_func(mycli, show_fish_help):
                 'Vi-mode ({})'.format(_get_vi_mode())
             ))
 
+        if mycli.toolbar_error_message:
+            result.append(
+                ('class:bottom-toolbar', '  ' + mycli.toolbar_error_message))
+            mycli.toolbar_error_message = None
+
         if show_fish_help():
             result.append(
                 ('class:bottom-toolbar', '  Right-arrow to complete suggestion'))

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -1,6 +1,6 @@
 import logging
 from prompt_toolkit.enums import EditingMode
-from prompt_toolkit.filters import completion_is_selected
+from prompt_toolkit.filters import completion_is_selected, emacs_mode, vi_mode
 from prompt_toolkit.key_binding import KeyBindings
 
 _logger = logging.getLogger(__name__)
@@ -60,6 +60,48 @@ def mycli_bindings(mycli):
             b.complete_next()
         else:
             b.start_completion(select_first=False)
+
+    @kb.add('>', filter=vi_mode)
+    @kb.add('c-x', 'p', filter=emacs_mode)
+    def _(event):
+        """
+        Prettify and indent current statement, usually into multiple lines.
+
+        Only accepts buffers containing single SQL statements.
+        """
+        _logger.debug('Detected <C-x p>/> key.')
+
+        b = event.app.current_buffer
+        cursorpos_relative = b.cursor_position / len(b.text)
+        pretty_text = mycli.handle_prettify_binding(b.text)
+        if len(pretty_text) > 0:
+            b.text = pretty_text
+            cursorpos_abs = int(round(cursorpos_relative * len(b.text)))
+            while 0 < cursorpos_abs < len(b.text) \
+                  and b.text[cursorpos_abs] in (' ', '\n'):
+                cursorpos_abs -= 1
+            b.cursor_position = min(cursorpos_abs, len(b.text))
+
+    @kb.add('<', filter=vi_mode)
+    @kb.add('c-x', 'u', filter=emacs_mode)
+    def _(event):
+        """
+        Unprettify and dedent current statement, usually into one line.
+
+        Only accepts buffers containing single SQL statements.
+        """
+        _logger.debug('Detected <C-x u>/< key.')
+
+        b = event.app.current_buffer
+        cursorpos_relative = b.cursor_position / len(b.text)
+        unpretty_text = mycli.handle_unprettify_binding(b.text)
+        if len(unpretty_text) > 0:
+            b.text = unpretty_text
+            cursorpos_abs = int(round(cursorpos_relative * len(b.text)))
+            while 0 < cursorpos_abs < len(b.text) \
+                  and b.text[cursorpos_abs] in (' ', '\n'):
+                cursorpos_abs -= 1
+            b.cursor_position = min(cursorpos_abs, len(b.text))
 
     @kb.add('enter', filter=completion_is_selected)
     def _(event):

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -724,7 +724,7 @@ class MyCli(object):
                         except KeyboardInterrupt:
                             pass
                         if self.beep_after_seconds > 0 and t >= self.beep_after_seconds:
-                            self.echo('\a', err=True, nl=False)
+                            self.bell()
                         if special.is_timing_enabled():
                             self.echo('Time: %0.03fs' % t)
                     except KeyboardInterrupt:
@@ -864,6 +864,11 @@ class MyCli(object):
         """
         self.log_output(s)
         click.secho(s, **kwargs)
+
+    def bell(self):
+        """Print a bell on the stderr.
+        """
+        click.secho('\a', err=True, nl=False)
 
     def get_output_margin(self, status=None):
         """Get the output margin (number of rows for the prompt, footer and

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,4 @@ paramiko==2.11.0
 pyperclip>=1.8.1
 importlib_resources>=5.0.0
 pyaes>=1.6.1
+sqlglot>=5.1.3

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ install_requirements = [
     'prompt_toolkit>=3.0.6,<4.0.0',
     'PyMySQL >= 0.9.2',
     'sqlparse>=0.3.0,<0.5.0',
+    'sqlglot>=5.1.3',
     'configobj >= 5.0.5',
     'cli_helpers[styles] >= 2.2.1',
     'pyperclip >= 1.8.1',

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -283,6 +283,20 @@ def test_list_dsn():
         assert result.output == "test : mysql://test/test\n"
 
 
+def test_prettify_statement():
+    statement = 'SELECT 1'
+    m = MyCli()
+    pretty_statement = m.handle_prettify_binding(statement)
+    assert pretty_statement == 'SELECT\n    1;'
+
+
+def test_unprettify_statement():
+    statement = 'SELECT\n    1'
+    m = MyCli()
+    unpretty_statement = m.handle_unprettify_binding(statement)
+    assert unpretty_statement == 'SELECT 1;'
+
+
 def test_list_ssh_config():
     runner = CliRunner()
     with NamedTemporaryFile(mode="w") as ssh_config:


### PR DESCRIPTION
## Description
Using https://github.com/tobymao/sqlglot, prettify the current statement, almost always on to multiple lines, or un-prettify the statement, collapsing onto a single line.

This is something I would use *all the time*!  I knew how to take it this far.  Some things I didn't know how to do:
 * ~give an informative feedback message on failure~ Solved
 * ~create vi bindings~ Solved
 * ~test coverage (got lost here on my most recent PR and gave up)~ Solved

~There's no documentation yet pending approval of this direction.~ Solved

If there is more than one statement in the buffer, we neither prettify nor unprettify but ~give a beep.~ give a transient message in the toolbar.

There is some attempt to find an appropriate cursor position in the reformatted buffer but of course that is difficult to do perfectly.  One would need the cooperation of the parser.

This introduces a dependency on sqlglot, when we already have a dependency on sqlparse.   But sqlglot is a more capable reader and is being more actively maintained.  We should not be bothered by the dependency; we should look into shifting more functionality to sqlglot.

Edit: In order to bring in the sqlglot dependency, we need to drop support for Python 3.6, per discussion below.  We should also add 3.10 to CI in a separate PR.

Demo

https://user-images.githubusercontent.com/727482/187200145-4b2d745a-dc38-469a-8323-276e820a268a.mov


## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
