### PR TITLE
Single `communicate()` input to `pipe_once` process

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+1.34.3 (2025/07/14)
+======================
+
+Bug Fixes
+--------
+
+* Use only `communicate()` to communicate with subprocess.
+
+
 1.34.2 (2025/07/12)
 ======================
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -799,7 +799,7 @@ class MyCli(object):
                     result_count += 1
                     mutating = mutating or destroy or is_mutating(status)
                 special.unset_once_if_written(self.post_redirect_command)
-                special.unset_pipe_once_if_written()
+                special.flush_pipe_once_if_written()
             except EOFError as e:
                 raise e
             except KeyboardInterrupt:

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -154,12 +154,12 @@ def test_pipe_once_command():
     if os.name == "nt":
         mycli.packages.special.execute(None, '\\pipe_once python -c "import sys; print(len(sys.stdin.read().strip()))"')
         mycli.packages.special.write_once("hello world")
-        mycli.packages.special.unset_pipe_once_if_written()
+        mycli.packages.special.flush_pipe_once_if_written()
     else:
         with tempfile.NamedTemporaryFile() as f:
             mycli.packages.special.execute(None, "\\pipe_once tee " + f.name)
             mycli.packages.special.write_pipe_once("hello world")
-            mycli.packages.special.unset_pipe_once_if_written()
+            mycli.packages.special.flush_pipe_once_if_written()
             f.seek(0)
             assert f.read() == b"hello world\n"
 


### PR DESCRIPTION
## Description
 * turn off line buffering for pipe_once
 * accumulate lines for input in an array
 * make a single `communicate()` call to the subprocess with the entire accumulated input
 * recast `unset_pipe_once_if_written()` as `flush_pipe_once_if_written(`) for clarity

Buffered communication is hard.  The `subprocess` docs recommend

> Warning Use communicate() rather than .stdin.write, .stdout.read or
> .stderr.read to avoid deadlocks due to any of the other OS pipe
> buffers filling up and blocking the child process.

 * https://docs.python.org/3/library/subprocess.html#subprocess.Popen.stderr

So, let's do that.

The issues we are trying to address involve buffering deadlocks.  These issues were always present with `\pipe_once`, but the issues are easier to exercise now that piping to an external process is easier to do.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
