### PR TITLE
Remove helpdoc text from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A command line client for MySQL that can do auto-completion and syntax highlighting.
 
-HomePage: [http://mycli.net](http://mycli.net)
+Homepage: [http://mycli.net](http://mycli.net)
 Documentation: [http://mycli.net/docs](http://mycli.net/docs)
 
 ![Completion](screenshots/tables.png)
@@ -15,107 +15,33 @@ Postgres Equivalent: [http://pgcli.com](http://pgcli.com)
 Quick Start
 -----------
 
-If you already know how to install python packages, then you can install it via pip:
+If you already know how to install Python packages, then you can install it via `pip`:
 
-You might need sudo on linux.
+You might need sudo on Linux.
 
-```
+```bash
 $ pip install -U mycli
 ```
 
 or
 
-```
+```bash
 $ brew update && brew install mycli  # Only on macOS
 ```
 
 or
 
-```
-$ sudo apt-get install mycli # Only on debian or ubuntu
+```bash
+$ sudo apt-get install mycli  # Only on Debian or Ubuntu
 ```
 
 ### Usage
 
-    $ mycli --help
-    Usage: mycli [OPTIONS] [DATABASE]
+See
 
-      A MySQL terminal client with auto-completion and syntax highlighting.
-
-      Examples:
-        - mycli my_database
-        - mycli -u my_user -h my_host.com my_database
-        - mycli mysql://my_user@my_host.com:3306/my_database
-
-    Options:
-      -h, --host TEXT               Host address of the database.
-      -P, --port INTEGER            Port number to use for connection. Honors
-                                    $MYSQL_TCP_PORT.
-
-      -u, --user TEXT               User name to connect to the database.
-      -S, --socket TEXT             The socket file to use for connection.
-      -p, --password TEXT           Password to connect to the database.
-      --pass TEXT                   Password to connect to the database.
-      --ssh-user TEXT               User name to connect to ssh server.
-      --ssh-host TEXT               Host name to connect to ssh server.
-      --ssh-port INTEGER            Port to connect to ssh server.
-      --ssh-password TEXT           Password to connect to ssh server.
-      --ssh-key-filename TEXT       Private key filename (identify file) for the
-                                    ssh connection.
-
-      --ssh-config-path TEXT        Path to ssh configuration.
-      --ssh-config-host TEXT        Host to connect to ssh server reading from ssh
-                                    configuration.
-
-      --ssl                         Enable SSL for connection (automatically
-                                    enabled with other flags).
-      --ssl-ca PATH                 CA file in PEM format.
-      --ssl-capath TEXT             CA directory.
-      --ssl-cert PATH               X509 cert in PEM format.
-      --ssl-key PATH                X509 key in PEM format.
-      --ssl-cipher TEXT             SSL cipher to use.
-      --tls-version [TLSv1|TLSv1.1|TLSv1.2|TLSv1.3]
-                                    TLS protocol version for secure connection.
-
-      --ssl-verify-server-cert      Verify server's "Common Name" in its cert
-                                    against hostname used when connecting. This
-                                    option is disabled by default.
-
-      -V, --version                 Output mycli's version.
-      -v, --verbose                 Verbose output.
-      -D, --database TEXT           Database to use.
-      -d, --dsn TEXT                Use DSN configured into the [alias_dsn]
-                                    section of myclirc file.
-
-      --list-dsn                    list of DSN configured into the [alias_dsn]
-                                    section of myclirc file.
-
-      --list-ssh-config             list ssh configurations in the ssh config
-                                    (requires paramiko).
-
-      -R, --prompt TEXT             Prompt format (Default: "\t \u@\h:\d> ").
-      -l, --logfile FILENAME        Log every query and its results to a file.
-      --defaults-group-suffix TEXT  Read MySQL config groups with the specified
-                                    suffix.
-
-      --defaults-file PATH          Only read MySQL options from the given file.
-      --myclirc PATH                Location of myclirc file.
-      --auto-vertical-output        Automatically switch to vertical output mode
-                                    if the result is wider than the terminal
-                                    width.
-
-      -t, --table                   Display batch output in table format.
-      --csv                         Display batch output in CSV format.
-      --warn / --no-warn            Warn before running a destructive query.
-      --local-infile BOOLEAN        Enable/disable LOAD DATA LOCAL INFILE.
-      -g, --login-path TEXT         Read this path from the login file.
-      -e, --execute TEXT            Execute command and quit.
-      --init-command TEXT           SQL statement to execute after connecting.
-      --charset TEXT                Character set for MySQL session.
-      --password-file PATH          File or FIFO path containing the password
-                                    to connect to the db if not specified otherwise
-      --help                        Show this message and exit.
-
+```bash
+$ mycli --help
+```
 
 Features
 --------

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+Upcoming Release (TBD)
+======================
+
+Internal
+--------
+
+* Documentation cleanup
+
+
 1.33.0 (2025/07/07)
 ======================
 


### PR DESCRIPTION
## Description
This tends to stay out of date, and adds a lot of text to README.md, which should focus on features.

Incidentally fix orthography and add `bash` to fenced shell examples.


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
