### PR TITLE
Bind ctrl-r/alt-r to previous-item in fzf search

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming Release (TBD)
 Features
 --------
 * Make control-r reverse search style configurable.
+* Make fzf search key bindings more compatible with traditional isearch.
 
 
 Internal

--- a/mycli/packages/toolkit/fzf.py
+++ b/mycli/packages/toolkit/fzf.py
@@ -47,7 +47,7 @@ def search_history(event: KeyPressEvent, incremental: bool = False) -> None:
 
     result = fzf.prompt(
         formatted_history_items,
-        fzf_options="--scheme=history --tiebreak=index --preview-window=down:wrap --preview=\"printf '%s' {}\"",
+        fzf_options="--scheme=history --tiebreak=index --bind ctrl-r:up,alt-r:up --preview-window=down:wrap --preview=\"printf '%s' {}\"",
     )
 
     if result:


### PR DESCRIPTION
## Description
Bind the keys which may initiate an fzf-based reverse search to also iterating upward through the matched items, once we are in fzf mode.

This makes fzf search more closely match the keyboard muscle memory of traditional reverse incremental search (though it may look very different visually).

Like #1278 this is intended to address

 * https://github.com/dbcli/mycli/discussions/1265#discussioncomment-13791547

This also assumes that alt-r from #1278 can initiate an fzf search.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
