### PR TITLE
Use plain `print()` to communicate with subprocess

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+Upcoming Release (TBD)
+======================
+
+Internal
+--------
+
+* Use plain `print()` to communicate with subprocess.
+
+
 1.34.1 (2025/07/12)
 ======================
 

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -542,8 +542,8 @@ def write_pipe_once(output):
     global pipe_once_process, written_to_pipe_once_process
     if output and pipe_once_process:
         try:
-            click.echo(output, file=pipe_once_process.stdin, nl=False)
-            click.echo("\n", file=pipe_once_process.stdin, nl=False)
+            for line in output.split('\n'):
+                print(line, file=pipe_once_process.stdin)
         except (IOError, OSError) as e:
             pipe_once_process.terminate()
             raise OSError("Failed writing to pipe_once subprocess: {}".format(e.strerror))


### PR DESCRIPTION
## Description
Some lockups were observed when redirecting large outputs to `jq`. `click.echo` does `file.write()` and `file.flush()` which is probably not what we want given that line-buffering was requested in `Popen()`.

We might also want to avoid setting these:

    stdout=subprocess.PIPE,
    stderr=subprocess.PIPE,

and just allow the subprocess to communicate to the TTY.  That's where the output goes eventually anyway.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
