### PR TITLE
fix SSL through SSH jump

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming Release (TBD)
 Bug Fixes:
 ----------
 
+* fix SSL through SSH jump host by using a true python socket for a tunnel
 
 Internal:
 ---------

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -96,6 +96,7 @@ Contributors:
   * Alfred Wingate
   * Zhanze Wang
   * Houston Wong
+  * Cornel Cruceru
 
 
 Created by:

--- a/mycli/packages/paramiko_stub/__init__.py
+++ b/mycli/packages/paramiko_stub/__init__.py
@@ -13,9 +13,9 @@ class Paramiko:
         import sys
         from textwrap import dedent
         print(dedent("""
-            To enable certain SSH features you need to install paramiko:
+            To enable certain SSH features you need to install paramiko and sshtunnel:
             
-               pip install paramiko
+               pip install paramiko sshtunnel
                
             It is required for the following configuration options:
                 --list-ssh-config

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ colorama>=0.4.1
 git+https://github.com/hayd/pep8radius.git  # --error-status option not released
 click>=7.0
 paramiko==2.11.0
+sshtunnel==0.4.0
 pyperclip>=1.8.1
 importlib_resources>=5.0.0
 pyaes>=1.6.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38
+envlist = py36, py37, py38, py310
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
## Description
Attempt to fix https://github.com/dbcli/mycli/issues/1176
The error is caused by paramiko.channel.Channel class that implements a subset of python's socket API and cannot be properly wrapped in SSL because of this.

These changes replace the use of Channel with a straightforward approach of opening a python socket to local bound host and port of a tunnel to the jump host.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
