### PR TITLE
Enable `ruff check` rule A004

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from io import open
 import os
 import sys
 import shutil

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -4,7 +4,6 @@ import locale
 import logging
 import subprocess
 import shlex
-from io import open
 from time import sleep
 
 import click

--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -1,5 +1,5 @@
 import logging
-from re import compile, escape
+import re
 from collections import Counter
 
 from prompt_toolkit.completion import Completer, Completion
@@ -900,7 +900,7 @@ class SQLCompleter(Completer):
         self.reserved_words = set()
         for x in self.keywords:
             self.reserved_words.update(x.split())
-        self.name_pattern = compile(r"^[_a-z][_a-z0-9\$]*$")
+        self.name_pattern = re.compile(r"^[_a-z][_a-z0-9\$]*$")
 
         self.special_commands = []
         self.table_formats = supported_formats
@@ -1075,8 +1075,8 @@ class SQLCompleter(Completer):
         completions = []
 
         if fuzzy:
-            regex = ".*?".join(map(escape, text))
-            pat = compile("(%s)" % regex)
+            regex = ".*?".join(map(re.escape, text))
+            pat = re.compile("(%s)" % regex)
             for item in collection:
                 r = pat.search(item.lower())
                 if r:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ ignore = [
     'E117',   # over-indented
     'W191',   # tab-indentation
     # TODO
-    'A004',   # todo enableme import shadowing builtin
     'PIE796', # todo enableme Enum contains duplicate value
 ]
 


### PR DESCRIPTION

## Description
Enable `ruff check` rule A004: import shadowing builtin.

The import of `open` was a Python 2 relic.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
