### PR TITLE
Bump cli_helpers to v2.6.0, preparing bugfix release

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+1.34.1 (2025/07/12)
+======================
+
+Internal
+--------
+
+* Bump cli_helpers dependency for corrected output formats.
+
+
 1.34.0 (2025/07/11)
 ======================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "sqlparse>=0.3.0,<0.6.0",
     "sqlglot[rs] == 26.*",
     "configobj >= 5.0.5",
-    "cli_helpers[styles] >= 2.5.0",
+    "cli_helpers[styles] >= 2.6.0",
     "pyperclip >= 1.8.1",
     "pyaes >= 1.6.1",
     "pyfzf >= 0.3.1",


### PR DESCRIPTION
## Description
Version 2.6.0 of cli_helpers has corrected JSON output formats.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
