### PR TITLE
Deduplicate history lines when fuzzy searching

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features
 --------
 * Added explicit error handle to get_password_from_file with EAFP.
 * Use the "history" scheme for fzf searches.
+* Deduplicate history in fzf searches.
 
 Internal
 --------

--- a/mycli/packages/toolkit/fzf.py
+++ b/mycli/packages/toolkit/fzf.py
@@ -28,9 +28,13 @@ def search_history(event: KeyPressEvent):
 
         formatted_history_items = []
         original_history_items = []
+        seen = {}
         for item, timestamp in history_items_with_timestamp:
             formatted_item = item.replace("\n", " ")
             timestamp = timestamp.split(".")[0] if "." in timestamp else timestamp
+            if formatted_item in seen:
+                continue
+            seen[formatted_item] = True
             formatted_history_items.append(f"{timestamp}  {formatted_item}")
             original_history_items.append(item)
 


### PR DESCRIPTION
## Description

Only the most recent of a duplicated history line is shown.

## Checklist

- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
