### PR TITLE
Fix deprecated warning when building the package

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -3,16 +3,16 @@ All rights reserved.
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright notice, this
-  list of conditions and the following disclaimer in the documentation and/or
-  other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-* Neither the name of the {organization} nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software without
+   specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Unreleased
+======================
+
+Internal
+--------
+
+* Align LICENSE with SPDX format.
+
 1.37.0 (2025/07/28)
 ======================
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Internal
 --------
 
 * Align LICENSE with SPDX format.
+* Fix deprecated `license` specification format in `pyproject.toml`.
 
 1.37.0 (2025/07/28)
 ======================

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -66,6 +66,7 @@ Contributors:
   * Michał Górny
   * Mike Palandra
   * Mikhail Borisov
+  * Miodrag Tokić
   * Morgan Mitchell
   * mrdeathless
   * Nathan Huang

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 description = "CLI for MySQL Database. With auto-completion and syntax highlighting."
 readme = "README.md"
 requires-python = ">=3.9"
-license = { text = "BSD" }
+license = "BSD-3-Clause"
 authors = [{ name = "Mycli Core Team", email = "mycli-dev@googlegroups.com" }]
 urls = { homepage = "http://mycli.net" }
 


### PR DESCRIPTION
## Description

[AUR](https://aur.archlinux.org/packages/mycli) package maintainer here.

When building the package we get this warning

```
--- SNIP ---
/usr/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated                                  
!!                                                                                                                                                                                             
                                                                                                                                                                                               
        ********************************************************************************                                                                                                       
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).               
                                                                                                                                                                                               
        By 2026-Feb-18, you need to update your project and remove deprecated calls                                                                                                            
        or your builds will no longer be supported.                                                                                                                                            
                                                                                                                                                                                               
        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.                                                                                         
        ********************************************************************************                                                                                                       
                                                                                                                                                                                               
!!
--- SNIP ---
```

This PR aligns `LICENSE` with [SPDX](https://spdx.org/licenses/BSD-3-Clause.html) format and fixes deprecated `license` specification format in `pyproject.toml`.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [ ] I ran `uv ruff check && uv ruff format` to lint and format the code.
