### PR TITLE
Trailing shell-style redirect syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Features
 * Log every query and its results to a file (disabled by default).
 * Pretty prints tabular data (with colors!)
 * Support for SSL connections
+* Shell-style trailing redirects with `$>`, `$>>` and `$|` operators.
 * Some features are only exposed as [key bindings](doc/key_bindings.rst)
 
 Contributions:
@@ -150,7 +151,7 @@ https://github.com/dbcli/mycli/blob/main/CONTRIBUTING.md
 
 ## Additional Install Instructions:
 
-These are some alternative ways to install mycli that are not managed by our team but provided by OS package maintainers. These packages could be slightly out of date and take time to release the latest version. 
+These are some alternative ways to install mycli that are not managed by our team but provided by OS package maintainers. These packages could be slightly out of date and take time to release the latest version.
 
 ### Arch, Manjaro
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ Features
 
 * Keybindings to insert current date/datetime.
 * Improve feedback when running external commands.
+* Independent format for redirected output.
+* Trailing shell-style redirect syntax.
+
 
 Internal
 --------

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -39,6 +39,10 @@ beep_after_seconds = 0
 # Recommended: ascii
 table_format = ascii
 
+# Redirected otuput format
+# Recommended: csv
+redirect_format = csv
+
 # Syntax coloring style. Possible values (many support the "-dark" suffix):
 # manni, igor, xcode, vim, autumn, vs, rrt, native, perldoc, borland, tango, emacs,
 # friendly, monokai, paraiso, colorful, murphy, bw, pastie, paraiso, trac, default,

--- a/test/features/fixture_data/help_commands.txt
+++ b/test/features/fixture_data/help_commands.txt
@@ -1,31 +1,33 @@
-+-------------+----------------------------+------------------------------------------------------------+
-| Command     | Shortcut                   | Description                                                |
-+-------------+----------------------------+------------------------------------------------------------+
-| \G          | \G                         | Display current query results vertically.                  |
-| \clip       | \clip                      | Copy query to the system clipboard.                        |
-| \dt         | \dt[+] [table]             | List or describe tables.                                   |
-| \e          | \e                         | Edit command with editor (uses $EDITOR).                   |
-| \f          | \f [name [args..]]         | List or execute favorite queries.                          |
-| \fd         | \fd [name]                 | Delete a favorite query.                                   |
-| \fs         | \fs name query             | Save a favorite query.                                     |
-| \l          | \l                         | List databases.                                            |
-| \once       | \o [-o] filename           | Append next result to an output file (overwrite using -o). |
-| \pipe_once  | \| command                 | Send next result to a subprocess.                          |
-| \timing     | \t                         | Toggle timing of commands.                                 |
-| connect     | \r                         | Reconnect to the database. Optional database argument.     |
-| exit        | \q                         | Exit.                                                      |
-| help        | \?                         | Show this help.                                            |
-| nopager     | \n                         | Disable pager, print to stdout.                            |
-| notee       | notee                      | Stop writing results to an output file.                    |
-| pager       | \P [command]               | Set PAGER. Print the query results via PAGER.              |
-| prompt      | \R                         | Change prompt format.                                      |
-| quit        | \q                         | Quit.                                                      |
-| rehash      | \#                         | Refresh auto-completions.                                  |
-| source      | \. filename                | Execute commands from file.                                |
-| status      | \s                         | Get status information from the server.                    |
-| system      | system [command]           | Execute a system shell commmand.                           |
-| tableformat | \T                         | Change the table format used to output results.            |
-| tee         | tee [-o] filename          | Append all results to an output file (overwrite using -o). |
-| use         | \u                         | Change to a new database.                                  |
-| watch       | watch [seconds] [-c] query | Executes the query every [seconds] seconds (by default 5). |
-+-------------+----------------------------+------------------------------------------------------------+
++----------------+----------------------------+------------------------------------------------------------+
+| Command        | Shortcut                   | Description                                                |
++----------------+----------------------------+------------------------------------------------------------+
+| \G             | \G                         | Display current query results vertically.                  |
+| \clip          | \clip                      | Copy query to the system clipboard.                        |
+| \dt            | \dt[+] [table]             | List or describe tables.                                   |
+| \e             | \e                         | Edit command with editor (uses $EDITOR).                   |
+| \f             | \f [name [args..]]         | List or execute favorite queries.                          |
+| \fd            | \fd [name]                 | Delete a favorite query.                                   |
+| \fs            | \fs name query             | Save a favorite query.                                     |
+| \l             | \l                         | List databases.                                            |
+| \once          | \o [-o] filename           | Append next result to an output file (overwrite using -o). |
+| \pipe_once     | \| command                 | Send next result to a subprocess.                          |
+| \timing        | \t                         | Toggle timing of commands.                                 |
+| connect        | \r                         | Reconnect to the database. Optional database argument.     |
+| delimiter      | <null>                     | Change SQL delimiter.                                      |
+| exit           | \q                         | Exit.                                                      |
+| help           | \?                         | Show this help.                                            |
+| nopager        | \n                         | Disable pager, print to stdout.                            |
+| notee          | notee                      | Stop writing results to an output file.                    |
+| pager          | \P [command]               | Set PAGER. Print the query results via PAGER.              |
+| prompt         | \R                         | Change prompt format.                                      |
+| quit           | \q                         | Quit.                                                      |
+| redirectformat | \Tr                        | Change the table format used to output redirected results. |
+| rehash         | \#                         | Refresh auto-completions.                                  |
+| source         | \. filename                | Execute commands from file.                                |
+| status         | \s                         | Get status information from the server.                    |
+| system         | system [command]           | Execute a system shell commmand.                           |
+| tableformat    | \T                         | Change the table format used to output results.            |
+| tee            | tee [-o] filename          | Append all results to an output file (overwrite using -o). |
+| use            | \u                         | Change to a new database.                                  |
+| watch          | watch [seconds] [-c] query | Executes the query every [seconds] seconds (by default 5). |
++----------------+----------------------------+------------------------------------------------------------+

--- a/test/features/iocommands.feature
+++ b/test/features/iocommands.feature
@@ -27,15 +27,15 @@ Feature: I/O commands
 
    Scenario: set delimiter and query on same line
       When we query "select 123; delimiter $ select 456 $ delimiter %"
-      then we see result "123"
-      and we see result "456"
+      then we see tabular result "123"
+      and we see tabular result "456"
       and delimiter is set to "%"
 
    Scenario: send output to file
       When we query "\o /tmp/output1.sql"
       and we query "select 123"
       and we query "system cat /tmp/output1.sql"
-      then we see result "123"
+      then we see csv result "123"
 
    Scenario: send output to file two times
       When we query "\o /tmp/output1.sql"
@@ -43,5 +43,13 @@ Feature: I/O commands
       and we query "\o /tmp/output2.sql"
       and we query "select 456"
       and we query "system cat /tmp/output2.sql"
-      then we see result "456"
+      then we see csv result "456"
   
+   Scenario: shell style redirect to file
+      When we query "select 123 as constant $> /tmp/output1.csv"
+      and we query "system cat /tmp/output1.csv"
+      then we see csv 123 in redirected output
+
+   Scenario: shell style redirect to command
+      When we query "select 100 $| wc"
+      then we see 12 in redirected output

--- a/test/features/steps/iocommands.py
+++ b/test/features/steps/iocommands.py
@@ -69,9 +69,14 @@ def step_query_select_number(context, param):
     wrappers.expect_exact(context, "1 row in set", timeout=2)
 
 
-@then('we see result "{result}"')
-def step_see_result(context, result):
-    wrappers.expect_exact(context, "| {} |".format(result), timeout=2)
+@then('we see tabular result "{result}"')
+def step_see_tabular_result(context, result):
+    wrappers.expect_exact(context, '| {} |'.format(result), timeout=2)
+
+
+@then('we see csv result "{result}"')
+def step_see_csv_result(context, result):
+    wrappers.expect_exact(context, '"{}"'.format(result), timeout=2)
 
 
 @when('we query "{query}"')
@@ -90,6 +95,19 @@ def step_see_123456_in_ouput(context):
         assert "123456" in f.read()
     if os.path.exists(context.tee_file_name):
         os.remove(context.tee_file_name)
+
+
+@then("we see csv 123 in redirected output")
+def step_see_csv_123_in_ouput(context):
+    wrappers.expect_exact(context, '"123"', timeout=2)
+    temp_filename = "/tmp/output1.csv"
+    if os.path.exists(temp_filename):
+        os.remove(temp_filename)
+
+
+@then("we see 12 in redirected output")
+def step_see_12_in_ouput(context):
+    wrappers.expect_exact(context, ' 12', timeout=2)
 
 
 @then('delimiter is set to "{delimiter}"')

--- a/test/myclirc
+++ b/test/myclirc
@@ -39,6 +39,10 @@ beep_after_seconds = 0
 # Recommended: ascii
 table_format = ascii
 
+# Redirected otuput format
+# Recommended: csv
+redirect_format = csv
+
 # Syntax coloring style. Possible values (many support the "-dark" suffix):
 # manni, igor, xcode, vim, autumn, vs, rrt, native, perldoc, borland, tango, emacs,
 # friendly, monokai, paraiso, colorful, murphy, bw, pastie, paraiso, trac, default,

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -320,7 +320,8 @@ def test_dsn(monkeypatch):
         def __init__(self, **args):
             self.logger = Logger()
             self.destructive_warning = False
-            self.formatter = Formatter()
+            self.main_formatter = Formatter()
+            self.redirect_formatter = Formatter()
 
         def connect(self, **args):
             MockMyCli.connect_args = args
@@ -483,7 +484,8 @@ def test_ssh_config(monkeypatch):
         def __init__(self, **args):
             self.logger = Logger()
             self.destructive_warning = False
-            self.formatter = Formatter()
+            self.main_formatter = Formatter()
+            self.redirect_formatter = Formatter()
 
         def connect(self, **args):
             MockMyCli.connect_args = args

--- a/test/test_tabular_output.py
+++ b/test/test_tabular_output.py
@@ -46,8 +46,9 @@ def test_sql_output(mycli):
 
     # Test sql-update output format
     assert list(mycli.change_table_format("sql-update")) == [(None, None, None, "Changed table format to sql-update")]
-    mycli.formatter.query = ""
-    output = mycli.format_output(None, FakeCursor(), headers)
+    mycli.main_formatter.query = ""
+    mycli.redirect_formatter.query = ""
+    output = mycli.format_output(None, FakeCursor(), headers, False, False)
     actual = "\n".join(output)
     assert actual == dedent("""\
             UPDATE `DUAL` SET
@@ -64,8 +65,9 @@ def test_sql_output(mycli):
             WHERE `letters` = 'd';""")
     # Test sql-update-2 output format
     assert list(mycli.change_table_format("sql-update-2")) == [(None, None, None, "Changed table format to sql-update-2")]
-    mycli.formatter.query = ""
-    output = mycli.format_output(None, FakeCursor(), headers)
+    mycli.main_formatter.query = ""
+    mycli.redirect_formatter.query = ""
+    output = mycli.format_output(None, FakeCursor(), headers, False, False)
     assert "\n".join(output) == dedent("""\
             UPDATE `DUAL` SET
               `optional` = NULL
@@ -79,8 +81,9 @@ def test_sql_output(mycli):
             WHERE `letters` = 'd' AND `number` = 456;""")
     # Test sql-insert output format (without table name)
     assert list(mycli.change_table_format("sql-insert")) == [(None, None, None, "Changed table format to sql-insert")]
-    mycli.formatter.query = ""
-    output = mycli.format_output(None, FakeCursor(), headers)
+    mycli.main_formatter.query = ""
+    mycli.redirect_formatter.query = ""
+    output = mycli.format_output(None, FakeCursor(), headers, False, False)
     assert "\n".join(output) == dedent("""\
             INSERT INTO `DUAL` (`letters`, `number`, `optional`, `float`, `binary`) VALUES
               ('abc', 1, NULL, 10.0e0, X'aa')
@@ -88,8 +91,9 @@ def test_sql_output(mycli):
             ;""")
     # Test sql-insert output format (with table name)
     assert list(mycli.change_table_format("sql-insert")) == [(None, None, None, "Changed table format to sql-insert")]
-    mycli.formatter.query = "SELECT * FROM `table`"
-    output = mycli.format_output(None, FakeCursor(), headers)
+    mycli.main_formatter.query = "SELECT * FROM `table`"
+    mycli.redirect_formatter.query = "SELECT * FROM `table`"
+    output = mycli.format_output(None, FakeCursor(), headers, False, False)
     assert "\n".join(output) == dedent("""\
             INSERT INTO table (`letters`, `number`, `optional`, `float`, `binary`) VALUES
               ('abc', 1, NULL, 10.0e0, X'aa')
@@ -97,8 +101,9 @@ def test_sql_output(mycli):
             ;""")
     # Test sql-insert output format (with database + table name)
     assert list(mycli.change_table_format("sql-insert")) == [(None, None, None, "Changed table format to sql-insert")]
-    mycli.formatter.query = "SELECT * FROM `database`.`table`"
-    output = mycli.format_output(None, FakeCursor(), headers)
+    mycli.main_formatter.query = "SELECT * FROM `database`.`table`"
+    mycli.redirect_formatter.query = "SELECT * FROM `database`.`table`"
+    output = mycli.format_output(None, FakeCursor(), headers, False, False)
     assert "\n".join(output) == dedent("""\
             INSERT INTO database.table (`letters`, `number`, `optional`, `float`, `binary`) VALUES
               ('abc', 1, NULL, 10.0e0, X'aa')


### PR DESCRIPTION
## Description
Inspired by redis-cli, add trailing shell-style redirect syntax.  This mostly duplicates `\once` and `\pipe_once` in functionality but with much greater convenience.

Before:

```sql
\T csv;
\once -o name.csv;
select * from user where username = 'name';
\T ascii;
```

After

```sql
select * from user where username = 'name' $> name.csv;
```

Like the shell, a single angle bracket overwrites, and a double angle bracket appends.  The `$` character is needed to resolve ambiguity with SQL's built-in operators.

Limitation: the filename must not contain spaces or angle brackets.

Limitation: a trailing semicolon is still required in multiline mode.

Limitation: the input line must be a single statement.

The parsing algorithm is:
 * does the input contain a dollar-operator sequence, as tokenized by sqlglot?  This guarantees that the sequence is outside of a quote.
 * is the text to the left of the rightmost dollar-operator valid SQL?
 * is the text to the right of the rightmost dollar-operator free of space and angle-bracket characters?

If so, execute the SQL to the left of the operator and store the results to the file named after the right of the operator, appending or overwriting depending on the value of the operator.  Tilde expansion is applied to the filename.

Limitation: if any of the above conditions is not met, mycli will fall back to dispatching the command as plain SQL.  This means that error messages may not be clear when the user's intent is to use redirection, but the input is somehow not parseable.

A new setting `\Tr`, alias redirectformat, is introduced, making the redirected output format independent from the main interactive format. This defaults to CSV, which can be considered a breaking change, since previously the format was whatever the user had selected for interactive use.  The default for redirectformat can also be changed in myclirc.

`\once`, `\pipe_once`, and shell-style redirects now redirect content only to the designated output target and not to the TUI.  This can also be considered a breaking change.

tee is unchanged here, as the intention with tee may be different, considering that queries are also logged.

Support for a `|` operator is also included.  In this case, the shell portion may contain spaces.  The limitation is that there may be only one `|`, not a chained pipeline.  Still, one can do

```sql
select * from user where username = 'name' $| gh gist create;
```

or

```sql
select 100 as constant $| jq '. | length';
8
3
```

Documentation in this PR is a single line in `README.md`, and must be extended separately.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
