### PR TITLE
Post-save command hook for redirected output

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 Upcoming Release (TBD)
 ======================
 
+Features
+--------
+
+* Post-save command hook for redirected output.
+
 Internal
 --------
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -142,6 +142,7 @@ class MyCli(object):
         c_dest_warning = c["main"].as_bool("destructive_warning")
         self.destructive_warning = c_dest_warning if warn is None else warn
         self.login_path_as_host = c["main"].as_bool("login_path_as_host")
+        self.post_redirect_command = c['main'].get('post_redirect_command')
 
         # read from cli argument or user config file
         self.auto_vertical_output = auto_vertical_output or c["main"].as_bool("auto_vertical_output")
@@ -797,7 +798,7 @@ class MyCli(object):
                     start = time()
                     result_count += 1
                     mutating = mutating or destroy or is_mutating(status)
-                special.unset_once_if_written()
+                special.unset_once_if_written(self.post_redirect_command)
                 special.unset_pipe_once_if_written()
             except EOFError as e:
                 raise e

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -43,6 +43,11 @@ table_format = ascii
 # Recommended: csv
 redirect_format = csv
 
+# A command to run after a successful output redirect, with {} to be replaced
+# with the escaped filename.  Mac example: echo {} | pbcopy.  Escaping is not
+# reliable/safe on Windows.
+post_redirect_command =
+
 # Syntax coloring style. Possible values (many support the "-dark" suffix):
 # manni, igor, xcode, vim, autumn, vs, rrt, native, perldoc, borland, tango, emacs,
 # friendly, monokai, paraiso, colorful, murphy, bw, pastie, paraiso, trac, default,


### PR DESCRIPTION
## Description
Let a command be executed after successful save-to-file by redirect or `\once`, only if `main.post_redirect_command` is set in .myclirc.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
