### PR TITLE
Show username in password prompt, like pgcli

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 Upcoming Release (TBD)
 ======================
 
+Features
+--------
+* Show username in password prompt.
+
+
 Bug Fixes
 --------
 * Help Windows installations find a working default pager.

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -481,7 +481,7 @@ class MyCli:
                     if password_from_file:
                         new_passwd = password_from_file
                     else:
-                        new_passwd = click.prompt("Password", hide_input=True, show_default=False, type=str, err=True)
+                        new_passwd = click.prompt(f"Password for {user}", hide_input=True, show_default=False, type=str, err=True)
                     self.sqlexecute = SQLExecute(
                         database,
                         user,


### PR DESCRIPTION

## Description
Show username in password prompt, like pgcli, closing #1141 .

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv ruff check && uv ruff format` to lint and format the code.
