### PR TITLE
eliminate unnecessary SHOW TABLES which breaks on Vitess

### DIFF
--- a/mycli/completion_refresher.py
+++ b/mycli/completion_refresher.py
@@ -114,8 +114,9 @@ def refresh_schemata(completer, executor):
 
 @refresher("tables")
 def refresh_tables(completer, executor):
-    completer.extend_relations(executor.tables(), kind="tables")
-    completer.extend_columns(executor.table_columns(), kind="tables")
+    table_columns_dbresult = list(executor.table_columns())
+    completer.extend_relations(table_columns_dbresult, kind="tables")
+    completer.extend_columns(table_columns_dbresult, kind="tables")
 
 
 @refresher("users")

--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -1012,6 +1012,10 @@ class SQLCompleter(Completer):
         for relname, column in column_data:
             if relname not in metadata[self.dbname]:
                 _logger.error("relname '%s' was not found in db '%s'", relname, self.dbname)
+                # this could happen back when the completer populated via two calls:
+                # SHOW TABLES then SELECT table_name, column_name from information_schema.columns
+                # it's a slight race, but much more likely on Vitess picking random shards for each.
+                # see discussion in https://github.com/dbcli/mycli/pull/1182 (tl;dr - let's keep it)
                 continue
             metadata[self.dbname][relname].append(column)
             self.all_completions.add(column)

--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -1010,6 +1010,9 @@ class SQLCompleter(Completer):
 
         metadata = self.dbmetadata[kind]
         for relname, column in column_data:
+            if relname not in metadata[self.dbname]:
+                _logger.error("relname '%s' was not found in db '%s'", relname, self.dbname)
+                continue
             metadata[self.dbname][relname].append(column)
             self.all_completions.add(column)
 


### PR DESCRIPTION
## Description
mycli currently makes two queries to the database to prep its auto-completion feature after connecting:
1. `SHOW TABLES`
2. `select TABLE_NAME, COLUMN_NAME from information_schema.columns ...`
The first is actually unnecessary, as the second also contains the table names.
Arguably the above is trivial and not worth changing, HOWEVER the above results in an error on Vitess:
```
$ mycli --host 10.183.249.211 --port 15306 -Dloadtest
MySQL 8.0.31
mycli 1.24.3
Home: http://mycli.net/
Bug tracker: https://github.com/dbcli/mycli/issues
Thanks to the contributor - Shoma Suzuki
MySQL vt_user@10.183.249.211:loadtest> Exception in thread completion_refresh:
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python3/dist-packages/mycli/completion_refresher.py", line 63, in _bg_refresh
    refresher(completer, executor)
  File "/usr/lib/python3/dist-packages/mycli/completion_refresher.py", line 102, in refresh_tables
    completer.extend_columns(executor.table_columns(), kind='tables')
  File "/usr/lib/python3/dist-packages/mycli/sqlcompleter.py", line 172, in extend_columns
    metadata[self.dbname][relname].append(column)
KeyError: '_vt_hold_cb11180fb29d11efbe790affca8db0b9_20241206001421'
MySQL vt_user@10.183.249.211:loadtest>
```

[Vitess](https://planetscale.com/vitess) is a distributed database layer for sharding MySQL.
Their `vtgate` component behaves as a drop-in replacement for MySQL.
When a query is issued, it determines to which shard(s) it needs to proxy the query.
In the case of `SHOW TABLE` and `information_schema.*`, **it picks a shard at random on every query**.

Ideally, the schema should be identical across all Vitess shards, and certainly is for any user-created data on Vitess.
However, the maintainers have introduced an "Online DDL" feature which creates those `_vt_hold_...` tables for its own internal functions, which have a timestamp suffix that is slightly different between shards, hence the error above.
Arguably, what I have described is a Vitess bug, and I am also following up with them to see what can be done.

However, in light of the above `SHOW TABLES` call being totally unnecessary, I think it increases the usability of `mycli` to just make the change so it doesn't error on Vitess, because it will then only issue one query, which will go to one shard, which will be consistent for the normal tables, and only error if a user attempts to autocomplete the Vitess internal tables, which one should not expect to work anyway, as they have different table names between shards.

Note that the change I've done here is minimal wrt lines modified, yet it effectively undoes any performance benefit of using a generator. The generator feels a little unnecessary to me personally, but perhaps there once was someone with a mysql database with millions of columns. If you agree about eliminating `SHOW TABLES`, then we can iterate on this and make a different PR with a larger number of lines changed but preserving the generator.

## Checklist
let's discuss the change first, and if you agree on the implementation, i'll fill these out.
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
