### PR TITLE
Remove `urlparse` Python 2 compatibility trick

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -58,12 +58,8 @@ import itertools
 
 click.disable_unicode_literals_warning = True
 
-try:
-    from urlparse import urlparse
-    from urlparse import unquote
-except ImportError:
-    from urllib.parse import urlparse
-    from urllib.parse import unquote
+from urllib.parse import urlparse
+from urllib.parse import unquote
 
 from importlib import resources
 


### PR DESCRIPTION
## Description

Remove `urlparse` Python 2 compatibility trick.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
