### PR TITLE
Enable `ruff` to manage imports

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+Upcoming Release (TBD)
+======================
+
+Internal
+--------
+
+* Work on passing `ruff check` linting.
+
+
 1.31.2 (2025/05/01)
 ===================
 

--- a/mycli/clibuffer.py
+++ b/mycli/clibuffer.py
@@ -1,7 +1,8 @@
+from prompt_toolkit.application import get_app
 from prompt_toolkit.enums import DEFAULT_BUFFER
 from prompt_toolkit.filters import Condition
-from prompt_toolkit.application import get_app
-from .packages import special
+
+from mycli.packages import special
 
 
 def cli_is_multiline(mycli):

--- a/mycli/clistyle.py
+++ b/mycli/clistyle.py
@@ -1,11 +1,11 @@
 import logging
 
-import pygments.styles
-from pygments.token import string_to_tokentype, Token
-from pygments.style import Style as PygmentsStyle
-from pygments.util import ClassNotFound
+from prompt_toolkit.styles import Style, merge_styles
 from prompt_toolkit.styles.pygments import style_from_pygments_cls
-from prompt_toolkit.styles import merge_styles, Style
+from pygments.style import Style as PygmentsStyle
+import pygments.styles
+from pygments.token import Token, string_to_tokentype
+from pygments.util import ClassNotFound
 
 logger = logging.getLogger(__name__)
 

--- a/mycli/clitoolbar.py
+++ b/mycli/clitoolbar.py
@@ -1,7 +1,8 @@
-from prompt_toolkit.key_binding.vi_state import InputMode
 from prompt_toolkit.application import get_app
 from prompt_toolkit.enums import EditingMode
-from .packages import special
+from prompt_toolkit.key_binding.vi_state import InputMode
+
+from mycli.packages import special
 
 
 def create_toolbar_tokens_func(mycli, show_fish_help):

--- a/mycli/compat.py
+++ b/mycli/compat.py
@@ -2,5 +2,4 @@
 
 import sys
 
-
 WIN = sys.platform in ("win32", "cygwin")

--- a/mycli/completion_refresher.py
+++ b/mycli/completion_refresher.py
@@ -1,9 +1,9 @@
-import threading
-from .packages.special.main import COMMANDS
 from collections import OrderedDict
+import threading
 
-from .sqlcompleter import SQLCompleter
-from .sqlexecute import SQLExecute, ServerSpecies
+from mycli.packages.special.main import COMMANDS
+from mycli.sqlcompleter import SQLCompleter
+from mycli.sqlexecute import ServerSpecies, SQLExecute
 
 
 class CompletionRefresher(object):

--- a/mycli/config.py
+++ b/mycli/config.py
@@ -6,11 +6,10 @@ import os
 from os.path import exists
 import struct
 import sys
-from typing import Union, IO
+from typing import IO, Union
 
 from configobj import ConfigObj, ConfigObjError
 import pyaes
-
 
 logger = logging.getLogger(__name__)
 

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -1,9 +1,10 @@
 import logging
+
 from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.filters import completion_is_selected, emacs_mode
 from prompt_toolkit.key_binding import KeyBindings
 
-from .packages.toolkit.fzf import search_history
+from mycli.packages.toolkit.fzf import search_history
 
 _logger = logging.getLogger(__name__)
 

--- a/mycli/magic.py
+++ b/mycli/magic.py
@@ -1,7 +1,9 @@
-from .main import MyCli
-import sql.parse
-import sql.connection
 import logging
+
+import sql.connection
+import sql.parse
+
+from mycli.main import MyCli
 
 _logger = logging.getLogger(__name__)
 

--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -1,7 +1,8 @@
 import sqlparse
 from sqlparse.sql import Comparison, Identifier, Where
-from .parseutils import last_word, extract_tables, find_prev_keyword
-from .special import parse_special_command
+
+from mycli.packages.parseutils import extract_tables, find_prev_keyword, last_word
+from mycli.packages.special import parse_special_command
 
 
 def suggest_type(full_text, text_before_cursor):

--- a/mycli/packages/filepaths.py
+++ b/mycli/packages/filepaths.py
@@ -1,7 +1,6 @@
 import os
 import platform
 
-
 if os.name == "posix":
     if platform.system() == "Darwin":
         DEFAULT_SOCKET_DIRS = ["/tmp"]

--- a/mycli/packages/parseutils.py
+++ b/mycli/packages/parseutils.py
@@ -1,8 +1,9 @@
 import re
+
 import sqlglot
 import sqlparse
-from sqlparse.sql import IdentifierList, Identifier, Function
-from sqlparse.tokens import Keyword, DML, Punctuation
+from sqlparse.sql import Function, Identifier, IdentifierList
+from sqlparse.tokens import DML, Keyword, Punctuation
 
 cleanup_regex = {
     # This matches only alphanumerics and underscores.

--- a/mycli/packages/prompt_utils.py
+++ b/mycli/packages/prompt_utils.py
@@ -1,6 +1,8 @@
 import sys
+
 import click
-from .parseutils import is_destructive
+
+from mycli.packages.parseutils import is_destructive
 
 
 class ConfirmBoolParamType(click.ParamType):

--- a/mycli/packages/special/__init__.py
+++ b/mycli/packages/special/__init__.py
@@ -8,5 +8,7 @@ def export(defn):
     return defn
 
 
-from . import dbcommands  # noqa: E402 F401
-from . import iocommands  # noqa: E402 F401
+from mycli.packages.special import (
+    dbcommands,  # noqa: E402 F401
+    iocommands,  # noqa: E402 F401
+)

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -1,11 +1,13 @@
 import logging
 import os
 import platform
+
+from pymysql import ProgrammingError
+
 from mycli import __version__
 from mycli.packages.special import iocommands
+from mycli.packages.special.main import PARSED_QUERY, RAW_QUERY, special_command
 from mycli.packages.special.utils import format_uptime
-from .main import special_command, RAW_QUERY, PARSED_QUERY
-from pymysql import ProgrammingError
 
 log = logging.getLogger(__name__)
 

--- a/mycli/packages/special/delimitercommand.py
+++ b/mycli/packages/special/delimitercommand.py
@@ -1,4 +1,5 @@
 import re
+
 import sqlparse
 
 

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -1,21 +1,21 @@
-import os
-import re
 import locale
 import logging
-import subprocess
+import os
+import re
 import shlex
+import subprocess
 from time import sleep
 
 import click
 import pyperclip
 import sqlparse
 
-from . import export
-from .main import special_command, NO_QUERY, PARSED_QUERY
-from .favoritequeries import FavoriteQueries
-from .delimitercommand import DelimiterCommand
-from .utils import handle_cd_command
 from mycli.packages.prompt_utils import confirm_destructive_query
+from mycli.packages.special import export
+from mycli.packages.special.delimitercommand import DelimiterCommand
+from mycli.packages.special.favoritequeries import FavoriteQueries
+from mycli.packages.special.main import NO_QUERY, PARSED_QUERY, special_command
+from mycli.packages.special.utils import handle_cd_command
 
 TIMING_ENABLED = False
 use_expanded_output = False

--- a/mycli/packages/special/main.py
+++ b/mycli/packages/special/main.py
@@ -1,7 +1,7 @@
-import logging
 from collections import namedtuple
+import logging
 
-from . import export
+from mycli.packages.special import export
 
 log = logging.getLogger(__name__)
 

--- a/mycli/packages/toolkit/fzf.py
+++ b/mycli/packages/toolkit/fzf.py
@@ -1,11 +1,11 @@
 import re
 from shutil import which
 
-from pyfzf import FzfPrompt
 from prompt_toolkit import search
 from prompt_toolkit.key_binding.key_processor import KeyPressEvent
+from pyfzf import FzfPrompt
 
-from .history import FileHistoryWithTimestamp
+from mycli.packages.toolkit.history import FileHistoryWithTimestamp
 
 
 class Fzf(FzfPrompt):

--- a/mycli/packages/toolkit/history.py
+++ b/mycli/packages/toolkit/history.py
@@ -1,5 +1,5 @@
 import os
-from typing import Union, List, Tuple
+from typing import List, Tuple, Union
 
 from prompt_toolkit.history import FileHistory
 

--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -1,13 +1,13 @@
+from collections import Counter
 import logging
 import re
-from collections import Counter
 
 from prompt_toolkit.completion import Completer, Completion
 
-from .packages.completion_engine import suggest_type
-from .packages.parseutils import last_word
-from .packages.filepaths import parse_path, complete_path, suggest_path
-from .packages.special.favoritequeries import FavoriteQueries
+from mycli.packages.completion_engine import suggest_type
+from mycli.packages.filepaths import complete_path, parse_path, suggest_path
+from mycli.packages.parseutils import last_word
+from mycli.packages.special.favoritequeries import FavoriteQueries
 
 _logger = logging.getLogger(__name__)
 

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -3,9 +3,10 @@ import logging
 import re
 
 import pymysql
-from .packages import special
 from pymysql.constants import FIELD_TYPE
-from pymysql.converters import convert_datetime, convert_timedelta, convert_date, conversions, decoders
+from pymysql.converters import conversions, convert_date, convert_datetime, convert_timedelta, decoders
+
+from mycli.packages import special
 
 try:
     import paramiko  # noqa: F401

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ line-length = 140
 [tool.ruff.lint]
 select = [
     'A',
-#   'I',      # todo enableme imports
+    'I',
     'E',
     'W',
     'F',
@@ -90,6 +90,9 @@ known-first-party = [
     'test',
     'steps',
 ]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = 'all'
 
 [tool.ruff.format]
 preview = true

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,7 @@
 import pytest
-from .utils import HOST, USER, PASSWORD, PORT, CHARSET, create_db, db_connection, SSH_USER, SSH_HOST, SSH_PORT
+
 import mycli.sqlexecute
+from test.utils import CHARSET, HOST, PASSWORD, PORT, SSH_HOST, SSH_PORT, SSH_USER, USER, create_db, db_connection
 
 
 @pytest.fixture(scope="function")

--- a/test/features/steps/auto_vertical.py
+++ b/test/features/steps/auto_vertical.py
@@ -1,9 +1,8 @@
 from textwrap import dedent
 
 from behave import then, when
-
-import wrappers
 from utils import parse_cli_args_to_dict
+import wrappers
 
 
 @when("we run dbcli with {arg}")

--- a/test/features/steps/basic_commands.py
+++ b/test/features/steps/basic_commands.py
@@ -5,9 +5,10 @@ to call the step in "*.feature" file.
 
 """
 
-from behave import when, then
-from textwrap import dedent
 import tempfile
+from textwrap import dedent
+
+from behave import then, when
 import wrappers
 
 

--- a/test/features/steps/connection.py
+++ b/test/features/steps/connection.py
@@ -1,14 +1,13 @@
 import io
 import os
 
-from behave import when, then
-
+from behave import then, when
 import wrappers
-from test.features.steps.utils import parse_cli_args_to_dict
-from test.features.environment import MY_CNF_PATH, MYLOGIN_CNF_PATH, get_db_name_from_context
-from test.utils import HOST, PORT, USER, PASSWORD
-from mycli.config import encrypt_mylogin_cnf
 
+from mycli.config import encrypt_mylogin_cnf
+from test.features.environment import MY_CNF_PATH, MYLOGIN_CNF_PATH, get_db_name_from_context
+from test.features.steps.utils import parse_cli_args_to_dict
+from test.utils import HOST, PASSWORD, PORT, USER
 
 TEST_LOGIN_PATH = "test_login_path"
 

--- a/test/features/steps/crud_database.py
+++ b/test/features/steps/crud_database.py
@@ -5,10 +5,9 @@ to call the step in "*.feature" file.
 
 """
 
+from behave import then, when
 import pexpect
-
 import wrappers
-from behave import when, then
 
 
 @when("we create database")

--- a/test/features/steps/crud_table.py
+++ b/test/features/steps/crud_table.py
@@ -5,9 +5,10 @@ to call the step in "*.feature" file.
 
 """
 
-import wrappers
-from behave import when, then
 from textwrap import dedent
+
+from behave import then, when
+import wrappers
 
 
 @when("we create table")

--- a/test/features/steps/iocommands.py
+++ b/test/features/steps/iocommands.py
@@ -1,8 +1,8 @@
 import os
-import wrappers
-
-from behave import when, then
 from textwrap import dedent
+
+from behave import then, when
+import wrappers
 
 
 @when("we start external editor providing a file name")

--- a/test/features/steps/named_queries.py
+++ b/test/features/steps/named_queries.py
@@ -5,8 +5,8 @@ to call the step in "*.feature" file.
 
 """
 
+from behave import then, when
 import wrappers
-from behave import when, then
 
 
 @when("we save a named query")

--- a/test/features/steps/specials.py
+++ b/test/features/steps/specials.py
@@ -5,8 +5,8 @@ to call the step in "*.feature" file.
 
 """
 
+from behave import then, when
 import wrappers
-from behave import when, then
 
 
 @when("we refresh completions")

--- a/test/features/steps/wrappers.py
+++ b/test/features/steps/wrappers.py
@@ -1,8 +1,8 @@
 import re
-import pexpect
 import sys
 import textwrap
 
+import pexpect
 
 try:
     from StringIO import StringIO

--- a/test/test_clistyle.py
+++ b/test/test_clistyle.py
@@ -1,9 +1,8 @@
 """Test the mycli.clistyle module."""
 
-import pytest
-
 from pygments.style import Style
 from pygments.token import Token
+import pytest
 
 from mycli.clistyle import style_factory
 

--- a/test/test_completion_engine.py
+++ b/test/test_completion_engine.py
@@ -1,5 +1,6 @@
-from mycli.packages.completion_engine import suggest_type
 import pytest
+
+from mycli.packages.completion_engine import suggest_type
 
 
 def sorted_dicts(dicts):

--- a/test/test_completion_refresher.py
+++ b/test/test_completion_refresher.py
@@ -1,6 +1,7 @@
 import time
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 
 
 @pytest.fixture

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -5,6 +5,7 @@ import os
 import struct
 import sys
 import tempfile
+
 import pytest
 
 from mycli.config import (

--- a/test/test_dbspecial.py
+++ b/test/test_dbspecial.py
@@ -1,6 +1,6 @@
 from mycli.packages.completion_engine import suggest_type
-from .test_completion_engine import sorted_dicts
 from mycli.packages.special.utils import format_uptime
+from test.test_completion_engine import sorted_dicts
 
 
 def test_u_suggests_databases():

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,5 +1,8 @@
+from collections import namedtuple
 import os
 import shutil
+from tempfile import NamedTemporaryFile
+from textwrap import dedent
 
 import click
 from click.testing import CliRunner
@@ -7,13 +10,7 @@ from click.testing import CliRunner
 from mycli.main import MyCli, cli, thanks_picker
 from mycli.packages.special.main import COMMANDS as SPECIAL_COMMANDS
 from mycli.sqlexecute import ServerInfo
-from .utils import USER, HOST, PORT, PASSWORD, dbtest, run
-
-from textwrap import dedent
-from collections import namedtuple
-
-from tempfile import NamedTemporaryFile
-
+from test.utils import HOST, PASSWORD, PORT, USER, dbtest, run
 
 test_dir = os.path.abspath(os.path.dirname(__file__))
 project_dir = os.path.dirname(test_dir)

--- a/test/test_naive_completion.py
+++ b/test/test_naive_completion.py
@@ -1,6 +1,6 @@
-import pytest
 from prompt_toolkit.completion import Completion
 from prompt_toolkit.document import Document
+import pytest
 
 
 @pytest.fixture

--- a/test/test_parseutils.py
+++ b/test/test_parseutils.py
@@ -1,12 +1,13 @@
 import pytest
+
 from mycli.packages.parseutils import (
     extract_tables,
     extract_tables_from_complete_statements,
-    query_starts_with,
-    queries_start_with,
     is_destructive,
-    query_has_where_clause,
     is_dropping_database,
+    queries_start_with,
+    query_has_where_clause,
+    query_starts_with,
 )
 
 

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -1,7 +1,9 @@
-import pytest
 from unittest.mock import patch
+
 from prompt_toolkit.completion import Completion
 from prompt_toolkit.document import Document
+import pytest
+
 import mycli.packages.special.main as special
 
 metadata = {

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -4,12 +4,11 @@ import tempfile
 from time import time
 from unittest.mock import patch
 
-import pytest
 from pymysql import ProgrammingError
+import pytest
 
 import mycli.packages.special
-
-from .utils import dbtest, db_connection, send_ctrl_c
+from test.utils import db_connection, dbtest, send_ctrl_c
 
 
 def test_set_get_pager():

--- a/test/test_sqlexecute.py
+++ b/test/test_sqlexecute.py
@@ -1,10 +1,10 @@
 import os
 
-import pytest
 import pymysql
+import pytest
 
 from mycli.sqlexecute import ServerInfo, ServerSpecies
-from .utils import run, dbtest, set_expanded_output, is_expanded_output
+from test.utils import dbtest, is_expanded_output, run, set_expanded_output
 
 
 def assert_result_equal(result, title=None, rows=None, headers=None, status=None, auto_status=True, assert_contains=False):

--- a/test/test_tabular_output.py
+++ b/test/test_tabular_output.py
@@ -2,13 +2,11 @@
 
 from textwrap import dedent
 
-
-from .utils import USER, PASSWORD, HOST, PORT, dbtest
-
-import pytest
-from mycli.main import MyCli
-
 from pymysql.constants import FIELD_TYPE
+import pytest
+
+from mycli.main import MyCli
+from test.utils import HOST, PASSWORD, PORT, USER, dbtest
 
 
 @pytest.fixture

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,8 +1,8 @@
-import os
-import time
-import signal
-import platform
 import multiprocessing
+import os
+import platform
+import signal
+import time
 
 import pymysql
 import pytest


### PR DESCRIPTION
## Description
 * sorting
 * whitespace
 * conversion of relative imports to full paths starting with `mycli` or `test`
 * `pyproject.toml` setup

No functional changes.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
