### PR TITLE
Honor \G when executing from commandline with -e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,12 @@ jobs:
   linux:
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: [
+        '3.7',
+        '3.8',
+        '3.9',
+        '3.10',
+        ]
         include:
           - python-version: '3.7'
             os: ubuntu-18.04  # MySQL 5.7.32
@@ -61,4 +66,3 @@ jobs:
         run: |
           coverage combine
           coverage report
-          codecov

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ TBD
 Bug Fixes:
 ----------
 * better handle empty statements in un/prettify
+* honor `\G` when executing from commandline with `-e`
 
 
 1.26.1 (2022/09/01)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1038,7 +1038,7 @@ class MyCli(object):
         for result in results:
             title, cur, headers, status = result
             self.formatter.query = query
-            output = self.format_output(title, cur, headers)
+            output = self.format_output(title, cur, headers, special.is_expanded_output())
             for line in output:
                 click.echo(line, nl=new_line)
 
@@ -1331,7 +1331,12 @@ def cli(database, user, host, port, socket, password, dbname,
         try:
             if csv:
                 mycli.formatter.format_name = 'csv'
-            elif not table:
+                if execute.endswith(r'\G'):
+                    execute = execute[:-2]
+            elif table:
+                if execute.endswith(r'\G'):
+                    execute = execute[:-2]
+            else:
                 mycli.formatter.format_name = 'tsv'
 
             mycli.run_query(execute)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,6 @@ twine>=1.12.1
 behave>=1.2.4
 pexpect>=3.3
 coverage>=5.0.4
-codecov>=2.0.9
 autopep8==1.3.3
 colorama>=0.4.1
 git+https://github.com/hayd/pep8radius.git  # --error-status option not released

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -326,7 +326,7 @@ def test_auto_escaped_col_names(completer, complete_event):
         Completion(text='`ABC`', start_position=0),
     ] + \
         list(map(Completion, completer.functions)) + \
-        [Completion(text='`select`', start_position=0)] + \
+        [Completion(text='select', start_position=0)] + \
         list(map(Completion, completer.keywords))
 
 

--- a/test/test_tabular_output.py
+++ b/test/test_tabular_output.py
@@ -102,7 +102,7 @@ def test_sql_output(mycli):
     mycli.formatter.query = "SELECT * FROM `table`"
     output = mycli.format_output(None, FakeCursor(), headers)
     assert "\n".join(output) == dedent('''\
-            INSERT INTO `table` (`letters`, `number`, `optional`, `float`, `binary`) VALUES
+            INSERT INTO table (`letters`, `number`, `optional`, `float`, `binary`) VALUES
               ('abc', 1, NULL, 10.0e0, X'aa')
             , ('d', 456, '1', 0.5e0, X'aabb')
             ;''')
@@ -112,7 +112,7 @@ def test_sql_output(mycli):
     mycli.formatter.query = "SELECT * FROM `database`.`table`"
     output = mycli.format_output(None, FakeCursor(), headers)
     assert "\n".join(output) == dedent('''\
-            INSERT INTO `database`.`table` (`letters`, `number`, `optional`, `float`, `binary`) VALUES
+            INSERT INTO database.table (`letters`, `number`, `optional`, `float`, `binary`) VALUES
               ('abc', 1, NULL, 10.0e0, X'aa')
             , ('d', 456, '1', 0.5e0, X'aabb')
             ;''')


### PR DESCRIPTION
## Description

Honor `\G` when executing from commandline with `-e`, letting `--csv` or `--table` take precedence if given.

Edit: This required some unrelated changes to make CI pass.  I have no idea why.

Fixes #1111

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
