### PR TITLE
Better handle some elementary edge cases in un/prettify

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,14 @@
 
-1.26.1 (2022/09/01)
+TBD
 ===
+
+Bug Fixes:
+----------
+* better handle empty statements in un/prettify
+
+
+1.26.1 (2022/09/01)
+===================
 
 Bug Fixes:
 ----------

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -72,7 +72,7 @@ def mycli_bindings(mycli):
         _logger.debug('Detected <C-x p>/> key.')
 
         b = event.app.current_buffer
-        cursorpos_relative = b.cursor_position / len(b.text)
+        cursorpos_relative = b.cursor_position / max(1, len(b.text))
         pretty_text = mycli.handle_prettify_binding(b.text)
         if len(pretty_text) > 0:
             b.text = pretty_text
@@ -93,7 +93,7 @@ def mycli_bindings(mycli):
         _logger.debug('Detected <C-x u>/< key.')
 
         b = event.app.current_buffer
-        cursorpos_relative = b.cursor_position / len(b.text)
+        cursorpos_relative = b.cursor_position / max(1, len(b.text))
         unpretty_text = mycli.handle_unprettify_binding(b.text)
         if len(unpretty_text) > 0:
             b.text = unpretty_text

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -589,7 +589,7 @@ class MyCli(object):
             statements = sqlglot.parse(text, read='mysql')
         except Exception as e:
             statements = []
-        if len(statements) == 1:
+        if len(statements) == 1 and statements[0]:
             pretty_text = statements[0].sql(pretty=True, pad=4, dialect='mysql')
         else:
             pretty_text = ''
@@ -603,7 +603,7 @@ class MyCli(object):
             statements = sqlglot.parse(text, read='mysql')
         except Exception as e:
             statements = []
-        if len(statements) == 1:
+        if len(statements) == 1 and statements[0]:
             unpretty_text = statements[0].sql(pretty=False, dialect='mysql')
         else:
             unpretty_text = ''


### PR DESCRIPTION
## Description
* `sqlglot` parse()` might return an array of a single `None`
* don't divide by `len()` of the current statement if it is zero!  Should have been caught.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
