### PR TITLE
Enable typechecking for several files including `filepaths.py`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ Internal
 * Support only Python 3.9+ in `pyproject.toml`.
 * Add linting suggestion to pull request template.
 * Make CI names and properties more consistent.
+* Enable typechecking for several files.
 
 
 1.36.0 (2025/07/19)

--- a/mycli/__init__.py
+++ b/mycli/__init__.py
@@ -1,5 +1,5 @@
-# type: ignore
+from __future__ import annotations
 
 import importlib.metadata
 
-__version__ = importlib.metadata.version("mycli")
+__version__: str = importlib.metadata.version("mycli")

--- a/mycli/compat.py
+++ b/mycli/compat.py
@@ -1,7 +1,7 @@
-# type: ignore
-
 """Platform and Python version compatibility support."""
+
+from __future__ import annotations
 
 import sys
 
-WIN = sys.platform in ("win32", "cygwin")
+WIN: bool = sys.platform in ("win32", "cygwin")

--- a/mycli/lexer.py
+++ b/mycli/lexer.py
@@ -1,4 +1,4 @@
-# type: ignore
+from __future__ import annotations
 
 from pygments.lexer import inherit
 from pygments.lexers.sql import MySqlLexer

--- a/mycli/packages/filepaths.py
+++ b/mycli/packages/filepaths.py
@@ -1,18 +1,17 @@
-# type: ignore
+from __future__ import annotations
 
 import os
 import platform
 
+DEFAULT_SOCKET_DIRS: list[str] = []
 if os.name == "posix":
     if platform.system() == "Darwin":
         DEFAULT_SOCKET_DIRS = ["/tmp"]
     else:
         DEFAULT_SOCKET_DIRS = ["/var/run", "/var/lib"]
-else:
-    DEFAULT_SOCKET_DIRS = []
 
 
-def list_path(root_dir):
+def list_path(root_dir: str) -> list[str]:
     """List directory if exists.
 
     :param root_dir: str
@@ -26,7 +25,7 @@ def list_path(root_dir):
     return res
 
 
-def complete_path(curr_dir, last_dir):
+def complete_path(curr_dir: str, last_dir: str) -> str:
     """Return the path to complete that matches the last entered component.
 
     If the last entered component is ~, expanded path would not
@@ -41,9 +40,11 @@ def complete_path(curr_dir, last_dir):
         return curr_dir
     elif last_dir == "~":
         return os.path.join(last_dir, curr_dir)
+    else:
+        return ''
 
 
-def parse_path(root_dir):
+def parse_path(root_dir: str) -> tuple[str, str, int]:
     """Split path into head and last component for the completer.
 
     Also return position where last component starts.
@@ -59,7 +60,7 @@ def parse_path(root_dir):
     return base_dir, last_dir, position
 
 
-def suggest_path(root_dir):
+def suggest_path(root_dir: str) -> list[str]:
     """List all files and subdirectories in a directory.
 
     If the directory is not specified, suggest root directory,
@@ -81,7 +82,7 @@ def suggest_path(root_dir):
     return list_path(root_dir)
 
 
-def dir_path_exists(path):
+def dir_path_exists(path: str) -> bool:
     """Check if the directory path exists for a given file.
 
     For example, for a file /home/user/.cache/mycli/log, check if
@@ -94,7 +95,7 @@ def dir_path_exists(path):
     return os.path.exists(os.path.dirname(path))
 
 
-def guess_socket_location():
+def guess_socket_location() -> str | None:
     """Try to guess the location of the default mysql socket file."""
     socket_dirs = filter(os.path.exists, DEFAULT_SOCKET_DIRS)
     for directory in socket_dirs:

--- a/mycli/packages/hybrid_redirection.py
+++ b/mycli/packages/hybrid_redirection.py
@@ -5,8 +5,8 @@ import logging
 
 import sqlglot
 
-from mycli.compat import WIN  # type: ignore[attr-defined]
-from mycli.packages.special.delimitercommand import DelimiterCommand  # type: ignore[attr-defined]
+from mycli.compat import WIN
+from mycli.packages.special.delimitercommand import DelimiterCommand
 
 logger = logging.getLogger(__name__)
 delimiter_command = DelimiterCommand()

--- a/mycli/packages/special/delimitercommand.py
+++ b/mycli/packages/special/delimitercommand.py
@@ -1,15 +1,16 @@
-# type: ignore
+from __future__ import annotations
 
 import re
+from typing import Generator
 
 import sqlparse  # type: ignore[import-untyped]
 
 
 class DelimiterCommand(object):
-    def __init__(self):
+    def __init__(self) -> None:
         self._delimiter = ";"
 
-    def _split(self, sql):
+    def _split(self, sql: str) -> list[str]:
         """Temporary workaround until sqlparse.split() learns about custom
         delimiters."""
 
@@ -29,7 +30,7 @@ class DelimiterCommand(object):
 
         return [stmt.replace(";", self._delimiter).replace(placeholder, ";") for stmt in split]
 
-    def queries_iter(self, input_str):
+    def queries_iter(self, input_str: str) -> Generator[str, None, None]:
         """Iterate over queries in the input string."""
 
         queries = self._split(input_str)
@@ -54,7 +55,7 @@ class DelimiterCommand(object):
                         combined_statement += delimiter
                     queries = self._split(combined_statement)[1:]
 
-    def set(self, arg, **_):
+    def set(self, arg: str, **_) -> list[tuple[None, None, None, str]]:
         """Change delimiter.
 
         Since `arg` is everything that follows the DELIMITER token
@@ -76,5 +77,5 @@ class DelimiterCommand(object):
         return [(None, None, None, "Changed delimiter to {}".format(delimiter))]
 
     @property
-    def current(self):
+    def current(self) -> str:
         return self._delimiter

--- a/mycli/packages/special/favoritequeries.py
+++ b/mycli/packages/special/favoritequeries.py
@@ -1,8 +1,8 @@
-# type: ignore
+from __future__ import annotations
 
 
-class FavoriteQueries(object):
-    section_name = "favorite_queries"
+class FavoriteQueries:
+    section_name: str = "favorite_queries"
 
     usage = """
 Favorite Queries are a way to save frequently used queries
@@ -36,27 +36,27 @@ Examples:
     # Class-level variable, for convenience to use as a singleton.
     instance = None
 
-    def __init__(self, config):
+    def __init__(self, config) -> None:
         self.config = config
 
     @classmethod
     def from_config(cls, config):
         return FavoriteQueries(config)
 
-    def list(self):
+    def list(self) -> list[str | None]:
         return self.config.get(self.section_name, [])
 
-    def get(self, name):
+    def get(self, name) -> str | None:
         return self.config.get(self.section_name, {}).get(name, None)
 
-    def save(self, name, query):
+    def save(self, name: str, query: str) -> None:
         self.config.encoding = "utf-8"
         if self.section_name not in self.config:
             self.config[self.section_name] = {}
         self.config[self.section_name][name] = query
         self.config.write()
 
-    def delete(self, name):
+    def delete(self, name: str) -> str:
         try:
             del self.config[self.section_name][name]
         except KeyError:

--- a/mycli/packages/special/utils.py
+++ b/mycli/packages/special/utils.py
@@ -1,10 +1,10 @@
-# type: ignore
+from __future__ import annotations
 
 import os
 import subprocess
 
 
-def handle_cd_command(arg):
+def handle_cd_command(arg: str) -> tuple[bool, str | None]:
     """Handles a `cd` shell command by calling python's os.chdir."""
     CD_CMD = "cd"
     tokens = arg.split(CD_CMD + " ")
@@ -19,7 +19,7 @@ def handle_cd_command(arg):
         return False, e.strerror
 
 
-def format_uptime(uptime_in_seconds):
+def format_uptime(uptime_in_seconds: str) -> str:
     """Format number of seconds into human-readable string.
 
     :param uptime_in_seconds: The server uptime in seconds.
@@ -34,14 +34,14 @@ def format_uptime(uptime_in_seconds):
     h, m = divmod(m, 60)
     d, h = divmod(h, 24)
 
-    uptime_values = []
+    uptime_values: list[str] = []
 
     for value, unit in ((d, "days"), (h, "hours"), (m, "min"), (s, "sec")):
         if value == 0 and not uptime_values:
             # Don't include a value/unit if the unit isn't applicable to
             # the uptime. E.g. don't do 0 days 0 hours 1 min 30 sec.
             continue
-        elif value == 1 and unit.endswith("s"):
+        if value == 1 and unit.endswith("s"):
             # Remove the "s" if the unit is singular.
             unit = unit[:-1]
         uptime_values.append("{0} {1}".format(value, unit))

--- a/mycli/packages/toolkit/fzf.py
+++ b/mycli/packages/toolkit/fzf.py
@@ -1,4 +1,4 @@
-# type: ignore
+from __future__ import annotations
 
 import re
 from shutil import which

--- a/mycli/packages/toolkit/history.py
+++ b/mycli/packages/toolkit/history.py
@@ -1,7 +1,7 @@
-# type: ignore
+from __future__ import annotations
 
 import os
-from typing import List, Tuple, Union
+from typing import Union
 
 from prompt_toolkit.history import FileHistory
 
@@ -17,16 +17,16 @@ class FileHistoryWithTimestamp(FileHistory):
         self.filename = filename
         super().__init__(filename)
 
-    def load_history_with_timestamp(self) -> List[Tuple[str, str]]:
+    def load_history_with_timestamp(self) -> list[tuple[str, str]]:
         """
         Load history entries along with their timestamps.
 
         Returns:
-            List[Tuple[str, str]]: A list of tuples where each tuple contains
+            list[tuple[str, str]]: A list of tuples where each tuple contains
                                    a history entry and its corresponding timestamp.
         """
-        history_with_timestamp: List[Tuple[str, str]] = []
-        lines: List[str] = []
+        history_with_timestamp: list[tuple[str, str]] = []
+        lines: list[str] = []
         timestamp: str = ""
 
         def add() -> None:

--- a/test/test_parseutils.py
+++ b/test/test_parseutils.py
@@ -142,9 +142,9 @@ def test_query_starts_with_comment():
 
 def test_queries_start_with():
     sql = "# comment\nshow databases;use foo;"
-    assert queries_start_with(sql, ("show", "select")) is True
-    assert queries_start_with(sql, ("use", "drop")) is True
-    assert queries_start_with(sql, ("delete", "update")) is False
+    assert queries_start_with(sql, ["show", "select"]) is True
+    assert queries_start_with(sql, ["use", "drop"]) is True
+    assert queries_start_with(sql, ["delete", "update"]) is False
 
 
 def test_is_destructive():

--- a/test/utils.py
+++ b/test/utils.py
@@ -14,11 +14,11 @@ from mycli.main import special
 PASSWORD = os.getenv("PYTEST_PASSWORD")
 USER = os.getenv("PYTEST_USER", "root")
 HOST = os.getenv("PYTEST_HOST", "localhost")
-PORT = int(os.getenv("PYTEST_PORT", 3306))
+PORT = int(os.getenv("PYTEST_PORT", "3306"))
 CHARSET = os.getenv("PYTEST_CHARSET", "utf8")
 SSH_USER = os.getenv("PYTEST_SSH_USER", None)
 SSH_HOST = os.getenv("PYTEST_SSH_HOST", None)
-SSH_PORT = os.getenv("PYTEST_SSH_PORT", 22)
+SSH_PORT = int(os.getenv("PYTEST_SSH_PORT", "22"))
 
 
 def db_connection(dbname=None):


### PR DESCRIPTION
## Description

Add type annotations for

 * `mycli/__init__.py`
 * `mycli/compat.py`
 * `mycli/lexer.py`
 * `mycli/packages/filepaths.py`
 * `mycli/packages/hybrid_redirection.py`
 * `mycli/packages/parseutils.py`
 * `mycli/packages/special/delimitercommand.py`
 * `mycli/packages/toolkit/fzf.py`
 * `mycli/packages/toolkit/history.py`
 * `mycli/packages/special/favoritequeries.py`
 * `mycli/packages/special/utils.py`
 * `mycli/packages/tabular_output/sql_format.py`

and enable mypy checking for them in CI.

Convert capitalized types in `toolkit/history.py` to modern annotations.

Fix an `int()` cast on an env variable in `test/utils.py`, without enabling typecheck for the entire file.

Make `query_starts_with()` and `queries_starts_with(`) take a list rather than a tuple for the second argument.

Fix a bug where `extract_tables_from_complete_statements()` could crash without checking for a `None`.

Fix a bug where `table_format` was not checked for `None` before treating as a string.

Move `__main__` section of `parseutils.py` to bottom of file.  Consider removing it.

Remove a needless inherit from `object`.

Convert an if/elif to the guard clause pattern.


## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
