### PR TITLE
Add collapsed output special command

### DIFF
--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -32,6 +32,7 @@ Contributors:
   * Daniel West
   * Daniël van Eeden
   * Fabrizio Gennari
+  * FatBoyXPC
   * François Pietka
   * Frederic Aoustin
   * Georgy Frolov

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -674,6 +674,7 @@ class MyCli(object):
                     return
 
                 special.set_expanded_output(False)
+                special.set_forced_horizontal_output(False)
 
                 try:
                     text = self.handle_editor_command(text)
@@ -741,6 +742,9 @@ class MyCli(object):
                     if self.auto_vertical_output:
                         max_width = self.prompt_app.output.get_size().columns
                     else:
+                        max_width = None
+
+                    if special.forced_horizontal():
                         max_width = None
 
                     formatted = self.format_output(title, cur, headers, special.is_expanded_output(), max_width)

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -20,6 +20,7 @@ from mycli.packages.prompt_utils import confirm_destructive_query
 
 TIMING_ENABLED = False
 use_expanded_output = False
+force_horizontal_output = False
 PAGER_ENABLED = True
 tee_file = None
 once_file = None
@@ -97,6 +98,14 @@ def set_expanded_output(val):
 def is_expanded_output():
     return use_expanded_output
 
+@export
+def set_forced_horizontal_output(val):
+    global force_horizontal_output
+    force_horizontal_output = val
+
+@export
+def forced_horizontal():
+    return force_horizontal_output
 
 _logger = logging.getLogger(__name__)
 

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -298,6 +298,12 @@ class SQLExecute(object):
             if sql.endswith("\\G"):
                 special.set_expanded_output(True)
                 sql = sql[:-2].strip()
+            # \g is treated specially since we might want collapsed output when
+            # auto vertical output is enabled
+            elif sql.endswith('\\g'):
+                special.set_expanded_output(False)
+                special.set_forced_horizontal_output(True)
+                sql = sql[:-2].strip()
 
             cur = self.conn.cursor()
             try:  # Special command

--- a/test/test_sqlexecute.py
+++ b/test/test_sqlexecute.py
@@ -172,6 +172,11 @@ def test_favorite_query_expanded_output(executor):
     results = run(executor, "\\fd test-ae")
     assert_result_equal(results, status="test-ae: Deleted")
 
+@dbtest
+def test_collapsed_output_special_command(executor):
+    set_expanded_output(True)
+    results = run(executor, 'select 1\\g')
+    assert is_expanded_output() is False
 
 @dbtest
 def test_special_command(executor):


### PR DESCRIPTION


## Description
It's sometimes annoying to have auto_vertical_output enabled in myclirc and end up wanting to have the output not be expanded. The current workaround for this is to modify the setting in the rc file and restart mycli (or start a new session), which is obviously not super desirable. Now you can add `\g` at the end of the query akin to `\G` if you're not using auto vertical output.

I would add this to changelog but I don't see anywhere for unreleased features.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
