### PR TITLE
Fix an unexpected exception when using dsn without username & password

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+1.27.1
+===================
+
+Bug Fixes:
+---------
+
+* Fix unexpected exception when using dsn without username & password (Thanks: [Will Wang])
+
 1.27.0 (2023/08/11)
 ===================
 
@@ -950,3 +958,4 @@ Bug Fixes:
 [William GARCIA]: https://github.com/willgarcia
 [xeron]: https://github.com/xeron
 [Zach DeCook]: https://zachdecook.com
+[Will Wang]: https://github.com/willww64

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -94,6 +94,7 @@ Contributors:
   * Arvind Mishra
   * Kevin Schmeichel
   * Mel Dafert
+  * Will Wang
 
 Created by:
 -----------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1278,7 +1278,7 @@ def cli(database, user, host, port, socket, password, dbname,
         uri = urlparse(dsn_uri)
         if not database:
             database = uri.path[1:]  # ignore the leading fwd slash
-        if not user:
+        if not user and uri.username is not None:
             user = unquote(uri.username)
         if not password and uri.password is not None:
             password = unquote(uri.password)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

When the `-u, --user` flag is not provided and a DSN without the `user:pass@` part is used (such as `mysql://localhost:3306/mydb`), an unexpected exception occurs. The expected behavior should be fallback to the current logged-in user (line 420 of `main.py`, in the `connect` method).

 This is caused by an unchecked `None` value for `uri.username`. This pull request fixes this bug.

Example exception output:

```
$ mycli mysql://localhost:3306/mydb
Traceback (most recent call last):
  File "/usr/bin/mycli", line 33, in <module>
    sys.exit(load_entry_point('mycli==1.27.0', 'console_scripts', 'mycli')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/mycli/main.py", line 1282, in cli
    user = unquote(uri.username)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/urllib/parse.py", line 671, in unquote
    if '%' not in string:
       ^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
