### PR TITLE
Allow trailing file redirects after pipe commands

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,8 @@ Upcoming Release (TBD)
 Features
 --------
 
-* Support chained pipe operators.
+* Support chained pipe operators such as `select first_name from users $| grep '^J' $| head -10`.
+* Support trailing file redirects after pipe operators, such as `select 10 $| tail -1 $> ten.txt`.
 
 
 1.34.4 (2025/07/15)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -709,10 +709,10 @@ class MyCli(object):
                 return
 
             if special.is_redirect_command(text):
-                sql_part, operator_part, shell_part = special.get_redirect_components(text)
+                sql_part, command_part, file_operator_part, file_part = special.get_redirect_components(text)
                 text = sql_part
                 try:
-                    special.set_redirect(shell_part, operator_part)
+                    special.set_redirect(command_part, file_operator_part, file_part)
                 except (FileNotFoundError, OSError, RuntimeError) as e:
                     logger.error("sql: %r, error: %r", text, e)
                     logger.error("traceback: %r", traceback.format_exc())
@@ -799,7 +799,7 @@ class MyCli(object):
                     result_count += 1
                     mutating = mutating or destroy or is_mutating(status)
                 special.unset_once_if_written(self.post_redirect_command)
-                special.flush_pipe_once_if_written()
+                special.flush_pipe_once_if_written(self.post_redirect_command)
             except EOFError as e:
                 raise e
             except KeyboardInterrupt:

--- a/test/features/iocommands.feature
+++ b/test/features/iocommands.feature
@@ -48,12 +48,47 @@ Feature: I/O commands
    Scenario: shell style redirect to file
       When we query "select 123 as constant $> /tmp/output1.csv"
       and we query "system cat /tmp/output1.csv"
-      then we see csv 123 in redirected output
+      then we see csv 123 in file output
 
    Scenario: shell style redirect to command
       When we query "select 100 $| wc"
-      then we see 12 in redirected output
+      then we see space 12 in command output
 
    Scenario: shell style redirect to multiple commands
       When we query "select 100 $| head -1 $| wc"
-      then we see 6 in redirected output
+      then we see space 6 in command output
+
+   Scenario: shell style redirect to multiple commands with minimal spaces
+      When we query "select 100$|head -1$|wc"
+      then we see space 6 in command output
+
+   Scenario: shell style redirect to multiple commands containing single quotes
+      When we query "select 100 $| head '-1' $| wc"
+      then we see space 6 in command output
+
+   Scenario: shell style redirect to multiple commands containing single quotes and minimal spaces
+      When we query "select 100$|head '-1'$|wc"
+      then we see space 6 in command output
+
+   Scenario: shell style redirect to multiple commands containing double quotes
+      When we query "select 100 $| head ""-1"" $| wc"
+      then we see space 6 in command output
+
+   Scenario: shell style redirect with commands and capture to file
+      When we query "select 100 $| head -1 $| wc $> /tmp/output1.txt"
+      and we query "system cat /tmp/output1.txt"
+      then we see text 6 in file output
+
+   Scenario: shell style redirect with append to file
+      When we query "select 100 $> /tmp/output1.csv"
+      and we query "select 200 $>> /tmp/output1.csv"
+      and we query "system cat /tmp/output1.csv"
+      then we see csv 100 in file output
+      and we see csv 200 in file output
+
+   Scenario: shell style redirect with command and append to file
+      When we query "select 300 $| grep 0 $> /tmp/output1.csv"
+      and we query "select 400 $| grep 0 $>> /tmp/output1.csv"
+      and we query "system cat /tmp/output1.csv"
+      then we see csv 300 in file output
+      and we see csv 400 in file output

--- a/test/features/steps/iocommands.py
+++ b/test/features/steps/iocommands.py
@@ -97,21 +97,29 @@ def step_see_123456_in_ouput(context):
         os.remove(context.tee_file_name)
 
 
-@then("we see csv 123 in redirected output")
-def step_see_csv_123_in_ouput(context):
-    wrappers.expect_exact(context, '"123"', timeout=2)
+@then('we see csv {result} in file output')
+def step_see_csv_result_in_redirected_ouput(context, result):
+    wrappers.expect_exact(context, f'"{result}"', timeout=2)
     temp_filename = "/tmp/output1.csv"
     if os.path.exists(temp_filename):
         os.remove(temp_filename)
 
 
-@then("we see 12 in redirected output")
-def step_see_12_in_ouput(context):
+@then('we see text {result} in file output')
+def step_see_text_result_in_redirected_ouput(context, result):
+    wrappers.expect_exact(context, f' {result}', timeout=2)
+    temp_filename = "/tmp/output1.txt"
+    if os.path.exists(temp_filename):
+        os.remove(temp_filename)
+
+
+@then("we see space 12 in command output")
+def step_see_space_12_in_command_ouput(context):
     wrappers.expect_exact(context, ' 12', timeout=2)
 
 
-@then("we see 6 in redirected output")
-def step_see_6_in_ouput(context):
+@then("we see space 6 in command output")
+def step_see_space_6_in_command_ouput(context):
     wrappers.expect_exact(context, ' 6', timeout=2)
 
 

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -151,17 +151,17 @@ def test_pipe_once_command():
     with pytest.raises(OSError):
         mycli.packages.special.execute(None, "\\pipe_once /proc/access-denied")
         mycli.packages.special.write_pipe_once("select 1")
-        mycli.packages.special.flush_pipe_once_if_written()
+        mycli.packages.special.flush_pipe_once_if_written(None)
 
     if os.name == "nt":
         mycli.packages.special.execute(None, '\\pipe_once python -c "import sys; print(len(sys.stdin.read().strip()))"')
         mycli.packages.special.write_once("hello world")
-        mycli.packages.special.flush_pipe_once_if_written()
+        mycli.packages.special.flush_pipe_once_if_written(None)
     else:
         with tempfile.NamedTemporaryFile() as f:
             mycli.packages.special.execute(None, "\\pipe_once tee " + f.name)
             mycli.packages.special.write_pipe_once("hello world")
-            mycli.packages.special.flush_pipe_once_if_written()
+            mycli.packages.special.flush_pipe_once_if_written(None)
             f.seek(0)
             assert f.read() == b"hello world\n"
 


### PR DESCRIPTION
## Description

Allow the form

```
SQL $| command $> capture.txt
```

Simple example:

```
select 10 $| tail -1 $> ten.txt
```

Changes:
 * Extract four parts in `get_redirect_components()` instead of three: `sql_part`, `command_part`, `file_operator_part`, `file_part`.
 * Log the redirect parse at DEBUG level.
 * Support post_redirect_command in `flush_pipe_once_if_written()`, factoring out `_run_post_redirect_hook()`.
 * Gather pipe_once globals into a single `PIPE_ONCE` dictionary.
 * Give leading underscores to unused variables.
 * Recast redirect parsing functions to all begin with `_redirect`.
 * When assembling tokens to a string, synthesize surrounding quotation marks, fixing a bug introduced in #1263 , but not released.
 * Reorder decorators on `get_redirect_components()` so that caching actually happens.

Notes:
 * Normally at the size of four elements I would return something other than a tuple from `get_redirect_components()`.  But this form is intuitive because they are strictly ordered.
 * Some elements of the `get_redirect_components()` tuple may be `None`s. Previously the result could be only all-strings or all-Nones.  Now if only a command is present, but the output is not captured to a file, the tuple will be mixed.  As before, `sql_part` is always None unless we can successfully parse out a redirect.
 * The redirect parsing really belongs in a separate file at this point.
 * Our reportformat (default CSV) only applies to the first operator seen.  After that what happens is up to the shell commands.  So while

    ```
    select 10 $> output.csv
    ```

   produces a CSV,

    ```
    select 10 $| wc $> output.txt
    ```

   does not.  There is really no other way for it to work, but this should be explained when documenting.
 * The more interesting the possible shell commands, the less sense it makes to have a hardcoded timeout of 60 seconds on the pipeline, as we do now.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
