### PR TITLE
Add keybindings to insert server date/datetime

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+Upcoming Release (TBD)
+======================
+
+Features
+--------
+
+* Keybindings to insert current date/datetime.
+
+
 1.32.0 (2025/07/04)
 ======================
 

--- a/doc/key_bindings.rst
+++ b/doc/key_bindings.rst
@@ -63,3 +63,27 @@ C-x u (Emacs-mode)
 Unprettify and dedent current statement, usually into one line.
 
 Only accepts buffers containing single SQL statements.
+
+##################
+C-o d (Emacs-mode)
+##################
+
+Insert the current date at cursor, defined by NOW() on the server.
+
+####################
+C-o C-d (Emacs-mode)
+####################
+
+Insert the quoted current date at cursor.
+
+##################
+C-o t (Emacs-mode)
+##################
+
+Insert the current datetime at cursor.
+
+####################
+C-o C-t (Emacs-mode)
+####################
+
+Insert the quoted current datetime at cursor.

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -4,6 +4,7 @@ from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.filters import completion_is_selected, emacs_mode
 from prompt_toolkit.key_binding import KeyBindings
 
+from mycli import shortcuts
 from mycli.packages.toolkit.fzf import search_history
 
 _logger = logging.getLogger(__name__)
@@ -101,6 +102,42 @@ def mycli_bindings(mycli):
             while 0 < cursorpos_abs < len(b.text) and b.text[cursorpos_abs] in (" ", "\n"):
                 cursorpos_abs -= 1
             b.cursor_position = min(cursorpos_abs, len(b.text))
+
+    @kb.add("c-o", "d", filter=emacs_mode)
+    def _(event):
+        """
+        Insert the current date.
+        """
+        _logger.debug("Detected <C-o d> key.")
+
+        event.app.current_buffer.insert_text(shortcuts.server_date(mycli.sqlexecute))
+
+    @kb.add("c-o", "c-d", filter=emacs_mode)
+    def _(event):
+        """
+        Insert the quoted current date.
+        """
+        _logger.debug("Detected <C-o C-d> key.")
+
+        event.app.current_buffer.insert_text(shortcuts.server_date(mycli.sqlexecute, quoted=True))
+
+    @kb.add("c-o", "t", filter=emacs_mode)
+    def _(event):
+        """
+        Insert the current datetime.
+        """
+        _logger.debug("Detected <C-o t> key.")
+
+        event.app.current_buffer.insert_text(shortcuts.server_datetime(mycli.sqlexecute))
+
+    @kb.add("c-o", "c-t", filter=emacs_mode)
+    def _(event):
+        """
+        Insert the quoted current datetime.
+        """
+        _logger.debug("Detected <C-o C-t> key.")
+
+        event.app.current_buffer.insert_text(shortcuts.server_datetime(mycli.sqlexecute, quoted=True))
 
     @kb.add("c-r", filter=emacs_mode)
     def _(event):

--- a/mycli/shortcuts.py
+++ b/mycli/shortcuts.py
@@ -1,0 +1,14 @@
+def server_date(sqlexecute, quoted: bool = False) -> str:
+    server_date_str = sqlexecute.now().strftime('%Y-%m-%d')
+    if quoted:
+        return f"'{server_date_str}'"
+    else:
+        return server_date_str
+
+
+def server_datetime(sqlexecute, quoted: bool = False) -> str:
+    server_datetime_str = sqlexecute.now().strftime('%Y-%m-%d %H:%M:%S')
+    if quoted:
+        return f"'{server_datetime_str}'"
+    else:
+        return server_datetime_str

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -94,6 +94,8 @@ class SQLExecute(object):
                                     where table_schema = '%s'
                                     order by table_name,ordinal_position"""
 
+    now_query = """SELECT NOW()"""
+
     def __init__(
         self,
         database,
@@ -392,6 +394,12 @@ class SQLExecute(object):
             else:
                 for row in cur:
                     yield row
+
+    def now(self):
+        with self.conn.cursor() as cur:
+            _logger.debug("Now Query. sql: %r", self.now_query)
+            cur.execute(self.now_query)
+            return cur.fetchone()[0]
 
     def get_connection_id(self):
         if not self.connection_id:

--- a/test/features/basic_commands.feature
+++ b/test/features/basic_commands.feature
@@ -1,5 +1,7 @@
 Feature: run the cli,
   call the help command,
+  check our application name,
+  insert the date,
   exit the cli
 
   Scenario: run "\?" command
@@ -13,6 +15,10 @@ Feature: run the cli,
   Scenario: check our application_name
      When we run query to check application_name
       then we see found
+
+  Scenario: insert the date
+     When we send "ctrl + o, ctrl + d"
+      then we see the date
 
   Scenario: run the cli and exit
      When we send "ctrl + d"

--- a/test/features/steps/basic_commands.py
+++ b/test/features/steps/basic_commands.py
@@ -5,6 +5,7 @@ to call the step in "*.feature" file.
 
 """
 
+import datetime
 import tempfile
 from textwrap import dedent
 
@@ -27,6 +28,16 @@ def step_ctrl_d(context):
     """Send Ctrl + D to hopefully exit."""
     context.cli.sendcontrol("d")
     context.exit_sent = True
+
+
+@when('we send "ctrl + o, ctrl + d"')
+def step_ctrl_o_ctrl_d(context):
+    """Send ctrl + o, ctrl + d to insert the quoted date."""
+    context.cli.send("SELECT ")
+    context.cli.sendcontrol("o")
+    context.cli.sendcontrol("d")
+    context.cli.send(" AS dt")
+    context.cli.sendline("")
 
 
 @when(r'we send "\?" command')
@@ -68,6 +79,29 @@ def step_see_found(context):
             +-------+\r
             | found |\r
             +-------+\r
+            \r
+        """)
+        + context.conf["pager_boundary"],
+        timeout=5,
+    )
+
+
+@then("we see the date")
+def step_see_date(context):
+    # There are some edge cases in which this test could fail,
+    # such as running near midnight when the test database has
+    # a different TZ setting than the system.
+    date_str = datetime.datetime.now().strftime("%Y-%m-%d")
+    wrappers.expect_exact(
+        context,
+        context.conf["pager_boundary"]
+        + "\r"
+        + dedent(f"""
+            +------------+\r
+            | dt         |\r
+            +------------+\r
+            | {date_str} |\r
+            +------------+\r
             \r
         """)
         + context.conf["pager_boundary"],


### PR DESCRIPTION
 ## Description
* <kbd>C-o</kbd> <kbd>d</kbd>: date
 * <kbd>C-o</kbd> <kbd>C-d</kbd>: quoted date
 * <kbd>C-o</kbd> <kbd>t</kbd>: datetime
 * <kbd>C-o</kbd> <kbd>C-t</kbd>: quoted datetime

all in terms of `NOW()` on the server to which we are connected.

As noted in a comment, the included test could theoretically fail in some odd circumstances.

Closes #1172 .

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
