### PR TITLE
Add typehints for clitoolbar.py

### DIFF
--- a/mycli/clitoolbar.py
+++ b/mycli/clitoolbar.py
@@ -1,4 +1,4 @@
-# type: ignore
+from typing import Callable
 
 from prompt_toolkit.application import get_app
 from prompt_toolkit.enums import EditingMode
@@ -7,14 +7,14 @@ from prompt_toolkit.key_binding.vi_state import InputMode
 from mycli.packages import special
 
 
-def create_toolbar_tokens_func(mycli, show_fish_help):
+def create_toolbar_tokens_func(mycli, show_fish_help: Callable) -> Callable:
     """Return a function that generates the toolbar tokens."""
 
-    def get_toolbar_tokens():
+    def get_toolbar_tokens() -> list[tuple[str, str]]:
         result = [("class:bottom-toolbar", " ")]
 
         if mycli.multi_line:
-            delimiter = special.get_current_delimiter()
+            delimiter = special.get_current_delimiter()  # type: ignore
             result.append((
                 "class:bottom-toolbar",
                 " ({} [{}] will end the line) ".format("Semi-colon" if delimiter == ";" else "Delimiter", delimiter),
@@ -42,7 +42,7 @@ def create_toolbar_tokens_func(mycli, show_fish_help):
     return get_toolbar_tokens
 
 
-def _get_vi_mode():
+def _get_vi_mode() -> str:
     """Get the current vi mode for display."""
     return {
         InputMode.INSERT: "I",


### PR DESCRIPTION
## Description

Add typehints for clitoolbar.py

Currently needs one "type: ignore" for `special.get_current_delimiter()`.

The parameter `mycli` can't get a `MyCli` type here either, without a circular import.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv ruff check && uv ruff format` to lint and format the code.
