### PR TITLE
Support SSL query parameters on DSNs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 Upcoming Release (TBD)
 ======================
 
+Features
+--------
+
+* Support SSL query parameters on DSNs.
+
 Internal
 --------
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -433,6 +433,37 @@ def test_dsn(monkeypatch):
         and MockMyCli.connect_args["database"] == "dsn_database"
     )
 
+    # Use a DSN with query parameters
+    result = runner.invoke(mycli.main.cli, args=["mysql://dsn_user:dsn_passwd@dsn_host:6/dsn_database?ssl=True"])
+    assert result.exit_code == 0, result.output + " " + str(result.exception)
+    assert (
+        MockMyCli.connect_args["user"] == "dsn_user"
+        and MockMyCli.connect_args["passwd"] == "dsn_passwd"
+        and MockMyCli.connect_args["host"] == "dsn_host"
+        and MockMyCli.connect_args["port"] == 6
+        and MockMyCli.connect_args["database"] == "dsn_database"
+        and MockMyCli.connect_args["ssl"]["enable"] is True
+    )
+
+    # When a user uses a DSN with query parameters, and used command line
+    # arguments, use the command line arguments.
+    result = runner.invoke(
+        mycli.main.cli,
+        args=[
+            "mysql://dsn_user:dsn_passwd@dsn_host:6/dsn_database?ssl=False",
+            "--ssl",
+        ],
+    )
+    assert result.exit_code == 0, result.output + " " + str(result.exception)
+    assert (
+        MockMyCli.connect_args["user"] == "dsn_user"
+        and MockMyCli.connect_args["passwd"] == "dsn_passwd"
+        and MockMyCli.connect_args["host"] == "dsn_host"
+        and MockMyCli.connect_args["port"] == 6
+        and MockMyCli.connect_args["database"] == "dsn_database"
+        and MockMyCli.connect_args["ssl"]["enable"] is True
+    )
+
 
 def test_ssh_config(monkeypatch):
     # Setup classes to mock mycli.main.MyCli


### PR DESCRIPTION
## Description

Though limited to SSL/TLS parameters, a couple of others could be included such as charsets.

The form matches the CLI options.  Example:

```
mysql://mycli@localhost:3306/mysql?ssl=True
```

As with other DSN elements, explicit CLI options will override.

This closes #1237 as written though it does not answer the original specific Discussion question of how to set SSL as a default in `~/.myclirc`.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
