### PR TITLE
Bump sqlglot version to 26.x

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Internal
 
 * Work on passing `ruff check` linting.
 * Relax expectation for unreliable test.
+* Bump sqlglot version to v26 and add rs extras.
 
 
 1.31.2 (2025/05/01)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "prompt_toolkit>=3.0.6,<4.0.0",
     "PyMySQL >= 0.9.2",
     "sqlparse>=0.3.0,<0.6.0",
-    "sqlglot>=5.1.3",
+    "sqlglot[rs] == 26.*",
     "configobj >= 5.0.5",
     "cli_helpers[styles] >= 2.2.1",
     "pyperclip >= 1.8.1",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,5 +14,5 @@ sshtunnel==0.4.0
 pyperclip>=1.8.1
 importlib_resources>=5.0.0
 pyaes>=1.6.1
-sqlglot>=5.1.3
+sqlglot[rs] == 26.*
 setuptools<=71.1.0


### PR DESCRIPTION
## Description
Bump sqlglot version to 26.x and add rs extras for performance

Based on an emailed bug report, some users are unable to run the test suite after #1227 .  This may help.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
