### PR TITLE
Tests: monkeypatch shutil.get_terminal_size properly

### DIFF
--- a/test/test_main.py
+++ b/test/test_main.py
@@ -254,18 +254,14 @@ def test_conditional_pager(monkeypatch):
     SPECIAL_COMMANDS['pager'].handler('')
 
 
-def test_reserved_space_is_integer():
+def test_reserved_space_is_integer(monkeypatch):
     """Make sure that reserved space is returned as an integer."""
     def stub_terminal_size():
         return (5, 5)
 
-    old_func = shutil.get_terminal_size
-
-    shutil.get_terminal_size = stub_terminal_size
+    monkeypatch.setattr(shutil, 'get_terminal_size', stub_terminal_size)
     mycli = MyCli()
     assert isinstance(mycli.get_reserved_space(), int)
-
-    shutil.get_terminal_size = old_func
 
 
 def test_list_dsn():


### PR DESCRIPTION
The original way led to very confusing internal pytest errors when the test failed.

When the test failed, the original function was not restored, and pytest uses it:

    INTERNALERROR> Traceback (most recent call last):
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/_pytest/main.py", line 271, in wrap_session
    INTERNALERROR>     session.exitstatus = doit(config, session) or 0
    INTERNALERROR>                          ~~~~^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/_pytest/main.py", line 325, in _main
    INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
    INTERNALERROR>     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/pluggy/_hooks.py", line 493, in __call__
    INTERNALERROR>     return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
    INTERNALERROR>            ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/pluggy/_manager.py", line 115, in _hookexec
    INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
    INTERNALERROR>            ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/pluggy/_callers.py", line 152, in _multicall
    INTERNALERROR>     return outcome.get_result()
    INTERNALERROR>            ~~~~~~~~~~~~~~~~~~^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/pluggy/_result.py", line 114, in get_result
    INTERNALERROR>     raise exc.with_traceback(exc.__traceback__)
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/pluggy/_callers.py", line 77, in _multicall
    INTERNALERROR>     res = hook_impl.function(*args)
    INTERNALERROR>           ~~~~~~~~~~~~~~~~~~^^^^^^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/_pytest/main.py", line 350, in pytest_runtestloop
    INTERNALERROR>     item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
    INTERNALERROR>     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/pluggy/_hooks.py", line 493, in __call__
    INTERNALERROR>     return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
    INTERNALERROR>            ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/pluggy/_manager.py", line 115, in _hookexec
    INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
    INTERNALERROR>            ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/pluggy/_callers.py", line 152, in _multicall
    INTERNALERROR>     return outcome.get_result()
    INTERNALERROR>            ~~~~~~~~~~~~~~~~~~^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/pluggy/_result.py", line 114, in get_result
    INTERNALERROR>     raise exc.with_traceback(exc.__traceback__)
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/pluggy/_callers.py", line 77, in _multicall
    INTERNALERROR>     res = hook_impl.function(*args)
    INTERNALERROR>           ~~~~~~~~~~~~~~~~~~^^^^^^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/_pytest/runner.py", line 113, in pytest_runtest_protocol
    INTERNALERROR>     ihook.pytest_runtest_logstart(nodeid=item.nodeid, location=item.location)
    INTERNALERROR>     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/pluggy/_hooks.py", line 493, in __call__
    INTERNALERROR>     return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
    INTERNALERROR>            ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/pluggy/_manager.py", line 115, in _hookexec
    INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
    INTERNALERROR>            ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/pluggy/_callers.py", line 113, in _multicall
    INTERNALERROR>     raise exception.with_traceback(exception.__traceback__)
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/pluggy/_callers.py", line 77, in _multicall
    INTERNALERROR>     res = hook_impl.function(*args)
    INTERNALERROR>           ~~~~~~~~~~~~~~~~~~^^^^^^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/_pytest/terminal.py", line 566, in pytest_runtest_logstart
    INTERNALERROR>     self.write_fspath_result(nodeid, "")
    INTERNALERROR>     ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/_pytest/terminal.py", line 430, in write_fspath_result
    INTERNALERROR>     self._write_progress_information_filling_space()
    INTERNALERROR>     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/_pytest/terminal.py", line 684, in _write_progress_information_filling_space
    INTERNALERROR>     fill = self._tw.fullwidth - w - 1
    INTERNALERROR>            ^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/_pytest/_io/terminalwriter.py", line 86, in fullwidth
    INTERNALERROR>     return get_terminal_width()
    INTERNALERROR>            ~~~~~~~~~~~~~~~~~~^^
    INTERNALERROR>   File "/usr/lib/python3.13/site-packages/_pytest/_io/terminalwriter.py", line 17, in get_terminal_width
    INTERNALERROR>     width, _ = shutil.get_terminal_size(fallback=(80, 24))
    INTERNALERROR>                ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
    INTERNALERROR> TypeError: test_reserved_space_is_integer.<locals>.stub_terminal_size() got an unexpected keyword argument 'fallback'

## Description
<!--- Describe your changes in detail. -->



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
