### PR TITLE
Typehinting for `clibuffer.py`, and several special/*.py files

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -29,4 +29,5 @@ jobs:
 
       - name: Run mypy
         run: |
-          uv run --no-sync --frozen -- python -m mypy --no-pretty --install-types .
+          uv run --no-sync --frozen -- python -m ensurepip
+          uv run --no-sync --frozen -- python -m mypy --no-pretty --install-types --non-interactive .

--- a/mycli/clibuffer.py
+++ b/mycli/clibuffer.py
@@ -1,13 +1,13 @@
-# type: ignore
+from typing import Callable
 
 from prompt_toolkit.application import get_app
 from prompt_toolkit.enums import DEFAULT_BUFFER
 from prompt_toolkit.filters import Condition
 
-from mycli.packages import special
+from mycli.packages.special import iocommands
 
 
-def cli_is_multiline(mycli):
+def cli_is_multiline(mycli) -> Callable:
     @Condition
     def cond():
         doc = get_app().layout.get_buffer_by_name(DEFAULT_BUFFER).document
@@ -20,7 +20,7 @@ def cli_is_multiline(mycli):
     return cond
 
 
-def _multiline_exception(text):
+def _multiline_exception(text: str) -> bool:
     orig = text
     text = text.strip()
 
@@ -39,7 +39,7 @@ def _multiline_exception(text):
         or
         # Ended with the current delimiter (usually a semi-column)
         text.endswith((
-            special.get_current_delimiter(),
+            iocommands.get_current_delimiter(),
             "\\g",
             "\\G",
             r"\e",

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -52,7 +52,7 @@ from mycli.packages.hybrid_redirection import get_redirect_components, is_redire
 from mycli.packages.parseutils import is_destructive, is_dropping_database
 from mycli.packages.prompt_utils import confirm, confirm_destructive_query
 from mycli.packages.special.favoritequeries import FavoriteQueries
-from mycli.packages.special.main import NO_QUERY
+from mycli.packages.special.main import ArgType
 from mycli.packages.tabular_output import sql_format
 from mycli.packages.toolkit.history import FileHistoryWithTimestamp
 from mycli.sqlcompleter import SQLCompleter
@@ -198,24 +198,24 @@ class MyCli:
         self.prompt_app = None
 
     def register_special_commands(self):
-        special.register_special_command(self.change_db, "use", "\\u", "Change to a new database.", aliases=("\\u",))
+        special.register_special_command(self.change_db, "use", "\\u", "Change to a new database.", aliases=["\\u"])
         special.register_special_command(
             self.change_db,
             "connect",
             "\\r",
             "Reconnect to the database. Optional database argument.",
-            aliases=("\\r",),
+            aliases=["\\r"],
             case_sensitive=True,
         )
         special.register_special_command(
-            self.refresh_completions, "rehash", "\\#", "Refresh auto-completions.", arg_type=NO_QUERY, aliases=("\\#",)
+            self.refresh_completions, "rehash", "\\#", "Refresh auto-completions.", arg_type=ArgType.NO_QUERY, aliases=["\\#"]
         )
         special.register_special_command(
             self.change_table_format,
             "tableformat",
             "\\T",
             "Change the table format used to output results.",
-            aliases=("\\T",),
+            aliases=["\\T"],
             case_sensitive=True,
         )
         special.register_special_command(
@@ -223,12 +223,12 @@ class MyCli:
             "redirectformat",
             "\\Tr",
             "Change the table format used to output redirected results.",
-            aliases=("\\Tr",),
+            aliases=["\\Tr"],
             case_sensitive=True,
         )
-        special.register_special_command(self.execute_from_file, "source", "\\. filename", "Execute commands from file.", aliases=("\\.",))
+        special.register_special_command(self.execute_from_file, "source", "\\. filename", "Execute commands from file.", aliases=["\\."])
         special.register_special_command(
-            self.change_prompt_format, "prompt", "\\R", "Change prompt format.", aliases=("\\R",), case_sensitive=True
+            self.change_prompt_format, "prompt", "\\R", "Change prompt format.", aliases=["\\R"], case_sensitive=True
         )
 
     def change_table_format(self, arg, **_):
@@ -574,7 +574,7 @@ class MyCli:
         while special.editor_command(text):
             filename = special.get_filename(text)
             query = special.get_editor_query(text) or self.get_last_query()
-            sql, message = special.open_external_editor(filename, sql=query)
+            sql, message = special.open_external_editor(filename=filename, sql=query)
             if message:
                 # Something went wrong. Raise an exception and bail.
                 raise RuntimeError(message)

--- a/mycli/packages/parseutils.py
+++ b/mycli/packages/parseutils.py
@@ -123,7 +123,7 @@ def extract_from_part(parsed: TokenList, stop_at_punctuation: bool = True) -> Ge
                     break
 
 
-def extract_table_identifiers(token_stream: TokenList) -> Generator[tuple[str | None, str, str]]:
+def extract_table_identifiers(token_stream: TokenList) -> Generator[tuple[str | None, str, str], None, None]:
     """yields tuples of (schema_name, table_name, table_alias)"""
 
     for item in token_stream:

--- a/mycli/packages/special/__init__.py
+++ b/mycli/packages/special/__init__.py
@@ -1,9 +1,11 @@
-# type: ignore
+from __future__ import annotations
 
-__all__ = []
+from typing import Callable
+
+__all__: list[str] = []
 
 
-def export(defn):
+def export(defn: Callable):
     """Decorator to explicitly mark functions that are exposed in a lib."""
     globals()[defn.__name__] = defn
     __all__.append(defn.__name__)

--- a/mycli/packages/special/favoritequeries.py
+++ b/mycli/packages/special/favoritequeries.py
@@ -34,7 +34,7 @@ Examples:
 """
 
     # Class-level variable, for convenience to use as a singleton.
-    instance = None
+    instance: FavoriteQueries
 
     def __init__(self, config) -> None:
         self.config = config

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -170,14 +170,14 @@ def test_pipe_once_command():
 
 def test_parseargfile():
     """Test that parseargfile expands the user directory."""
-    expected = {"file": os.path.join(os.path.expanduser("~"), "filename"), "mode": "a"}
+    expected = (os.path.join(os.path.expanduser("~"), "filename"), "a")
 
     if os.name == "nt":
         assert expected == mycli.packages.special.iocommands.parseargfile("~\\filename")
     else:
         assert expected == mycli.packages.special.iocommands.parseargfile("~/filename")
 
-    expected = {"file": os.path.join(os.path.expanduser("~"), "filename"), "mode": "w"}
+    expected = (os.path.join(os.path.expanduser("~"), "filename"), "w")
     if os.name == "nt":
         assert expected == mycli.packages.special.iocommands.parseargfile("-o ~\\filename")
     else:


### PR DESCRIPTION
## Description

Add typehints for files:

 * `mycli/clibuffer.py`
 * `mycli/packages/special/__init__.py`
 * `mycli/packages/special/dbcommands.py`
 * `mycli/packages/special/favoritequeries.py`
 * `mycli/packages/special/iocommands.py`
 * `mycli/packages/special/main.py`

Changes
 * Import `iocommands` instead of toplevel `special`
 * create `ArgType` Enum for `NO_QUERY` and friends
 * convert special-command aliases argument to a list, since it is of variable length
 * rewrite `open_external_editor` to respect two different modes for invoking `click.echo()`: with and without filename
 * recast `log` as `logger` for consistency across the project
 * bugfix: always test whether `fetchone()` returns an unpackable value
 * don't set `FavoriteQueries.instance` to `None`
 * add some explicit returns
 * update docstrings
 * convert some format strings to f-strings
 * convert unassigned strings not in docstring position to comments
 * remove a Python 2 compatibility conditional
 * return a tuple from `parseargfile()` rather than a dict
 * reformat some long lines
 * remove `type: ignore`s
 * precede unused variables with underscores
 * don't rewrite variables with different-type values
 * add `--non-interactive` to CI when installing type stubs
 * ensurepip in CI before installing type stubs
 * import annotations for 3.9 compatibility

After this change, about 58% of non-test function or method definitions have typehints, and 7 non-test files remain untyped.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv ruff check && uv ruff format` to lint and format the code.
