### PR TITLE
Remove import trick needed for Python 3.7

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,8 +3,8 @@ Upcoming Release (TBD)
 
 Internal
 --------
-
 * Work on passing `ruff check` linting.
+* Remove backward-compatibility hacks.
 
 
 1.31.1 (2025/04/25)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -66,11 +66,7 @@ except ImportError:
     from urllib.parse import urlparse
     from urllib.parse import unquote
 
-try:
-    import importlib.resources as resources
-except ImportError:
-    # Python < 3.7
-    import importlib_resources as resources
+from importlib import resources
 
 try:
     import paramiko


### PR DESCRIPTION
## Description
Remove import trick needed for Python 3.7, since 3.7 is no longer supported

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
