### PR TITLE
Working extract-tables for multi-statement inputs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,15 @@
 Upcoming Release (TBD)
 ======================
 
+Bug Fixes
+----------
+
+* Let table-name extraction work on multi-statement inputs.
+
+
 Internal
 --------
+
 * Work on passing `ruff check` linting.
 * Remove backward-compatibility hacks.
 * Pin more GitHub Actions and add Dependabot support.

--- a/mycli/packages/tabular_output/sql_format.py
+++ b/mycli/packages/tabular_output/sql_format.py
@@ -1,6 +1,6 @@
 """Format adapter for sql."""
 
-from mycli.packages.parseutils import extract_tables
+from mycli.packages.parseutils import extract_tables_from_complete_statements
 
 supported_formats = (
     "sql-insert",
@@ -20,7 +20,7 @@ def escape_for_sql_statement(value):
 
 
 def adapter(data, headers, table_format=None, **kwargs):
-    tables = extract_tables(formatter.query)
+    tables = extract_tables_from_complete_statements(formatter.query)
     if len(tables) > 0:
         table = tables[0]
         if table[0]:

--- a/test/test_parseutils.py
+++ b/test/test_parseutils.py
@@ -1,6 +1,7 @@
 import pytest
 from mycli.packages.parseutils import (
     extract_tables,
+    extract_tables_from_complete_statements,
     query_starts_with,
     queries_start_with,
     is_destructive,
@@ -104,6 +105,22 @@ def test_join_table_schema_qualified():
 
 def test_join_as_table():
     tables = extract_tables("SELECT * FROM my_table AS m WHERE m.a > 5")
+    assert tables == [(None, "my_table", "m")]
+
+
+def test_extract_tables_from_complete_statements():
+    tables = extract_tables_from_complete_statements("SELECT * FROM my_table AS m WHERE m.a > 5")
+    assert tables == [(None, "my_table", "m")]
+
+
+def test_extract_tables_from_complete_statements_cte():
+    tables = extract_tables_from_complete_statements("WITH my_cte (id, num) AS ( SELECT id, COUNT(1) FROM my_table GROUP BY id ) SELECT *")
+    assert tables == [(None, "my_table", None)]
+
+
+# this would confuse plain extract_tables() per #1122
+def test_extract_tables_from_multiple_complete_statements():
+    tables = extract_tables_from_complete_statements(r'\T sql-insert; SELECT * FROM my_table AS m WHERE m.a > 5')
     assert tables == [(None, "my_table", "m")]
 
 


### PR DESCRIPTION
## Description
Working extract-tables for multi-statement inputs, using an unholy combination of sqlparse and sqlglot.

sqlparse is more lenient and can chop up multiple statements even though it doesn't understand `\T`.  sqlglot is stricter, and chokes when it sees `\T`, but is better at the simple task of extracting table names from a valid statement, and provides a much better interface.

We could also use `sqlglot.tokenize()` and split on the semicolon token, which would be more verbose.

Closes #1122, in which the table name was always given as `DUAL` when multiple statements were in the same input leading with `\T sql-insert`.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
