### PR TITLE
Add a preview window to fuzzy history search

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Features
 * Added explicit error handle to get_password_from_file with EAFP.
 * Use the "history" scheme for fzf searches.
 * Deduplicate history in fzf searches.
+* Add a preview window to fzf history searches.
 
 Internal
 --------

--- a/mycli/packages/toolkit/fzf.py
+++ b/mycli/packages/toolkit/fzf.py
@@ -1,3 +1,4 @@
+import re
 from shutil import which
 
 from pyfzf import FzfPrompt
@@ -30,7 +31,7 @@ def search_history(event: KeyPressEvent):
         original_history_items = []
         seen = {}
         for item, timestamp in history_items_with_timestamp:
-            formatted_item = item.replace("\n", " ")
+            formatted_item = re.sub(r'\s+', ' ', item)
             timestamp = timestamp.split(".")[0] if "." in timestamp else timestamp
             if formatted_item in seen:
                 continue
@@ -38,7 +39,10 @@ def search_history(event: KeyPressEvent):
             formatted_history_items.append(f"{timestamp}  {formatted_item}")
             original_history_items.append(item)
 
-        result = fzf.prompt(formatted_history_items, fzf_options="--scheme=history --tiebreak=index")
+        result = fzf.prompt(
+            formatted_history_items,
+            fzf_options="--scheme=history --tiebreak=index --preview-window=down:wrap --preview=\"printf '%s' {}\"",
+        )
 
         if result:
             selected_index = formatted_history_items.index(result[0])


### PR DESCRIPTION
## Description
Add a preview window to fuzzy history search, compressing whitespace, and wrapping text.

This is highly desirable since many queries are longer than one line, and can't be distinguished in the search.  That can be considered a regression over non-fuzzy search.

It would be even nicer to
 * somehow avoid compressing quoted whitespace
 * detect when the user has already set a preview location preference in $FZF_DEFAULT_OPTS

## Checklist

- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
