### PR TITLE
Relax expectation for unreliable test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Internal
 --------
 
 * Work on passing `ruff check` linting.
+* Relax expectation for unreliable test.
 
 
 1.31.2 (2025/05/01)

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -219,12 +219,12 @@ def test_watch_query_full():
     expected_value = "1"
     query = "SELECT {0!s}".format(expected_value)
     expected_title = "> {0!s}".format(query)
-    expected_results = 4
+    expected_results = [4, 5]
     ctrl_c_process = send_ctrl_c(wait_interval)
     with db_connection().cursor() as cur:
         results = list(mycli.packages.special.iocommands.watch_query(arg="{0!s} {1!s}".format(watch_seconds, query), cur=cur))
     ctrl_c_process.join(1)
-    assert len(results) == expected_results
+    assert len(results) in expected_results
     for result in results:
         assert result[0] == expected_title
         assert result[2][0] == expected_value


### PR DESCRIPTION
## Description
In practice, this watch_query could run either four or five times on my machine.  Just allow either value.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
