### PR TITLE
Update cli_helpers to v2.7.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming Release (TBD)
 Features
 --------
 * Show username in password prompt.
+* Add a `mysql` and `mysql_unicode` table format.
 
 
 Bug Fixes
@@ -21,6 +22,7 @@ Internal
 * CI: turn off fail-fast matrix strategy.
 * Remove unused Python 2 compatibility code.
 * Also run CI tests without installing SSH extra dependencies.
+* Update `cli_helpers` dependency, and list of table formats.
 
 
 1.36.0 (2025/07/19)

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -33,11 +33,13 @@ timing = True
 # Beep after long-running queries are completed; 0 to disable.
 beep_after_seconds = 0
 
-# Table format. Possible values: ascii, double, github,
-# psql, plain, simple, grid, fancy_grid, pipe, orgtbl, rst, mediawiki, html,
-# latex, latex_booktabs, textile, moinmoin, jira, vertical, tsv, tsv_noheader,
-# csv, csv-noheader, jsonl, jsonl_unescaped.
-# Recommended: ascii
+# Table format. Possible values: ascii, ascii_escaped, csv, csv-noheader,
+# csv-tab, csv-tab-noheader, double, fancy_grid, github, grid, html, jira,
+# jsonl, jsonl_escaped, latex, latex_booktabs, mediawiki, minimal, moinmoin,
+# mysql, mysql_unicode, orgtbl, pipe, plain, psql, psql_unicode, rst, simple,
+# sql-insert, sql-update, sql-update-1, sql-update-2, textile, tsv,
+# tsv_noheader, vertical.
+# Recommended: ascii.
 table_format = ascii
 
 # Redirected otuput format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "sqlparse>=0.3.0,<0.6.0",
     "sqlglot[rs] == 26.*",
     "configobj >= 5.0.5",
-    "cli_helpers[styles] >= 2.6.0",
+    "cli_helpers[styles] >= 2.7.0",
     "pyperclip >= 1.8.1",
     "pyaes >= 1.6.1",
     "pyfzf >= 0.3.1",


### PR DESCRIPTION
## Description
Update cli_helpers to v2.7.0 and update the list of possible table formats in the myclirc commentary.

This pulls in a `mysql` format which was supposed to right-align numeric values.  The right-alignment does not appear to happen within mycli yet, though nothing breaks.  The right-alignment did work within the cli_helpers test suite.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv ruff check && uv ruff format` to lint and format the code.
