### PR TITLE
Correct version parsing of TiDB

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ Bug Fixes:
 * Better handle empty statements in un/prettify
 * Remove vi-mode bindings for prettify/unprettify.
 * honor `\G` when executing from commandline with `-e`
+* Correctly report the version of TiDB.
 
 
 

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -56,7 +56,7 @@ class ServerInfo:
 
         re_species = (
             (r'(?P<version>[0-9\.]+)-MariaDB', ServerSpecies.MariaDB),
-            (r'(?P<version>[0-9\.]+)[a-z0-9]*-TiDB', ServerSpecies.TiDB),
+            (r'[0-9\.]*-TiDB-v(?P<version>[0-9\.]+)-?(?P<comment>[a-z0-9\-]*)', ServerSpecies.TiDB),
             (r'(?P<version>[0-9\.]+)[a-z0-9]*-(?P<comment>[0-9]+$)',
              ServerSpecies.Percona),
             (r'(?P<version>[0-9\.]+)[a-z0-9]*-(?P<comment>[A-Za-z0-9_]+)',

--- a/test/test_sqlexecute.py
+++ b/test/test_sqlexecute.py
@@ -276,7 +276,8 @@ def test_multiple_results(executor):
 @pytest.mark.parametrize(
     'version_string, species, parsed_version_string, version',
     (
-        ('5.7.25-TiDB-v6.1.0','TiDB', '5.7.25', 50725),
+        ('5.7.25-TiDB-v6.1.0','TiDB', '6.1.0', 60100),
+        ('8.0.11-TiDB-v7.2.0-alpha-69-g96e9e68daa', 'TiDB', '7.2.0', 70200),
         ('5.7.32-35', 'Percona', '5.7.32', 50732),
         ('5.7.32-0ubuntu0.18.04.1', 'MySQL', '5.7.32', 50732),
         ('10.5.8-MariaDB-1:10.5.8+maria~focal', 'MariaDB', '10.5.8', 100508),


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Update the version reporting for TiDB.

Examples:
- `5.7.25-TiDB-v7.0.0` (v7.0.0 release)
- `8.0.11-TiDB-v7.2.0-alpha-69-g96e9e68daa` (build from git branch)

Without this change this would parse as `5.7.25` and `8.0.11`.

With this change this parses as `7.0.0` and `7.2.0`.

The first version in the version string (5.7.25, 8.0.11) is the version of MySQL that TiDB claims to be compatible with. The second version is the actual version of TiDB.





## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
