### PR TITLE
Typehint `sqlcompleter.py`

### DIFF
--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -9,7 +9,7 @@ from mycli.packages.parseutils import extract_tables, find_prev_keyword, last_wo
 from mycli.packages.special.main import parse_special_command
 
 
-def suggest_type(full_text: str, text_before_cursor: str) -> list[dict[str, str]]:
+def suggest_type(full_text: str, text_before_cursor: str) -> list[dict[str, Any]]:
     """Takes the full_text that is typed so far and also the text before the
     cursor to suggest completion type and scope.
 


### PR DESCRIPTION
 ## Description
 * relax `str` constraint in `completion_engine.py`
 * import annotations for Python 3.9 compatibility
 * add type hints
 * reformat some long type signatures
 * remove incorrect comments regarding generator objects
 * remove try/except when object is not a generator
 * rename variables to avoid type collisions, and for consistency

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv ruff check && uv ruff format` to lint and format the code.
