### PR TITLE
No need to inherit from `object`

### DIFF
--- a/mycli/completion_refresher.py
+++ b/mycli/completion_refresher.py
@@ -8,7 +8,7 @@ from mycli.sqlcompleter import SQLCompleter
 from mycli.sqlexecute import ServerSpecies, SQLExecute
 
 
-class CompletionRefresher(object):
+class CompletionRefresher:
     refreshers = OrderedDict()
 
     def __init__(self):

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -75,7 +75,7 @@ class PasswordFileError(Exception):
     """Base exception for errors related to reading password files."""
 
 
-class MyCli(object):
+class MyCli:
     default_prompt = "\\t \\u@\\h:\\d> "
     default_prompt_splitln = "\\u@\\h\\n(\\t):\\d>"
     max_len_prompt = 45

--- a/mycli/packages/special/delimitercommand.py
+++ b/mycli/packages/special/delimitercommand.py
@@ -6,7 +6,7 @@ from typing import Generator
 import sqlparse  # type: ignore[import-untyped]
 
 
-class DelimiterCommand(object):
+class DelimiterCommand:
     def __init__(self) -> None:
         self._delimiter = ";"
 

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -80,7 +80,7 @@ class ServerInfo:
             return self.version_str
 
 
-class SQLExecute(object):
+class SQLExecute:
     databases_query = """SHOW DATABASES"""
 
     tables_query = """SHOW TABLES"""

--- a/test/test_tabular_output.py
+++ b/test/test_tabular_output.py
@@ -23,7 +23,7 @@ def test_sql_output(mycli):
     """Test the sql output adapter."""
     headers = ["letters", "number", "optional", "float", "binary"]
 
-    class FakeCursor(object):
+    class FakeCursor:
         def __init__(self):
             self.data = [("abc", 1, None, 10.0, b"\xaa"), ("d", 456, "1", 0.5, b"\xaa\xbb")]
             self.description = [


### PR DESCRIPTION
## Description
Remove a Python 2 compatibility construct.


## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
