### PR TITLE
Use fzf `--scheme=history`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming Release (TBD)
 Features
 --------
 * Added explicit error handle to get_password_from_file with EAFP.
+* Use the "history" scheme for fzf searches.
 
 Internal
 --------

--- a/mycli/packages/toolkit/fzf.py
+++ b/mycli/packages/toolkit/fzf.py
@@ -34,7 +34,7 @@ def search_history(event: KeyPressEvent):
             formatted_history_items.append(f"{timestamp}  {formatted_item}")
             original_history_items.append(item)
 
-        result = fzf.prompt(formatted_history_items, fzf_options="--tiebreak=index")
+        result = fzf.prompt(formatted_history_items, fzf_options="--scheme=history --tiebreak=index")
 
         if result:
             selected_index = formatted_history_items.index(result[0])


### PR DESCRIPTION
## Description

Per the man page, this is the scoring scheme tailored for chronological history data.

It could also be nice to remove duplicates.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
