### PR TITLE
Update cli_helpers to v2.5.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,8 @@ Features
 Internal
 --------
 
-* Documentation cleanup
+* Documentation cleanup.
+* Bump cli_helpers dependency for more output formats.
 
 
 1.33.0 (2025/07/07)

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -35,12 +35,13 @@ beep_after_seconds = 0
 
 # Table format. Possible values: ascii, double, github,
 # psql, plain, simple, grid, fancy_grid, pipe, orgtbl, rst, mediawiki, html,
-# latex, latex_booktabs, textile, moinmoin, jira, vertical, tsv, csv.
+# latex, latex_booktabs, textile, moinmoin, jira, vertical, tsv, tsv_noheader,
+# csv, csv-noheader, jsonl, jsonl_unescaped.
 # Recommended: ascii
 table_format = ascii
 
 # Redirected otuput format
-# Recommended: csv
+# Recommended: csv.
 redirect_format = csv
 
 # A command to run after a successful output redirect, with {} to be replaced

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "sqlparse>=0.3.0,<0.6.0",
     "sqlglot[rs] == 26.*",
     "configobj >= 5.0.5",
-    "cli_helpers[styles] >= 2.2.1",
+    "cli_helpers[styles] >= 2.5.0",
     "pyperclip >= 1.8.1",
     "pyaes >= 1.6.1",
     "pyfzf >= 0.3.1",

--- a/test/myclirc
+++ b/test/myclirc
@@ -35,13 +35,19 @@ beep_after_seconds = 0
 
 # Table format. Possible values: ascii, double, github,
 # psql, plain, simple, grid, fancy_grid, pipe, orgtbl, rst, mediawiki, html,
-# latex, latex_booktabs, textile, moinmoin, jira, vertical, tsv, csv.
+# latex, latex_booktabs, textile, moinmoin, jira, vertical, tsv, tsv_noheader,
+# csv, csv-noheader, jsonl, jsonl_unescaped.
 # Recommended: ascii
 table_format = ascii
 
 # Redirected otuput format
-# Recommended: csv
+# Recommended: csv.
 redirect_format = csv
+
+# A command to run after a successful output redirect, with {} to be replaced
+# with the escaped filename.  Mac example: echo {} | pbcopy.  Escaping is not
+# reliable/safe on Windows.
+post_redirect_command = ""
 
 # Syntax coloring style. Possible values (many support the "-dark" suffix):
 # manni, igor, xcode, vim, autumn, vs, rrt, native, perldoc, borland, tango, emacs,


### PR DESCRIPTION
## Description
Update cli_helpers to v2.5.0, allowing more output formats.  Some users might prefer jsonl over csv for redirected output.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
