### PR TITLE
fix(main.py): makes default prompt correctly

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming
 Bug Fixes:
 ----------
 * Don't install tests.
+* let the `--prompt` option act normally with its predefined default value
 
 1.27.0 (2023/08/11)
 ===================

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -96,6 +96,7 @@ Contributors:
   * Mel Dafert
   * Alfred Wingate
   * Zhanze Wang
+  * Houston Wong
 
 Created by:
 -----------

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -93,6 +93,7 @@ SUPPORT_INFO = (
 class MyCli(object):
 
     default_prompt = '\\t \\u@\\h:\\d> '
+    default_prompt_splitln = '\\u@\\h\\n(\\t):\\d>'
     max_len_prompt = 45
     defaults_suffix = None
 
@@ -643,7 +644,7 @@ class MyCli(object):
         def get_message():
             prompt = self.get_prompt(self.prompt_format)
             if self.prompt_format == self.default_prompt and len(prompt) > self.max_len_prompt:
-                prompt = self.get_prompt('\\d> ')
+                prompt = self.get_prompt(self.default_prompt_splitln)
             prompt = prompt.replace("\\x1b", "\x1b")
             return ANSI(prompt)
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1150,7 +1150,7 @@ class MyCli(object):
         help='list of DSN configured into the [alias_dsn] section of myclirc file.')
 @click.option('--list-ssh-config', 'list_ssh_config', is_flag=True,
               help='list ssh configurations in the ssh config (requires paramiko).')
-@click.option('-R', '--prompt', 'prompt',
+@click.option('-R', '--prompt', 'prompt', default=MyCli.default_prompt,
               help='Prompt format (Default: "{0}").'.format(
                   MyCli.default_prompt))
 @click.option('-l', '--logfile', type=click.File(mode='a', encoding='utf-8'),


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

default prompt option not working when exceeds max limit, which is 45 chars.

in this circumstance, only the databasename is show, which is a bit inconvenient and unexpected for information display.

<img width="1481" alt="image" src="https://github.com/dbcli/mycli/assets/10098327/6975336a-b0f4-4d6b-8f6d-a421d3b00e8e">


## Optimization PR

I made a PR to optimize it.

as image shown below, add a default prompt with `\n` for line splitting, when it exceeds the max length.

<img width="575" alt="image" src="https://github.com/dbcli/mycli/assets/10098327/81cb9011-50dc-45f6-bbfc-89dde5d24d43">


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
