### PR TITLE
Make control-r reverse search style configurable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 Upcoming Release (TBD)
 ======================
 
+Features
+--------
+* Make control-r reverse search style configurable.
+
+
 Internal
 --------
 

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -143,8 +143,18 @@ def mycli_bindings(mycli):
 
     @kb.add("c-r", filter=emacs_mode)
     def _(event):
-        """Search history using fzf or default reverse incremental search."""
+        """Search history using fzf or reverse incremental search."""
         _logger.debug("Detected <C-r> key.")
+        mode = mycli.config.get('keys', {}).get('control_r', 'auto')
+        if mode == 'reverse_isearch':
+            search_history(event, incremental=True)
+        else:
+            search_history(event)
+
+    @kb.add("escape", "r", filter=emacs_mode)
+    def _(event):
+        """Search history using fzf when available."""
+        _logger.debug("Detected <alt-r> key.")
         search_history(event)
 
     @kb.add("enter", filter=completion_is_selected)

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -102,6 +102,10 @@ enable_pager = True
 # Choose a specific pager
 pager = 'less'
 
+[keys]
+# possible values: auto, fzf, reverse_isearch
+control_r = auto
+
 # Custom colors for the completion menu, toolbar, etc.
 [colors]
 completion-menu.completion.current = 'bg:#ffffff #000000'

--- a/mycli/packages/toolkit/fzf.py
+++ b/mycli/packages/toolkit/fzf.py
@@ -20,36 +20,37 @@ class Fzf(FzfPrompt):
         return self.executable is not None
 
 
-def search_history(event: KeyPressEvent):
+def search_history(event: KeyPressEvent, incremental: bool = False) -> None:
     buffer = event.current_buffer
     history = buffer.history
 
     fzf = Fzf()
 
-    if fzf.is_available() and isinstance(history, FileHistoryWithTimestamp):
-        history_items_with_timestamp = history.load_history_with_timestamp()
-
-        formatted_history_items = []
-        original_history_items = []
-        seen = {}
-        for item, timestamp in history_items_with_timestamp:
-            formatted_item = re.sub(r'\s+', ' ', item)
-            timestamp = timestamp.split(".")[0] if "." in timestamp else timestamp
-            if formatted_item in seen:
-                continue
-            seen[formatted_item] = True
-            formatted_history_items.append(f"{timestamp}  {formatted_item}")
-            original_history_items.append(item)
-
-        result = fzf.prompt(
-            formatted_history_items,
-            fzf_options="--scheme=history --tiebreak=index --preview-window=down:wrap --preview=\"printf '%s' {}\"",
-        )
-
-        if result:
-            selected_index = formatted_history_items.index(result[0])
-            buffer.text = original_history_items[selected_index]
-            buffer.cursor_position = len(buffer.text)
-    else:
+    if incremental or not fzf.is_available() or not isinstance(history, FileHistoryWithTimestamp):
         # Fallback to default reverse incremental search
         search.start_search(direction=search.SearchDirection.BACKWARD)
+        return
+
+    history_items_with_timestamp = history.load_history_with_timestamp()
+
+    formatted_history_items = []
+    original_history_items = []
+    seen = {}
+    for item, timestamp in history_items_with_timestamp:
+        formatted_item = re.sub(r'\s+', ' ', item)
+        timestamp = timestamp.split(".")[0] if "." in timestamp else timestamp
+        if formatted_item in seen:
+            continue
+        seen[formatted_item] = True
+        formatted_history_items.append(f"{timestamp}  {formatted_item}")
+        original_history_items.append(item)
+
+    result = fzf.prompt(
+        formatted_history_items,
+        fzf_options="--scheme=history --tiebreak=index --preview-window=down:wrap --preview=\"printf '%s' {}\"",
+    )
+
+    if result:
+        selected_index = formatted_history_items.index(result[0])
+        buffer.text = original_history_items[selected_index]
+        buffer.cursor_position = len(buffer.text)


### PR DESCRIPTION
## Description
Allow the old control-r incremental search to be recovered via a config file setting.  In case control-r is bound to traditional incremental search, add alt-r bindings for fzf search so that it is always available.

The "fzf" setting for control_r in myclirc remains a bit of a lie, because we still fall back to reverse_isearch if fzf is not installed. But it could be nice to emit a warning in that case.

This is intended to address the discussion comment at

 * https://github.com/dbcli/mycli/discussions/1265#discussioncomment-13791547

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
