### PR TITLE
CI: turn off matrix fail-fast strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ Internal
 * Add linting suggestion to pull request template.
 * Make CI names and properties more consistent.
 * Enable typechecking for several files.
+* CI: turn off fail-fast matrix strategy.
 
 
 1.36.0 (2025/07/19)


### PR DESCRIPTION
## Description
Since the editor test is flaky, we expect these tests to sometimes fail.  Turning off fail-fast makes it less work to restart the failed runs in the GitHub UI.


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv ruff check && uv ruff format` to lint and format the code.
