### PR TITLE
Tests: Use monkeypatch.context to avoid side effects on pytest

### DIFF
--- a/test/test_main.py
+++ b/test/test_main.py
@@ -259,9 +259,10 @@ def test_reserved_space_is_integer(monkeypatch):
     def stub_terminal_size():
         return (5, 5)
 
-    monkeypatch.setattr(shutil, 'get_terminal_size', stub_terminal_size)
-    mycli = MyCli()
-    assert isinstance(mycli.get_reserved_space(), int)
+    with monkeypatch.context() as m:
+        m.setattr(shutil, 'get_terminal_size', stub_terminal_size)
+        mycli = MyCli()
+        assert isinstance(mycli.get_reserved_space(), int)
 
 
 def test_list_dsn():


### PR DESCRIPTION
* Otherwise this mocked attribute would affect pytest negatively when running tests with --verbose.

See-Also: https://github.com/dbcli/mycli/pull/1152#issuecomment-2027036256

## Description
<!--- Describe your changes in detail. -->
https://github.com/dbcli/mycli/pull/1152 had a side effect of breaking pytest when invoked with --verbose, this pr use monkeypatch.context so that setattr doesnt affect pytest itself.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
