### PR TITLE
Improve feedback from running external commands

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features
 --------
 
 * Keybindings to insert current date/datetime.
+* Improve feedback when running external commands.
 
 Internal
 --------

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -464,10 +464,12 @@ def unset_pipe_once_if_written():
     global pipe_once_process, written_to_pipe_once_process
     if written_to_pipe_once_process:
         (stdout_data, stderr_data) = pipe_once_process.communicate()
-        if len(stdout_data) > 0:
-            print(stdout_data.rstrip("\n"))
-        if len(stderr_data) > 0:
-            print(stderr_data.rstrip("\n"))
+        if stdout_data:
+            click.secho(stdout_data.rstrip('\n'))
+        if stderr_data:
+            click.secho(stderr_data.rstrip('\n'), err=True, fg='red')
+        if pipe_once_process.returncode:
+            click.secho(f'process exited with nonzero code {pipe_once_process.returncode}', err=True, fg='red')
         pipe_once_process = None
         written_to_pipe_once_process = False
 


### PR DESCRIPTION
## Description
 * use `click.secho()` instead of `print()`
 * show `STDERR` output in red
 * add nonzero exit code message, in red
 
We could consider showing diagnostic output in another color such as blue, but emphasizing the exit code message in red.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
