### PR TITLE
Enable minimal `ruff check` in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,12 +15,11 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-        # todo
         # remember to sync the ruff-check version number with pyproject.toml
-        # - name: Run ruff check
-        #   uses: astral-sh/ruff-action@9828f49eb4cadf267b40eaa330295c412c68c1f9 # v3.2.2
-        #   with:
-        #     version: 0.11.5
+      - name: Run ruff check
+        uses: astral-sh/ruff-action@9828f49eb4cadf267b40eaa330295c412c68c1f9 # v3.2.2
+        with:
+          version: 0.11.5
 
         # remember to sync the ruff-check version number with pyproject.toml
       - name: Run ruff format

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,10 +46,9 @@ jobs:
       run: |
         uv run tox -e py${{ matrix.python-version }}
 
-    # TODO enable style checks here and in CI for PRs
-    #
-    # - name: Run Style Checks
-    #   run: uv run tox -e style
+      # arguably this should be made identical to CI for PRs
+    - name: Run Style Checks
+      run: uv run tox -e style
 
   build:
     runs-on: ubuntu-latest

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+Upcoming Release (TBD)
+======================
+
+Internal
+--------
+
+* Work on passing `ruff check` linting.
+
+
 1.31.1 (2025/04/25)
 ===================
 

--- a/mycli/clibuffer.py
+++ b/mycli/clibuffer.py
@@ -35,11 +35,13 @@ def _multiline_exception(text):
         text.lower().startswith("delimiter")
         or
         # Ended with the current delimiter (usually a semi-column)
-        text.endswith(special.get_current_delimiter())
-        or text.endswith("\\g")
-        or text.endswith("\\G")
-        or text.endswith(r"\e")
-        or text.endswith(r"\clip")
+        text.endswith((
+            special.get_current_delimiter(),
+            text.endswith("\\g"),
+            text.endswith("\\G"),
+            text.endswith(r"\e"),
+            text.endswith(r"\clip"),
+        ))
         or
         # Exit doesn't need semi-column`
         (text == "exit")

--- a/mycli/config.py
+++ b/mycli/config.py
@@ -73,7 +73,7 @@ def get_included_configs(config_file: Union[str, TextIOWrapper]) -> list:
     try:
         with open(config_file) as f:
             include_directives = filter(lambda s: s.startswith("!includedir"), f)
-            dirs_split = map(lambda s: s.strip().split()[-1], include_directives)
+            dirs_split = (s.strip().split()[-1] for s in include_directives)
             dirs = filter(os.path.isdir, dirs_split)
             for dir_ in dirs:
                 for filename in os.listdir(dir_):

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -7,10 +7,7 @@ import traceback
 import logging
 import threading
 import re
-import stat
 from collections import namedtuple
-
-from pygments.lexer import combined
 
 try:
     from pwd import getpwuid

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1453,7 +1453,7 @@ def is_mutating(status):
     if not status:
         return False
 
-    mutating = set(["insert", "update", "delete", "alter", "create", "drop", "replace", "truncate", "load", "rename"])
+    mutating = {"insert", "update", "delete", "alter", "create", "drop", "replace", "truncate", "load", "rename"}
     return status.split(None, 1)[0].lower() in mutating
 
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -86,8 +86,6 @@ SUPPORT_INFO = "Home: http://mycli.net\nBug tracker: https://github.com/dbcli/my
 class PasswordFileError(Exception):
     """Base exception for errors related to reading password files."""
 
-    pass
-
 
 class MyCli(object):
     default_prompt = "\\t \\u@\\h:\\d> "

--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -129,7 +129,7 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
     else:
         token_v = token.value.lower()
 
-    is_operand = lambda x: x and any([x.endswith(op) for op in ["+", "-", "*", "/"]])  # noqa: E731
+    is_operand = lambda x: x and any(x.endswith(op) for op in ["+", "-", "*", "/"])  # noqa: E731
 
     if not token:
         return [{"type": "keyword"}, {"type": "special"}]

--- a/mycli/packages/paramiko_stub/__init__.py
+++ b/mycli/packages/paramiko_stub/__init__.py
@@ -16,9 +16,9 @@ class Paramiko:
         print(
             dedent("""
             To enable certain SSH features you need to install paramiko and sshtunnel:
-            
+
                pip install paramiko sshtunnel
-               
+
             It is required for the following configuration options:
                 --list-ssh-config
                 --ssh-config-host

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ line-length = 140
 [tool.ruff.lint]
 select = [
     'A',
-    'I',
+#   'I',      # todo enableme imports
     'E',
     'W',
     'F',
@@ -79,6 +79,11 @@ ignore = [
     'E114',   # indentation-with-invalid-multiple-comment
     'E117',   # over-indented
     'W191',   # tab-indentation
+    # TODO
+    'A001',   # todo enableme variable shadowing builtin
+    'A002',   # todo enableme function argument shadowing builtin
+    'A004',   # todo enableme import shadowing builtin
+    'PIE796', # todo enableme Enum contains duplicate value
 ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,8 @@ ignore = [
 force-sort-within-sections = true
 known-first-party = [
     'mycli',
+    'test',
+    'steps',
 ]
 
 [tool.ruff.format]

--- a/test/test_naive_completion.py
+++ b/test/test_naive_completion.py
@@ -28,7 +28,7 @@ def test_select_keyword_completion(completer, complete_event):
     text = "SEL"
     position = len("SEL")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list([Completion(text="SELECT", start_position=-3)])
+    assert result == [Completion(text="SELECT", start_position=-3)]
 
 
 def test_function_name_completion(completer, complete_event):

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -58,7 +58,7 @@ def test_select_keyword_completion(completer, complete_event):
     text = "SEL"
     position = len("SEL")
     result = completer.get_completions(Document(text=text, cursor_position=position), complete_event)
-    assert list(result) == list([Completion(text="SELECT", start_position=-3)])
+    assert list(result) == [Completion(text="SELECT", start_position=-3)]
 
 
 def test_select_star(completer, complete_event):
@@ -72,19 +72,19 @@ def test_table_completion(completer, complete_event):
     text = "SELECT * FROM "
     position = len(text)
     result = completer.get_completions(Document(text=text, cursor_position=position), complete_event)
-    assert list(result) == list([
+    assert list(result) == [
         Completion(text="users", start_position=0),
         Completion(text="orders", start_position=0),
         Completion(text="`select`", start_position=0),
         Completion(text="`réveillé`", start_position=0),
-    ])
+    ]
 
 
 def test_function_name_completion(completer, complete_event):
     text = "SELECT MA"
     position = len("SELECT MA")
     result = completer.get_completions(Document(text=text, cursor_position=position), complete_event)
-    assert list(result) == list([
+    assert list(result) == [
         Completion(text="MAX", start_position=-2),
         Completion(text="CHANGE MASTER TO", start_position=-2),
         Completion(text="CURRENT_TIMESTAMP", start_position=-2),
@@ -94,7 +94,7 @@ def test_function_name_completion(completer, complete_event):
         Completion(text="PRIMARY", start_position=-2),
         Completion(text="ROW_FORMAT", start_position=-2),
         Completion(text="SMALLINT", start_position=-2),
-    ])
+    ]
 
 
 def test_suggested_column_names(completer, complete_event):
@@ -134,13 +134,13 @@ def test_suggested_column_names_in_function(completer, complete_event):
     text = "SELECT MAX( from users"
     position = len("SELECT MAX(")
     result = completer.get_completions(Document(text=text, cursor_position=position), complete_event)
-    assert list(result) == list([
+    assert list(result) == [
         Completion(text="*", start_position=0),
         Completion(text="id", start_position=0),
         Completion(text="email", start_position=0),
         Completion(text="first_name", start_position=0),
         Completion(text="last_name", start_position=0),
-    ])
+    ]
 
 
 def test_suggested_column_names_with_table_dot(completer, complete_event):
@@ -154,13 +154,13 @@ def test_suggested_column_names_with_table_dot(completer, complete_event):
     text = "SELECT users. from users"
     position = len("SELECT users.")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list([
+    assert result == [
         Completion(text="*", start_position=0),
         Completion(text="id", start_position=0),
         Completion(text="email", start_position=0),
         Completion(text="first_name", start_position=0),
         Completion(text="last_name", start_position=0),
-    ])
+    ]
 
 
 def test_suggested_column_names_with_alias(completer, complete_event):
@@ -174,13 +174,13 @@ def test_suggested_column_names_with_alias(completer, complete_event):
     text = "SELECT u. from users u"
     position = len("SELECT u.")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list([
+    assert result == [
         Completion(text="*", start_position=0),
         Completion(text="id", start_position=0),
         Completion(text="email", start_position=0),
         Completion(text="first_name", start_position=0),
         Completion(text="last_name", start_position=0),
-    ])
+    ]
 
 
 def test_suggested_multiple_column_names(completer, complete_event):
@@ -221,13 +221,13 @@ def test_suggested_multiple_column_names_with_alias(completer, complete_event):
     text = "SELECT u.id, u. from users u"
     position = len("SELECT u.id, u.")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list([
+    assert result == [
         Completion(text="*", start_position=0),
         Completion(text="id", start_position=0),
         Completion(text="email", start_position=0),
         Completion(text="first_name", start_position=0),
         Completion(text="last_name", start_position=0),
-    ])
+    ]
 
 
 def test_suggested_multiple_column_names_with_dot(completer, complete_event):
@@ -242,65 +242,65 @@ def test_suggested_multiple_column_names_with_dot(completer, complete_event):
     text = "SELECT users.id, users. from users u"
     position = len("SELECT users.id, users.")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list([
+    assert result == [
         Completion(text="*", start_position=0),
         Completion(text="id", start_position=0),
         Completion(text="email", start_position=0),
         Completion(text="first_name", start_position=0),
         Completion(text="last_name", start_position=0),
-    ])
+    ]
 
 
 def test_suggested_aliases_after_on(completer, complete_event):
     text = "SELECT u.name, o.id FROM users u JOIN orders o ON "
     position = len("SELECT u.name, o.id FROM users u JOIN orders o ON ")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list([
+    assert result == [
         Completion(text="u", start_position=0),
         Completion(text="o", start_position=0),
-    ])
+    ]
 
 
 def test_suggested_aliases_after_on_right_side(completer, complete_event):
     text = "SELECT u.name, o.id FROM users u JOIN orders o ON o.user_id = "
     position = len("SELECT u.name, o.id FROM users u JOIN orders o ON o.user_id = ")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list([
+    assert result == [
         Completion(text="u", start_position=0),
         Completion(text="o", start_position=0),
-    ])
+    ]
 
 
 def test_suggested_tables_after_on(completer, complete_event):
     text = "SELECT users.name, orders.id FROM users JOIN orders ON "
     position = len("SELECT users.name, orders.id FROM users JOIN orders ON ")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list([
+    assert result == [
         Completion(text="users", start_position=0),
         Completion(text="orders", start_position=0),
-    ])
+    ]
 
 
 def test_suggested_tables_after_on_right_side(completer, complete_event):
     text = "SELECT users.name, orders.id FROM users JOIN orders ON orders.user_id = "
     position = len("SELECT users.name, orders.id FROM users JOIN orders ON orders.user_id = ")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list([
+    assert result == [
         Completion(text="users", start_position=0),
         Completion(text="orders", start_position=0),
-    ])
+    ]
 
 
 def test_table_names_after_from(completer, complete_event):
     text = "SELECT * FROM "
     position = len("SELECT * FROM ")
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert result == list([
+    assert result == [
         Completion(text="users", start_position=0),
         Completion(text="orders", start_position=0),
         Completion(text="`select`", start_position=0),
         Completion(text="`réveillé`", start_position=0),
-    ])
+    ]
 
 
 def test_auto_escaped_col_names(completer, complete_event):

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -369,5 +369,5 @@ def dummy_list_path(dir_name):
 def test_file_name_completion(completer, complete_event, text, expected):
     position = len(text)
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    expected = list((Completion(txt, pos) for txt, pos in expected))
+    expected = [Completion(txt, pos) for txt, pos in expected]
     assert result == expected

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -223,9 +223,7 @@ def test_watch_query_full():
     expected_results = 4
     ctrl_c_process = send_ctrl_c(wait_interval)
     with db_connection().cursor() as cur:
-        results = list(
-            result for result in mycli.packages.special.iocommands.watch_query(arg="{0!s} {1!s}".format(watch_seconds, query), cur=cur)
-        )
+        results = list(mycli.packages.special.iocommands.watch_query(arg="{0!s} {1!s}".format(watch_seconds, query), cur=cur))
     ctrl_c_process.join(1)
     assert len(results) == expected_results
     for result in results:

--- a/test/test_sqlexecute.py
+++ b/test/test_sqlexecute.py
@@ -61,8 +61,8 @@ def test_table_and_columns_query(executor):
     run(executor, "create table a(x text, y text)")
     run(executor, "create table b(z text)")
 
-    assert set(executor.tables()) == set([("a",), ("b",)])
-    assert set(executor.table_columns()) == set([("a", "x"), ("a", "y"), ("b", "z")])
+    assert set(executor.tables()) == {("a",), ("b",)}
+    assert set(executor.table_columns()) == {("a", "x"), ("a", "y"), ("b", "z")}
 
 
 @dbtest

--- a/tox.ini
+++ b/tox.ini
@@ -17,5 +17,5 @@ commands = uv pip install -e .[dev,ssh]
 [testenv:style]
 skip_install = true
 deps = ruff
-commands = ruff check --fix
-           ruff format
+commands = ruff check
+           ruff format --diff


### PR DESCRIPTION
## Description
 * remove unused imports from `main.py`
 * remove unneeded `pass` statement
 * clean up unneeded list literals
 * remove needless whitespace
 * call `endswith()` only once with a tuple
 * fix needless generators, rule C400
 * fix needless list comprehension
 * prefer generator over map+lambda
 * disable sufficient rules for `ruff check` to pass
 * proactively add some known-first-party imports
 * enable `ruff check` in CI, modifying `tox.ini` such that files are checked but not modified

While there are many fixes, this leaves some individual rules disabled, to be enabled one-by-one in future PRs.  The key thing is that checks are turned on in CI.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
