### PR TITLE
Override the default pager on Windows if not found

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 Upcoming Release (TBD)
 ======================
 
+Bug Fixes
+--------
+* Help Windows installations find a working default pager.
+
+
 Internal
 --------
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1016,6 +1016,11 @@ class MyCli(object):
 
         cnf = self.read_my_cnf_files(self.cnf_files, ["pager", "skip-pager"])
         cnf_pager = cnf["pager"] or self.config["main"]["pager"]
+
+        # help Windows users who haven't edited the default myclirc
+        if WIN and cnf_pager == 'less' and not shutil.which(cnf_pager):
+            cnf_pager = 'more'
+
         if cnf_pager:
             special.set_pager(cnf_pager)
             self.explicit_pager = True


### PR DESCRIPTION
## Description
If the pager is set to `less`, the default, and we cannot find `less` on the PATH, fall back to `more`, a Windows builtin.

It would be cleaner for myclirc to have some kind of `pager = auto` setting but it is likely too late for that.

Addresses issue #1260 .

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
