### PR TITLE
Enable `ruff check` rule PIE796

### DIFF
--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -27,7 +27,7 @@ class ServerSpecies(enum.Enum):
     MariaDB = "MariaDB"
     Percona = "Percona"
     TiDB = "TiDB"
-    Unknown = "MySQL"
+    Unknown = "Unknown"
 
 
 class ServerInfo:
@@ -50,7 +50,7 @@ class ServerInfo:
     @classmethod
     def from_version_string(cls, version_string):
         if not version_string:
-            return cls(ServerSpecies.Unknown, "")
+            return cls(ServerSpecies.MySQL, "")
 
         re_species = (
             (r"(?P<version>[0-9\.]+)-MariaDB", ServerSpecies.MariaDB),
@@ -65,7 +65,7 @@ class ServerInfo:
                 detected_species = species
                 break
         else:
-            detected_species = ServerSpecies.Unknown
+            detected_species = ServerSpecies.MySQL
             parsed_version = ""
 
         return cls(detected_species, parsed_version)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,6 @@ ignore = [
     'E114',   # indentation-with-invalid-multiple-comment
     'E117',   # over-indented
     'W191',   # tab-indentation
-    # TODO
-    'PIE796', # todo enableme Enum contains duplicate value
 ]
 
 [tool.ruff.lint.isort]

--- a/test/test_sqlexecute.py
+++ b/test/test_sqlexecute.py
@@ -290,6 +290,6 @@ def test_multiple_results(executor):
 )
 def test_version_parsing(version_string, species, parsed_version_string, version):
     server_info = ServerInfo.from_version_string(version_string)
-    assert (server_info.species and server_info.species.name) == species or ServerSpecies.Unknown
+    assert (server_info.species and server_info.species.name) == species or ServerSpecies.MySQL
     assert server_info.version_str == parsed_version_string
     assert server_info.version == version


### PR DESCRIPTION
## Description
Enable `ruff check` rule PIE796: duplicate value in Enum.

Unlike other lint fixes, this requires changes to the actual logic, returning `ServerSpecies.MySQL` where `ServerSpecies.Unknown` was returned previously.

The `Unknown` enum value ends up being unused and could be removed.

This rule could be argued to be pedantic, but I do find the fix to be slightly easier to follow as the meaning is more obvious.

## Checklist

- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
