### PR TITLE
A few mypy/lint fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Internal
 --------
 
 * Update sqlparse to <=0.6.0
+* Typing/lint fixes.
 
 
 1.30.0 (2025/04/19)

--- a/mycli/config.py
+++ b/mycli/config.py
@@ -1,4 +1,5 @@
 from copy import copy
+from importlib import resources
 from io import BytesIO, TextIOWrapper
 import logging
 import os
@@ -9,12 +10,6 @@ from typing import Union, IO
 
 from configobj import ConfigObj, ConfigObjError
 import pyaes
-
-try:
-    import importlib.resources as resources
-except ImportError:
-    # Python < 3.7
-    import importlib_resources as resources
 
 try:
     basestring
@@ -78,12 +73,12 @@ def get_included_configs(config_file: Union[str, TextIOWrapper]) -> list:
     try:
         with open(config_file) as f:
             include_directives = filter(lambda s: s.startswith("!includedir"), f)
-            dirs = map(lambda s: s.strip().split()[-1], include_directives)
-            dirs = filter(os.path.isdir, dirs)
-            for dir in dirs:
-                for filename in os.listdir(dir):
+            dirs_split = map(lambda s: s.strip().split()[-1], include_directives)
+            dirs = filter(os.path.isdir, dirs_split)
+            for dir_ in dirs:
+                for filename in os.listdir(dir_):
                     if filename.endswith(".cnf"):
-                        included_configs.append(os.path.join(dir, filename))
+                        included_configs.append(os.path.join(dir_, filename))
     except (PermissionError, UnicodeDecodeError):
         pass
     return included_configs

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -104,10 +104,7 @@ class MyCli(object):
     ]
 
     # check XDG_CONFIG_HOME exists and not an empty string
-    if os.environ.get("XDG_CONFIG_HOME"):
-        xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
-    else:
-        xdg_config_home = "~/.config"
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME", "~/.config")
     system_config_files = ["/etc/myclirc", os.path.join(os.path.expanduser(xdg_config_home), "mycli", "myclirc")]
 
     pwd_config_file = os.path.join(os.getcwd(), ".myclirc")

--- a/mycli/packages/filepaths.py
+++ b/mycli/packages/filepaths.py
@@ -4,11 +4,11 @@ import platform
 
 if os.name == "posix":
     if platform.system() == "Darwin":
-        DEFAULT_SOCKET_DIRS = ("/tmp",)
+        DEFAULT_SOCKET_DIRS = ["/tmp"]
     else:
-        DEFAULT_SOCKET_DIRS = ("/var/run", "/var/lib")
+        DEFAULT_SOCKET_DIRS = ["/var/run", "/var/lib"]
 else:
-    DEFAULT_SOCKET_DIRS = ()
+    DEFAULT_SOCKET_DIRS = []
 
 
 def list_path(root_dir):


### PR DESCRIPTION
## Description
 * we no longer support Python < 3.7 so importlib can be trusted
 * re-assigning to "dirs" confuses the typechecker
 * prefer "dir_" rather than redefining a builtin
 * fix xdg_config_home so that the value cannot be None (at least so that mypy can infer that)
 * use an array instead of a tuple for a value of varying length

No functional change.

There are other places where we try to support old Pythons which could now be cleaned up.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
