### PR TITLE
Incrementally improve linting setup

### DIFF
--- a/mycli/clitoolbar.py
+++ b/mycli/clitoolbar.py
@@ -12,12 +12,10 @@ def create_toolbar_tokens_func(mycli, show_fish_help):
 
         if mycli.multi_line:
             delimiter = special.get_current_delimiter()
-            result.append(
-                (
-                    "class:bottom-toolbar",
-                    " ({} [{}] will end the line) ".format("Semi-colon" if delimiter == ";" else "Delimiter", delimiter),
-                )
-            )
+            result.append((
+                "class:bottom-toolbar",
+                " ({} [{}] will end the line) ".format("Semi-colon" if delimiter == ";" else "Delimiter", delimiter),
+            ))
 
         if mycli.multi_line:
             result.append(("class:bottom-toolbar.on", "[F3] Multiline: ON  "))

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -195,14 +195,12 @@ class SQLExecute(object):
             init_command,
         )
         conv = conversions.copy()
-        conv.update(
-            {
-                FIELD_TYPE.TIMESTAMP: lambda obj: (convert_datetime(obj) or obj),
-                FIELD_TYPE.DATETIME: lambda obj: (convert_datetime(obj) or obj),
-                FIELD_TYPE.TIME: lambda obj: (convert_timedelta(obj) or obj),
-                FIELD_TYPE.DATE: lambda obj: (convert_date(obj) or obj),
-            }
-        )
+        conv.update({
+            FIELD_TYPE.TIMESTAMP: lambda obj: (convert_datetime(obj) or obj),
+            FIELD_TYPE.DATETIME: lambda obj: (convert_datetime(obj) or obj),
+            FIELD_TYPE.TIME: lambda obj: (convert_timedelta(obj) or obj),
+            FIELD_TYPE.DATE: lambda obj: (convert_date(obj) or obj),
+        })
 
         defer_connect = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ mycli = ["myclirc", "AUTHORS", "SPONSORS"]
 include = ["mycli*"]
 
 [tool.ruff]
+target-version = 'py39'
 line-length = 140
 
 [tool.ruff.lint]
@@ -72,12 +73,22 @@ select = [
 ignore = [
     'E401',   # Multiple imports on one line
     'E402',   # Module level import not at top of file
-    'E501',   # Line too long
-    'F541',   # f-string without placeholders
     'PIE808', # range() starting with 0
+    # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    'E111',   # indentation-with-invalid-multiple
+    'E114',   # indentation-with-invalid-multiple-comment
+    'E117',   # over-indented
+    'W191',   # tab-indentation
+]
+
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+known-first-party = [
+    'mycli',
 ]
 
 [tool.ruff.format]
+preview = true
 quote-style = 'preserve'
 exclude = [
     'build',

--- a/test/test_completion_engine.py
+++ b/test/test_completion_engine.py
@@ -9,26 +9,22 @@ def sorted_dicts(dicts):
 
 def test_select_suggests_cols_with_visible_table_scope():
     suggestions = suggest_type("SELECT  FROM tabl", "SELECT ")
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "alias", "aliases": ["tabl"]},
-            {"type": "column", "tables": [(None, "tabl", None)]},
-            {"type": "function", "schema": []},
-            {"type": "keyword"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "alias", "aliases": ["tabl"]},
+        {"type": "column", "tables": [(None, "tabl", None)]},
+        {"type": "function", "schema": []},
+        {"type": "keyword"},
+    ])
 
 
 def test_select_suggests_cols_with_qualified_table_scope():
     suggestions = suggest_type("SELECT  FROM sch.tabl", "SELECT ")
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "alias", "aliases": ["tabl"]},
-            {"type": "column", "tables": [("sch", "tabl", None)]},
-            {"type": "function", "schema": []},
-            {"type": "keyword"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "alias", "aliases": ["tabl"]},
+        {"type": "column", "tables": [("sch", "tabl", None)]},
+        {"type": "function", "schema": []},
+        {"type": "keyword"},
+    ])
 
 
 @pytest.mark.parametrize(
@@ -48,14 +44,12 @@ def test_select_suggests_cols_with_qualified_table_scope():
 )
 def test_where_suggests_columns_functions(expression):
     suggestions = suggest_type(expression, expression)
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "alias", "aliases": ["tabl"]},
-            {"type": "column", "tables": [(None, "tabl", None)]},
-            {"type": "function", "schema": []},
-            {"type": "keyword"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "alias", "aliases": ["tabl"]},
+        {"type": "column", "tables": [(None, "tabl", None)]},
+        {"type": "function", "schema": []},
+        {"type": "keyword"},
+    ])
 
 
 @pytest.mark.parametrize(
@@ -67,27 +61,23 @@ def test_where_suggests_columns_functions(expression):
 )
 def test_where_in_suggests_columns(expression):
     suggestions = suggest_type(expression, expression)
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "alias", "aliases": ["tabl"]},
-            {"type": "column", "tables": [(None, "tabl", None)]},
-            {"type": "function", "schema": []},
-            {"type": "keyword"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "alias", "aliases": ["tabl"]},
+        {"type": "column", "tables": [(None, "tabl", None)]},
+        {"type": "function", "schema": []},
+        {"type": "keyword"},
+    ])
 
 
 def test_where_equals_any_suggests_columns_or_keywords():
     text = "SELECT * FROM tabl WHERE foo = ANY("
     suggestions = suggest_type(text, text)
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "alias", "aliases": ["tabl"]},
-            {"type": "column", "tables": [(None, "tabl", None)]},
-            {"type": "function", "schema": []},
-            {"type": "keyword"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "alias", "aliases": ["tabl"]},
+        {"type": "column", "tables": [(None, "tabl", None)]},
+        {"type": "function", "schema": []},
+        {"type": "keyword"},
+    ])
 
 
 def test_lparen_suggests_cols():
@@ -107,14 +97,12 @@ def test_operand_inside_function_suggests_cols2():
 
 def test_select_suggests_cols_and_funcs():
     suggestions = suggest_type("SELECT ", "SELECT ")
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "alias", "aliases": []},
-            {"type": "column", "tables": []},
-            {"type": "function", "schema": []},
-            {"type": "keyword"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "alias", "aliases": []},
+        {"type": "column", "tables": []},
+        {"type": "function", "schema": []},
+        {"type": "keyword"},
+    ])
 
 
 @pytest.mark.parametrize(
@@ -170,14 +158,12 @@ def test_distinct_suggests_cols():
 
 def test_col_comma_suggests_cols():
     suggestions = suggest_type("SELECT a, b, FROM tbl", "SELECT a, b,")
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "alias", "aliases": ["tbl"]},
-            {"type": "column", "tables": [(None, "tbl", None)]},
-            {"type": "function", "schema": []},
-            {"type": "keyword"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "alias", "aliases": ["tbl"]},
+        {"type": "column", "tables": [(None, "tbl", None)]},
+        {"type": "function", "schema": []},
+        {"type": "keyword"},
+    ])
 
 
 def test_table_comma_suggests_tables_and_schemas():
@@ -207,50 +193,42 @@ def test_insert_into_lparen_comma_suggests_cols():
 
 def test_partially_typed_col_name_suggests_col_names():
     suggestions = suggest_type("SELECT * FROM tabl WHERE col_n", "SELECT * FROM tabl WHERE col_n")
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "alias", "aliases": ["tabl"]},
-            {"type": "column", "tables": [(None, "tabl", None)]},
-            {"type": "function", "schema": []},
-            {"type": "keyword"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "alias", "aliases": ["tabl"]},
+        {"type": "column", "tables": [(None, "tabl", None)]},
+        {"type": "function", "schema": []},
+        {"type": "keyword"},
+    ])
 
 
 def test_dot_suggests_cols_of_a_table_or_schema_qualified_table():
     suggestions = suggest_type("SELECT tabl. FROM tabl", "SELECT tabl.")
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "column", "tables": [(None, "tabl", None)]},
-            {"type": "table", "schema": "tabl"},
-            {"type": "view", "schema": "tabl"},
-            {"type": "function", "schema": "tabl"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "column", "tables": [(None, "tabl", None)]},
+        {"type": "table", "schema": "tabl"},
+        {"type": "view", "schema": "tabl"},
+        {"type": "function", "schema": "tabl"},
+    ])
 
 
 def test_dot_suggests_cols_of_an_alias():
     suggestions = suggest_type("SELECT t1. FROM tabl1 t1, tabl2 t2", "SELECT t1.")
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "table", "schema": "t1"},
-            {"type": "view", "schema": "t1"},
-            {"type": "column", "tables": [(None, "tabl1", "t1")]},
-            {"type": "function", "schema": "t1"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "table", "schema": "t1"},
+        {"type": "view", "schema": "t1"},
+        {"type": "column", "tables": [(None, "tabl1", "t1")]},
+        {"type": "function", "schema": "t1"},
+    ])
 
 
 def test_dot_col_comma_suggests_cols_or_schema_qualified_table():
     suggestions = suggest_type("SELECT t1.a, t2. FROM tabl1 t1, tabl2 t2", "SELECT t1.a, t2.")
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "column", "tables": [(None, "tabl2", "t2")]},
-            {"type": "table", "schema": "t2"},
-            {"type": "view", "schema": "t2"},
-            {"type": "function", "schema": "t2"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "column", "tables": [(None, "tabl2", "t2")]},
+        {"type": "table", "schema": "t2"},
+        {"type": "view", "schema": "t2"},
+        {"type": "function", "schema": "t2"},
+    ])
 
 
 @pytest.mark.parametrize(
@@ -306,34 +284,31 @@ def test_sub_select_table_name_completion(expression):
 
 def test_sub_select_col_name_completion():
     suggestions = suggest_type("SELECT * FROM (SELECT  FROM abc", "SELECT * FROM (SELECT ")
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "alias", "aliases": ["abc"]},
-            {"type": "column", "tables": [(None, "abc", None)]},
-            {"type": "function", "schema": []},
-            {"type": "keyword"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "alias", "aliases": ["abc"]},
+        {"type": "column", "tables": [(None, "abc", None)]},
+        {"type": "function", "schema": []},
+        {"type": "keyword"},
+    ])
 
 
 @pytest.mark.xfail
 def test_sub_select_multiple_col_name_completion():
     suggestions = suggest_type("SELECT * FROM (SELECT a, FROM abc", "SELECT * FROM (SELECT a, ")
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [{"type": "column", "tables": [(None, "abc", None)]}, {"type": "function", "schema": []}]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "column", "tables": [(None, "abc", None)]},
+        {"type": "function", "schema": []},
+    ])
 
 
 def test_sub_select_dot_col_name_completion():
     suggestions = suggest_type("SELECT * FROM (SELECT t. FROM tabl t", "SELECT * FROM (SELECT t.")
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "column", "tables": [(None, "tabl", "t")]},
-            {"type": "table", "schema": "t"},
-            {"type": "view", "schema": "t"},
-            {"type": "function", "schema": "t"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "column", "tables": [(None, "tabl", "t")]},
+        {"type": "table", "schema": "t"},
+        {"type": "view", "schema": "t"},
+        {"type": "function", "schema": "t"},
+    ])
 
 
 @pytest.mark.parametrize("join_type", ["", "INNER", "LEFT", "RIGHT OUTER"])
@@ -353,14 +328,12 @@ def test_join_suggests_tables_and_schemas(tbl_alias, join_type):
 )
 def test_join_alias_dot_suggests_cols1(sql):
     suggestions = suggest_type(sql, sql)
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "column", "tables": [(None, "abc", "a")]},
-            {"type": "table", "schema": "a"},
-            {"type": "view", "schema": "a"},
-            {"type": "function", "schema": "a"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "column", "tables": [(None, "abc", "a")]},
+        {"type": "table", "schema": "a"},
+        {"type": "view", "schema": "a"},
+        {"type": "function", "schema": "a"},
+    ])
 
 
 @pytest.mark.parametrize(
@@ -372,14 +345,12 @@ def test_join_alias_dot_suggests_cols1(sql):
 )
 def test_join_alias_dot_suggests_cols2(sql):
     suggestions = suggest_type(sql, sql)
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "column", "tables": [(None, "def", "d")]},
-            {"type": "table", "schema": "d"},
-            {"type": "view", "schema": "d"},
-            {"type": "function", "schema": "d"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "column", "tables": [(None, "def", "d")]},
+        {"type": "table", "schema": "d"},
+        {"type": "view", "schema": "d"},
+        {"type": "function", "schema": "d"},
+    ])
 
 
 @pytest.mark.parametrize(
@@ -445,14 +416,12 @@ def test_join_using_suggests_common_columns(col_list):
 )
 def test_two_join_alias_dot_suggests_cols1(sql):
     suggestions = suggest_type(sql, sql)
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "column", "tables": [(None, "ghi", "g")]},
-            {"type": "table", "schema": "g"},
-            {"type": "view", "schema": "g"},
-            {"type": "function", "schema": "g"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "column", "tables": [(None, "ghi", "g")]},
+        {"type": "table", "schema": "g"},
+        {"type": "view", "schema": "g"},
+        {"type": "function", "schema": "g"},
+    ])
 
 
 def test_2_statements_2nd_current():
@@ -460,14 +429,12 @@ def test_2_statements_2nd_current():
     assert sorted_dicts(suggestions) == sorted_dicts([{"type": "table", "schema": []}, {"type": "view", "schema": []}, {"type": "schema"}])
 
     suggestions = suggest_type("select * from a; select  from b", "select * from a; select ")
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "alias", "aliases": ["b"]},
-            {"type": "column", "tables": [(None, "b", None)]},
-            {"type": "function", "schema": []},
-            {"type": "keyword"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "alias", "aliases": ["b"]},
+        {"type": "column", "tables": [(None, "b", None)]},
+        {"type": "function", "schema": []},
+        {"type": "keyword"},
+    ])
 
     # Should work even if first statement is invalid
     suggestions = suggest_type("select * from; select * from ", "select * from; select * from ")
@@ -479,14 +446,12 @@ def test_2_statements_1st_current():
     assert sorted_dicts(suggestions) == sorted_dicts([{"type": "table", "schema": []}, {"type": "view", "schema": []}, {"type": "schema"}])
 
     suggestions = suggest_type("select  from a; select * from b", "select ")
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "alias", "aliases": ["a"]},
-            {"type": "column", "tables": [(None, "a", None)]},
-            {"type": "function", "schema": []},
-            {"type": "keyword"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "alias", "aliases": ["a"]},
+        {"type": "column", "tables": [(None, "a", None)]},
+        {"type": "function", "schema": []},
+        {"type": "keyword"},
+    ])
 
 
 def test_3_statements_2nd_current():
@@ -494,14 +459,12 @@ def test_3_statements_2nd_current():
     assert sorted_dicts(suggestions) == sorted_dicts([{"type": "table", "schema": []}, {"type": "view", "schema": []}, {"type": "schema"}])
 
     suggestions = suggest_type("select * from a; select  from b; select * from c", "select * from a; select ")
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [
-            {"type": "alias", "aliases": ["b"]},
-            {"type": "column", "tables": [(None, "b", None)]},
-            {"type": "function", "schema": []},
-            {"type": "keyword"},
-        ]
-    )
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "alias", "aliases": ["b"]},
+        {"type": "column", "tables": [(None, "b", None)]},
+        {"type": "function", "schema": []},
+        {"type": "keyword"},
+    ])
 
 
 def test_create_db_with_template():

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -72,33 +72,29 @@ def test_table_completion(completer, complete_event):
     text = "SELECT * FROM "
     position = len(text)
     result = completer.get_completions(Document(text=text, cursor_position=position), complete_event)
-    assert list(result) == list(
-        [
-            Completion(text="users", start_position=0),
-            Completion(text="orders", start_position=0),
-            Completion(text="`select`", start_position=0),
-            Completion(text="`réveillé`", start_position=0),
-        ]
-    )
+    assert list(result) == list([
+        Completion(text="users", start_position=0),
+        Completion(text="orders", start_position=0),
+        Completion(text="`select`", start_position=0),
+        Completion(text="`réveillé`", start_position=0),
+    ])
 
 
 def test_function_name_completion(completer, complete_event):
     text = "SELECT MA"
     position = len("SELECT MA")
     result = completer.get_completions(Document(text=text, cursor_position=position), complete_event)
-    assert list(result) == list(
-        [
-            Completion(text="MAX", start_position=-2),
-            Completion(text="CHANGE MASTER TO", start_position=-2),
-            Completion(text="CURRENT_TIMESTAMP", start_position=-2),
-            Completion(text="DECIMAL", start_position=-2),
-            Completion(text="FORMAT", start_position=-2),
-            Completion(text="MASTER", start_position=-2),
-            Completion(text="PRIMARY", start_position=-2),
-            Completion(text="ROW_FORMAT", start_position=-2),
-            Completion(text="SMALLINT", start_position=-2),
-        ]
-    )
+    assert list(result) == list([
+        Completion(text="MAX", start_position=-2),
+        Completion(text="CHANGE MASTER TO", start_position=-2),
+        Completion(text="CURRENT_TIMESTAMP", start_position=-2),
+        Completion(text="DECIMAL", start_position=-2),
+        Completion(text="FORMAT", start_position=-2),
+        Completion(text="MASTER", start_position=-2),
+        Completion(text="PRIMARY", start_position=-2),
+        Completion(text="ROW_FORMAT", start_position=-2),
+        Completion(text="SMALLINT", start_position=-2),
+    ])
 
 
 def test_suggested_column_names(completer, complete_event):
@@ -138,15 +134,13 @@ def test_suggested_column_names_in_function(completer, complete_event):
     text = "SELECT MAX( from users"
     position = len("SELECT MAX(")
     result = completer.get_completions(Document(text=text, cursor_position=position), complete_event)
-    assert list(result) == list(
-        [
-            Completion(text="*", start_position=0),
-            Completion(text="id", start_position=0),
-            Completion(text="email", start_position=0),
-            Completion(text="first_name", start_position=0),
-            Completion(text="last_name", start_position=0),
-        ]
-    )
+    assert list(result) == list([
+        Completion(text="*", start_position=0),
+        Completion(text="id", start_position=0),
+        Completion(text="email", start_position=0),
+        Completion(text="first_name", start_position=0),
+        Completion(text="last_name", start_position=0),
+    ])
 
 
 def test_suggested_column_names_with_table_dot(completer, complete_event):
@@ -160,15 +154,13 @@ def test_suggested_column_names_with_table_dot(completer, complete_event):
     text = "SELECT users. from users"
     position = len("SELECT users.")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list(
-        [
-            Completion(text="*", start_position=0),
-            Completion(text="id", start_position=0),
-            Completion(text="email", start_position=0),
-            Completion(text="first_name", start_position=0),
-            Completion(text="last_name", start_position=0),
-        ]
-    )
+    assert result == list([
+        Completion(text="*", start_position=0),
+        Completion(text="id", start_position=0),
+        Completion(text="email", start_position=0),
+        Completion(text="first_name", start_position=0),
+        Completion(text="last_name", start_position=0),
+    ])
 
 
 def test_suggested_column_names_with_alias(completer, complete_event):
@@ -182,15 +174,13 @@ def test_suggested_column_names_with_alias(completer, complete_event):
     text = "SELECT u. from users u"
     position = len("SELECT u.")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list(
-        [
-            Completion(text="*", start_position=0),
-            Completion(text="id", start_position=0),
-            Completion(text="email", start_position=0),
-            Completion(text="first_name", start_position=0),
-            Completion(text="last_name", start_position=0),
-        ]
-    )
+    assert result == list([
+        Completion(text="*", start_position=0),
+        Completion(text="id", start_position=0),
+        Completion(text="email", start_position=0),
+        Completion(text="first_name", start_position=0),
+        Completion(text="last_name", start_position=0),
+    ])
 
 
 def test_suggested_multiple_column_names(completer, complete_event):
@@ -231,15 +221,13 @@ def test_suggested_multiple_column_names_with_alias(completer, complete_event):
     text = "SELECT u.id, u. from users u"
     position = len("SELECT u.id, u.")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list(
-        [
-            Completion(text="*", start_position=0),
-            Completion(text="id", start_position=0),
-            Completion(text="email", start_position=0),
-            Completion(text="first_name", start_position=0),
-            Completion(text="last_name", start_position=0),
-        ]
-    )
+    assert result == list([
+        Completion(text="*", start_position=0),
+        Completion(text="id", start_position=0),
+        Completion(text="email", start_position=0),
+        Completion(text="first_name", start_position=0),
+        Completion(text="last_name", start_position=0),
+    ])
 
 
 def test_suggested_multiple_column_names_with_dot(completer, complete_event):
@@ -254,77 +242,65 @@ def test_suggested_multiple_column_names_with_dot(completer, complete_event):
     text = "SELECT users.id, users. from users u"
     position = len("SELECT users.id, users.")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list(
-        [
-            Completion(text="*", start_position=0),
-            Completion(text="id", start_position=0),
-            Completion(text="email", start_position=0),
-            Completion(text="first_name", start_position=0),
-            Completion(text="last_name", start_position=0),
-        ]
-    )
+    assert result == list([
+        Completion(text="*", start_position=0),
+        Completion(text="id", start_position=0),
+        Completion(text="email", start_position=0),
+        Completion(text="first_name", start_position=0),
+        Completion(text="last_name", start_position=0),
+    ])
 
 
 def test_suggested_aliases_after_on(completer, complete_event):
     text = "SELECT u.name, o.id FROM users u JOIN orders o ON "
     position = len("SELECT u.name, o.id FROM users u JOIN orders o ON ")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list(
-        [
-            Completion(text="u", start_position=0),
-            Completion(text="o", start_position=0),
-        ]
-    )
+    assert result == list([
+        Completion(text="u", start_position=0),
+        Completion(text="o", start_position=0),
+    ])
 
 
 def test_suggested_aliases_after_on_right_side(completer, complete_event):
     text = "SELECT u.name, o.id FROM users u JOIN orders o ON o.user_id = "
     position = len("SELECT u.name, o.id FROM users u JOIN orders o ON o.user_id = ")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list(
-        [
-            Completion(text="u", start_position=0),
-            Completion(text="o", start_position=0),
-        ]
-    )
+    assert result == list([
+        Completion(text="u", start_position=0),
+        Completion(text="o", start_position=0),
+    ])
 
 
 def test_suggested_tables_after_on(completer, complete_event):
     text = "SELECT users.name, orders.id FROM users JOIN orders ON "
     position = len("SELECT users.name, orders.id FROM users JOIN orders ON ")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list(
-        [
-            Completion(text="users", start_position=0),
-            Completion(text="orders", start_position=0),
-        ]
-    )
+    assert result == list([
+        Completion(text="users", start_position=0),
+        Completion(text="orders", start_position=0),
+    ])
 
 
 def test_suggested_tables_after_on_right_side(completer, complete_event):
     text = "SELECT users.name, orders.id FROM users JOIN orders ON orders.user_id = "
     position = len("SELECT users.name, orders.id FROM users JOIN orders ON orders.user_id = ")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list(
-        [
-            Completion(text="users", start_position=0),
-            Completion(text="orders", start_position=0),
-        ]
-    )
+    assert result == list([
+        Completion(text="users", start_position=0),
+        Completion(text="orders", start_position=0),
+    ])
 
 
 def test_table_names_after_from(completer, complete_event):
     text = "SELECT * FROM "
     position = len("SELECT * FROM ")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list(
-        [
-            Completion(text="users", start_position=0),
-            Completion(text="orders", start_position=0),
-            Completion(text="`select`", start_position=0),
-            Completion(text="`réveillé`", start_position=0),
-        ]
-    )
+    assert result == list([
+        Completion(text="users", start_position=0),
+        Completion(text="orders", start_position=0),
+        Completion(text="`select`", start_position=0),
+        Completion(text="`réveillé`", start_position=0),
+    ])
 
 
 def test_auto_escaped_col_names(completer, complete_event):


### PR DESCRIPTION
## Description

 * let lint target the oldest supported Python version
 * disable lint rules which may conflict with the formatter, per Astral recommendations, and document
 * establish rules for sorting imports (but don't activate this yet in CI)
 * enable preview mode for "ruff format", and reformat code, making some whitespace tighter

Enabling `preview = true` for ruff might be controversial, but I've had only good luck with it.

The ignored lint rules wouldn't be needed by default, but the "E" and "W" series are explicitly activated.

## Checklist
- [x] ~I've added this contribution to the `changelog.md`.~ already covered
- [x] I've added my name to the `AUTHORS` file (or it's already there).
