### PR TITLE
Add fzf history search feature

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,8 @@ Internal:
 Features:
 ---------
 
+* Added fzf history search functionality. The feature can switch between the old implementation and the new one based on the presence of the fzf binary.
+
 
 1.27.2 (2024/04/03)
 ===================
@@ -23,7 +25,6 @@ Bug Fixes:
 
 1.27.1 (2024/03/28)
 ===================
-* Added fzf history search functionality. The feature can switch between the old implementation and the new one based on the presence of the fzf binary.
 
 Bug Fixes:
 ----------

--- a/changelog.md
+++ b/changelog.md
@@ -23,7 +23,7 @@ Bug Fixes:
 
 1.27.1 (2024/03/28)
 ===================
-* Added fzf-like history search functionality. The feature can switch between the old implementation and the new one based on the presence of the fzf binary.
+* Added fzf history search functionality. The feature can switch between the old implementation and the new one based on the presence of the fzf binary.
 
 Bug Fixes:
 ----------

--- a/changelog.md
+++ b/changelog.md
@@ -23,7 +23,7 @@ Bug Fixes:
 
 1.27.1 (2024/03/28)
 ===================
-
+* Added fzf-like history search functionality. The feature can switch between the old implementation and the new one based on the presence of the fzf binary.
 
 Bug Fixes:
 ----------

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -97,6 +97,7 @@ Contributors:
   * Zhanze Wang
   * Houston Wong
   * Mohamed Rezk
+  * Ryosuke Kazami
 
 
 Created by:

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -3,6 +3,8 @@ from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.filters import completion_is_selected, emacs_mode
 from prompt_toolkit.key_binding import KeyBindings
 
+from .packages.toolkit.fzf import search_history
+
 _logger = logging.getLogger(__name__)
 
 
@@ -100,6 +102,12 @@ def mycli_bindings(mycli):
                   and b.text[cursorpos_abs] in (' ', '\n'):
                 cursorpos_abs -= 1
             b.cursor_position = min(cursorpos_abs, len(b.text))
+
+    @kb.add('c-r', filter=emacs_mode)
+    def _(event):
+        """Search history using fzf or default reverse incremental search."""
+        _logger.debug('Detected <C-r> key.')
+        search_history(event)
 
     @kb.add('enter', filter=completion_is_selected)
     def _(event):

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -36,7 +36,6 @@ from prompt_toolkit.formatted_text import ANSI
 from prompt_toolkit.layout.processors import (HighlightMatchingBracketProcessor,
                                               ConditionalProcessor)
 from prompt_toolkit.lexers import PygmentsLexer
-from prompt_toolkit.history import FileHistory
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 
 from .packages.special.main import NO_QUERY
@@ -44,6 +43,7 @@ from .packages.prompt_utils import confirm, confirm_destructive_query
 from .packages.tabular_output import sql_format
 from .packages import special
 from .packages.special.favoritequeries import FavoriteQueries
+from .packages.toolkit.history import FileHistoryWithTimestamp
 from .sqlcompleter import SQLCompleter
 from .clitoolbar import create_toolbar_tokens_func
 from .clistyle import style_factory, style_factory_output
@@ -626,7 +626,7 @@ class MyCli(object):
         history_file = os.path.expanduser(
             os.environ.get('MYCLI_HISTFILE', '~/.mycli-history'))
         if dir_path_exists(history_file):
-            history = FileHistory(history_file)
+            history = FileHistoryWithTimestamp(history_file)
         else:
             history = None
             self.echo(

--- a/mycli/packages/filepaths.py
+++ b/mycli/packages/filepaths.py
@@ -100,7 +100,7 @@ def guess_socket_location():
         for r, dirs, files in os.walk(directory, topdown=True):
             for filename in files:
                 name, ext = os.path.splitext(filename)
-                if name.startswith("mysql") and ext in ('.socket', '.sock'):
+                if name.startswith("mysql") and name != "mysqlx" and ext in ('.socket', '.sock'):
                     return os.path.join(r, filename)
             dirs[:] = [d for d in dirs if d.startswith("mysql")]
     return None

--- a/mycli/packages/toolkit/fzf.py
+++ b/mycli/packages/toolkit/fzf.py
@@ -1,0 +1,45 @@
+from shutil import which
+
+from pyfzf import FzfPrompt
+from prompt_toolkit import search
+from prompt_toolkit.key_binding.key_processor import KeyPressEvent
+
+from .history import FileHistoryWithTimestamp
+
+
+class Fzf(FzfPrompt):
+    def __init__(self):
+        self.executable = which("fzf")
+        if self.executable:
+            super().__init__()
+
+    def is_available(self) -> bool:
+        return self.executable is not None
+
+
+def search_history(event: KeyPressEvent):
+    buffer = event.current_buffer
+    history = buffer.history
+
+    fzf = Fzf()
+
+    if fzf.is_available() and isinstance(history, FileHistoryWithTimestamp):
+        history_items_with_timestamp = history.load_history_with_timestamp()
+
+        formatted_history_items = []
+        original_history_items = []
+        for item, timestamp in history_items_with_timestamp:
+            formatted_item = item.replace('\n', ' ')
+            timestamp = timestamp.split(".")[0] if "." in timestamp else timestamp
+            formatted_history_items.append(f"{timestamp}  {formatted_item}")
+            original_history_items.append(item)
+
+        result = fzf.prompt(formatted_history_items, fzf_options="--tiebreak=index")
+
+        if result:
+            selected_index = formatted_history_items.index(result[0])
+            buffer.text = original_history_items[selected_index]
+            buffer.cursor_position = len(buffer.text)
+    else:
+        # Fallback to default reverse incremental search
+        search.start_search(direction=search.SearchDirection.BACKWARD)

--- a/mycli/packages/toolkit/history.py
+++ b/mycli/packages/toolkit/history.py
@@ -15,29 +15,6 @@ class FileHistoryWithTimestamp(FileHistory):
         self.filename = filename
         super().__init__(filename)
 
-    def load_history_strings(self) -> Iterable[str]:
-        strings: list[str] = []
-        lines: list[str] = []
-
-        def add() -> None:
-            if lines:
-                string = "".join(lines)[:-1]
-                strings.append(string)
-
-        if os.path.exists(self.filename):
-            with open(self.filename, "rb") as f:
-                for line_bytes in f:
-                    line = line_bytes.decode("utf-8", errors="replace")
-                    if line.startswith("+"):
-                        lines.append(line[1:])
-                    else:
-                        add()
-                        lines = []
-
-                add()
-
-        return reversed(strings)
-
     def load_history_with_timestamp(self) -> List[Tuple[str, str]]:
         """
         Load history entries along with their timestamps.

--- a/mycli/packages/toolkit/history.py
+++ b/mycli/packages/toolkit/history.py
@@ -1,0 +1,75 @@
+import os
+from typing import Iterable, Union, List, Tuple
+
+from prompt_toolkit.history import FileHistory
+
+_StrOrBytesPath = Union[str, bytes, os.PathLike]
+
+
+class FileHistoryWithTimestamp(FileHistory):
+    """
+    :class:`.FileHistory` class that stores all strings in a file with timestamp.
+    """
+
+    def __init__(self, filename: _StrOrBytesPath) -> None:
+        self.filename = filename
+        super().__init__(filename)
+
+    def load_history_strings(self) -> Iterable[str]:
+        strings: list[str] = []
+        lines: list[str] = []
+
+        def add() -> None:
+            if lines:
+                string = "".join(lines)[:-1]
+                strings.append(string)
+
+        if os.path.exists(self.filename):
+            with open(self.filename, "rb") as f:
+                for line_bytes in f:
+                    line = line_bytes.decode("utf-8", errors="replace")
+                    if line.startswith("+"):
+                        lines.append(line[1:])
+                    else:
+                        add()
+                        lines = []
+
+                add()
+
+        return reversed(strings)
+
+    def load_history_with_timestamp(self) -> List[Tuple[str, str]]:
+        """
+        Load history entries along with their timestamps.
+
+        Returns:
+            List[Tuple[str, str]]: A list of tuples where each tuple contains
+                                   a history entry and its corresponding timestamp.
+        """
+        history_with_timestamp: List[Tuple[str, str]] = []
+        lines: List[str] = []
+        timestamp: str = ""
+
+        def add() -> None:
+            if lines:
+                # Join and drop trailing newline.
+                string = "".join(lines)[:-1]
+                history_with_timestamp.append((string, timestamp))
+
+        if os.path.exists(self.filename):
+            with open(self.filename, "rb") as f:
+                for line_bytes in f:
+                    line = line_bytes.decode("utf-8", errors="replace")
+
+                    if line.startswith("#"):
+                        # Extract timestamp
+                        timestamp = line[2:].strip()
+                    elif line.startswith("+"):
+                        lines.append(line[1:])
+                    else:
+                        add()
+                        lines = []
+
+                add()
+
+        return list(reversed(history_with_timestamp))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,4 +14,4 @@ pyperclip>=1.8.1
 importlib_resources>=5.0.0
 pyaes>=1.6.1
 sqlglot>=5.1.3
-setuptools
+setuptools<=71.1.0

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ install_requirements = [
     'configobj >= 5.0.5',
     'cli_helpers[styles] >= 2.2.1',
     'pyperclip >= 1.8.1',
-    'pyaes >= 1.6.1'
+    'pyaes >= 1.6.1',
+    'pyfzf >= 0.3.1',
 ]
 
 if sys.version_info.minor < 9:


### PR DESCRIPTION
## Description

### Background
Previously, the history function of mycli only allowed viewing history one line at a time, making it feel like peering through a keyhole. Users had to navigate through the history by typing on the keyboard to see the previous and next entries, making it difficult to find the desired history entry. A request for a feature to enable fzf-like history search was made at https://github.com/dbcli/mycli/issues/726.


### Achievements
Implemented the ability to perform fzf search on mycli history. fzf is a software written in Go, and its binary file is also named fzf. (See: [junegunn/fzf: :cherry_blossom: A command-line fuzzy finder](https://github.com/junegunn/fzf))
The mycli history fzf search feature is designed to switch between the old implementation and the new one based on the presence of the fzf binary. (It might be better to have this feature turned off by default and enabled via an option. Feedback is welcome.)

The history format is `<timestamp>  <stmt>`. (Placing the timestamp at the end makes formatting difficult and searching by date harder.) Currently, the timestamp is handled as a string and displayed with seconds. Using `FormattedText` from `prompt_toolkit` to gray out the timestamp could improve visibility, but to keep the scope of this PR focused, this enhancement is not included.

Since fzf provides line-based selection functionality, newlines in the history are replaced with spaces for the suggestion list. However, when setting data to the buffer, the original text is retrieved and set.

Regarding the fzf search score, the `tiebreak=index` option is used. This is because I believe that when searching for SQL queries, users often prefer to use the most recent ones. If the default `length` option is used, searching for a common term like `select` would bring up entries where `select` was mistakenly entered by itself, which can be annoying. For more details, see the [fzf tiebreak option documentation](https://man.archlinux.org/man/fzf.1.en#tiebreak=).

This implementation is an ad-hoc override of some `prompt_toolkit` behavior. Therefore, the implementation is gathered under a `toolkit` subpackage within the `packages` directory.

### Alternative Approach
Ideally, we should contribute to `prompt_toolkit` and use the history functionality implemented there in mycli. However, `prompt_toolkit` is pure Python, and fzf cannot be integrated directly. Rewriting the Go-based program in Python and adapting it to the `prompt_toolkit` Completion mechanism would be a significant undertaking.

For this reason, I decided to override some history-related implementations and keybindings in mycli.

### Comments
mycli is a great tool, and I have greatly benefited from it. I am pleased to have the opportunity to contribute to this excellent software and hope that mycli will become an even more convenient tool.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
