### PR TITLE
Do not ignore the socket passed with the -S option, even when no port…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming
 Bug Fixes:
 ----------
 * Don't install tests.
+* Do not ignore the socket passed with the -S option, even when no port is passed
 
 1.27.0 (2023/08/11)
 ===================

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -35,6 +35,7 @@ Contributors:
   * Daniel Black
   * Daniel West
   * Daniël van Eeden
+  * Fabrizio Gennari
   * François Pietka
   * Frederic Aoustin
   * Georgy Frolov

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -427,6 +427,7 @@ class MyCli(object):
             port = 3306
             if not host or host == 'localhost':
                 socket = (
+                    socket or
                     cnf['socket'] or
                     cnf['default_socket'] or
                     guess_socket_location()


### PR DESCRIPTION
… is passed

## Description
When `mycli -S <socket>`  is used, mycli tries to connect to localhost anyway instead of using the provided socket. The problem seems to be there since 51b8ee3c.

The problem has been reported as #1001 



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [X] I've added this contribution to the `changelog.md`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
