### PR TITLE
Support chained pipe operations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+Upcoming Release (TBD)
+======================
+
+Features
+--------
+
+* Support chained pipe operators.
+
+
 1.34.4 (2025/07/15)
 ======================
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -709,10 +709,10 @@ class MyCli(object):
                 return
 
             if special.is_redirect_command(text):
-                redirect_sql, redirect_operator, redirect_filename = special.get_redirect_components(text)
-                text = redirect_sql
+                sql_part, operator_part, shell_part = special.get_redirect_components(text)
+                text = sql_part
                 try:
-                    special.set_redirect(redirect_filename, redirect_operator)
+                    special.set_redirect(shell_part, operator_part)
                 except (FileNotFoundError, OSError, RuntimeError) as e:
                     logger.error("sql: %r, error: %r", text, e)
                     logger.error("traceback: %r", traceback.format_exc())

--- a/test/features/iocommands.feature
+++ b/test/features/iocommands.feature
@@ -53,3 +53,7 @@ Feature: I/O commands
    Scenario: shell style redirect to command
       When we query "select 100 $| wc"
       then we see 12 in redirected output
+
+   Scenario: shell style redirect to multiple commands
+      When we query "select 100 $| head -1 $| wc"
+      then we see 6 in redirected output

--- a/test/features/steps/iocommands.py
+++ b/test/features/steps/iocommands.py
@@ -110,6 +110,11 @@ def step_see_12_in_ouput(context):
     wrappers.expect_exact(context, ' 12', timeout=2)
 
 
+@then("we see 6 in redirected output")
+def step_see_6_in_ouput(context):
+    wrappers.expect_exact(context, ' 6', timeout=2)
+
+
 @then('delimiter is set to "{delimiter}"')
 def delimiter_is_set(context, delimiter):
     wrappers.expect_exact(context, "Changed delimiter to {}".format(delimiter), timeout=2)

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -150,6 +150,8 @@ def test_pipe_once_command():
 
     with pytest.raises(OSError):
         mycli.packages.special.execute(None, "\\pipe_once /proc/access-denied")
+        mycli.packages.special.write_pipe_once("select 1")
+        mycli.packages.special.flush_pipe_once_if_written()
 
     if os.name == "nt":
         mycli.packages.special.execute(None, '\\pipe_once python -c "import sys; print(len(sys.stdin.read().strip()))"')


### PR DESCRIPTION
## Description

With changed pipe operations, you can use multiple steps to process the output of a query, using the shell.

For example, MySQL can compute an average but not a median.  But this query might tell you the median signup date for a user, if you have the `datamash` utility installed:

```sql
SELECT YEAR(create_date) FROM users $| grep -Eo '\d+' $| datamash median 1;
```

The `grep` command extracts plain numbers from our CSV output.  The `datamash` command computes the median.

Changes:
 * recast variables from parse as `sql_part`, `operator_part`, and `shell_part`.  Use these consistently.
 * cache `get_redirect_command()` since it is called twice: once to see if a redirected is wanted; the second time for the parts.
 * break redirect parser into units.
 * rewrite parse to allow chained pipe operations, accepting any number of `$|`.  Disallow chained `$|` on Windows, since there isn't a POSIX `sh` we can depend on.  `pipe_once` may already not work well on Windows.

The parse rule is changed from looking for the rightmost matching shell operator to the leftmost matching operator.  This can have no effect for file redirections, since the angle bracket was and is a disallowed character in the file part.

A chain of `$|` followed by `$>` is disallowed in the parse, but there is a comment that this is a reasonable future feature.

This implementation currently has the bug/hidden feature that only the leftmost `$|` must have the dollar sign.  That probably must be fixed.

The behavior of `\pipe_once` is changing on certain errors.  The error is not thrown immediately for example on `\pipe_once nonexistent_command`. It is not thrown until some input is given.  This is required by the switch to `communicate()`, and is much more predictable behavior, as previously only some types of errors were frontloaded.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
