### PR TITLE
Remove duplicate `SMALLINT` token in `sqlcompleter`

### DIFF
--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -96,6 +96,7 @@ Contributors:
   * Alfred Wingate
   * Zhanze Wang
   * Houston Wong
+  * Mohamed Rezk
 
 
 Created by:

--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -31,7 +31,7 @@ class SQLCompleter(Completer):
             'PORT', 'PRIMARY', 'PRIVILEGES', 'PROCESSLIST', 'PURGE',
             'REFERENCES', 'REGEXP', 'RENAME', 'REPAIR', 'RESET', 'REVOKE',
             'RIGHT', 'ROLLBACK', 'ROW', 'ROWS', 'ROW_FORMAT', 'SAVEPOINT',
-            'SESSION', 'SET', 'SHARE', 'SHOW', 'SLAVE', 'SMALLINT', 'SMALLINT',
+            'SESSION', 'SET', 'SHARE', 'SHOW', 'SLAVE', 'SMALLINT',
             'START', 'STOP', 'TABLE', 'THEN', 'TINYINT', 'TO', 'TRANSACTION',
             'TRIGGER', 'TRUNCATE', 'UNION', 'UNIQUE', 'UNSIGNED', 'USE',
             'USER', 'USING', 'VALUES', 'VARCHAR', 'VIEW', 'WHEN', 'WITH'


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
It does not need to be included in  the `changelog.md`.
- [ ] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
