### PR TITLE
Typehint most of main.py, with consequent fixes elsewhere

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 Upcoming Release (TBD)
 ======================
 
+Features
+--------
+* Add LLM support.
+
+
 Bug Fixes
 --------
 * Improve missing ssh-extras message.
@@ -9,6 +14,7 @@ Bug Fixes
 Internal
 --------
 * Improve pull request template lint commands.
+* Continue typehinting the non-test codebase.
 
 
 1.37.1 (2025/07/28)

--- a/mycli/clibuffer.py
+++ b/mycli/clibuffer.py
@@ -1,13 +1,13 @@
-from typing import Callable
+from __future__ import annotations
 
 from prompt_toolkit.application import get_app
 from prompt_toolkit.enums import DEFAULT_BUFFER
-from prompt_toolkit.filters import Condition
+from prompt_toolkit.filters import Condition, Filter
 
 from mycli.packages.special import iocommands
 
 
-def cli_is_multiline(mycli) -> Callable:
+def cli_is_multiline(mycli) -> Filter:
     @Condition
     def cond():
         doc = get_app().layout.get_buffer_by_name(DEFAULT_BUFFER).document

--- a/mycli/config.py
+++ b/mycli/config.py
@@ -8,7 +8,7 @@ import os
 from os.path import exists
 import struct
 import sys
-from typing import IO, BinaryIO, Literal
+from typing import IO, BinaryIO, Literal, TextIO
 
 from configobj import ConfigObj, ConfigObjError
 import pyaes
@@ -25,7 +25,7 @@ def log(logger: logging.Logger, level: int, message: str) -> None:
     logger.log(level, message)
 
 
-def read_config_file(f: str | TextIOWrapper, list_values: bool = True) -> ConfigObj | None:
+def read_config_file(f: str | TextIO | TextIOWrapper, list_values: bool = True) -> ConfigObj | None:
     """Read a config file.
 
     *list_values* set to `True` is the default behavior of ConfigObj.
@@ -52,7 +52,7 @@ def read_config_file(f: str | TextIOWrapper, list_values: bool = True) -> Config
     return config
 
 
-def get_included_configs(config_file: str | TextIOWrapper) -> list[str]:
+def get_included_configs(config_file: str | TextIOWrapper) -> list[str | TextIOWrapper]:
     """Get a list of configuration files that are included into config_path
     with !includedir directive.
 
@@ -64,7 +64,7 @@ def get_included_configs(config_file: str | TextIOWrapper) -> list[str]:
     """
     if not isinstance(config_file, str) or not os.path.isfile(config_file):
         return []
-    included_configs = []
+    included_configs: list[str | TextIOWrapper] = []
 
     try:
         with open(config_file) as f:
@@ -80,7 +80,7 @@ def get_included_configs(config_file: str | TextIOWrapper) -> list[str]:
     return included_configs
 
 
-def read_config_files(files: list[str], list_values: bool = True) -> ConfigObj:
+def read_config_files(files: list[str | TextIOWrapper], list_values: bool = True) -> ConfigObj:
     """Read and merge a list of config files."""
 
     config = create_default_config(list_values=list_values)

--- a/mycli/packages/parseutils.py
+++ b/mycli/packages/parseutils.py
@@ -274,13 +274,13 @@ def is_destructive(queries: str) -> bool:
     return False
 
 
-def is_dropping_database(queries: list[str], dbname: str | None) -> bool:
+def is_dropping_database(queries: str, dbname: str | None) -> bool:
     """Determine if the query is dropping a specific database."""
     result = False
     if dbname is None:
         return False
 
-    def normalize_db_name(db):
+    def normalize_db_name(db: str) -> str:
         return db.lower().strip('`"')
 
     dbname = normalize_db_name(dbname)

--- a/mycli/packages/special/__init__.py
+++ b/mycli/packages/special/__init__.py
@@ -1,19 +1,95 @@
 from __future__ import annotations
 
-from typing import Callable
-
-__all__: list[str] = []
-
-
-def export(defn: Callable):
-    """Decorator to explicitly mark functions that are exposed in a lib."""
-    globals()[defn.__name__] = defn
-    __all__.append(defn.__name__)
-    return defn
-
-
-from mycli.packages.special import (
-    dbcommands,  # noqa: E402 F401
-    iocommands,  # noqa: E402 F401
-    llm,  # noqa: E402 F401
+from mycli.packages.special.dbcommands import (
+    list_databases,
+    list_tables,
+    status,
 )
+from mycli.packages.special.iocommands import (
+    clip_command,
+    close_tee,
+    copy_query_to_clipboard,
+    disable_pager,
+    editor_command,
+    flush_pipe_once_if_written,
+    forced_horizontal,
+    get_clip_query,
+    get_current_delimiter,
+    get_editor_query,
+    get_filename,
+    is_expanded_output,
+    is_pager_enabled,
+    is_redirected,
+    is_timing_enabled,
+    open_external_editor,
+    set_delimiter,
+    set_expanded_output,
+    set_favorite_queries,
+    set_forced_horizontal_output,
+    set_pager,
+    set_pager_enabled,
+    set_redirect,
+    set_timing_enabled,
+    split_queries,
+    unset_once_if_written,
+    write_once,
+    write_pipe_once,
+    write_tee,
+)
+from mycli.packages.special.llm import (
+    FinishIteration,
+    handle_llm,
+    is_llm_command,
+    sql_using_llm,
+)
+from mycli.packages.special.main import (
+    CommandNotFound,
+    execute,
+    parse_special_command,
+    register_special_command,
+    special_command,
+)
+
+__all__: list[str] = [
+    'CommandNotFound',
+    'FinishIteration',
+    'clip_command',
+    'close_tee',
+    'copy_query_to_clipboard',
+    'disable_pager',
+    'editor_command',
+    'execute',
+    'flush_pipe_once_if_written',
+    'forced_horizontal',
+    'get_clip_query',
+    'get_current_delimiter',
+    'get_editor_query',
+    'get_filename',
+    'handle_llm',
+    'is_expanded_output',
+    'is_llm_command',
+    'is_pager_enabled',
+    'is_redirected',
+    'is_timing_enabled',
+    'list_databases',
+    'list_tables',
+    'open_external_editor',
+    'parse_special_command',
+    'register_special_command',
+    'set_delimiter',
+    'set_expanded_output',
+    'set_favorite_queries',
+    'set_forced_horizontal_output',
+    'set_pager',
+    'set_pager_enabled',
+    'set_redirect',
+    'set_timing_enabled',
+    'special_command',
+    'split_queries',
+    'sql_using_llm',
+    'status',
+    'unset_once_if_written',
+    'write_once',
+    'write_pipe_once',
+    'write_tee',
+]

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -17,7 +17,6 @@ import sqlparse
 
 from mycli.compat import WIN
 from mycli.packages.prompt_utils import confirm_destructive_query
-from mycli.packages.special import export
 from mycli.packages.special.delimitercommand import DelimiterCommand
 from mycli.packages.special.favoritequeries import FavoriteQueries
 from mycli.packages.special.main import ArgType, special_command
@@ -40,30 +39,25 @@ delimiter_command = DelimiterCommand()
 favoritequeries = FavoriteQueries(ConfigObj())
 
 
-@export
 def set_favorite_queries(config):
     global favoritequeries
     favoritequeries = FavoriteQueries(config)
 
 
-@export
 def set_timing_enabled(val: bool) -> None:
     global TIMING_ENABLED
     TIMING_ENABLED = val
 
 
-@export
 def set_pager_enabled(val: bool) -> None:
     global PAGER_ENABLED
     PAGER_ENABLED = val
 
 
-@export
 def is_pager_enabled() -> bool:
     return PAGER_ENABLED
 
 
-@export
 @special_command(
     "pager",
     "\\P [command]",
@@ -88,7 +82,6 @@ def set_pager(arg: str, **_) -> list[tuple]:
     return [(None, None, None, msg)]
 
 
-@export
 @special_command("nopager", "\\n", "Disable pager, print to stdout.", arg_type=ArgType.NO_QUERY, aliases=["\\n"], case_sensitive=True)
 def disable_pager() -> list[tuple]:
     set_pager_enabled(False)
@@ -104,29 +97,24 @@ def toggle_timing() -> list[tuple]:
     return [(None, None, None, message)]
 
 
-@export
 def is_timing_enabled() -> bool:
     return TIMING_ENABLED
 
 
-@export
 def set_expanded_output(val: bool) -> None:
     global use_expanded_output
     use_expanded_output = val
 
 
-@export
 def is_expanded_output() -> bool:
     return use_expanded_output
 
 
-@export
 def set_forced_horizontal_output(val: bool) -> None:
     global force_horizontal_output
     force_horizontal_output = val
 
 
-@export
 def forced_horizontal() -> bool:
     return force_horizontal_output
 
@@ -134,7 +122,6 @@ def forced_horizontal() -> bool:
 _logger = logging.getLogger(__name__)
 
 
-@export
 def editor_command(command: str) -> bool:
     """
     Is this an external editor command?
@@ -145,7 +132,6 @@ def editor_command(command: str) -> bool:
     return command.strip().endswith("\\e") or command.strip().startswith("\\e")
 
 
-@export
 def get_filename(sql: str) -> str | None:
     if sql.strip().startswith("\\e"):
         command, _, filename = sql.partition(" ")
@@ -154,7 +140,6 @@ def get_filename(sql: str) -> str | None:
         return None
 
 
-@export
 def get_editor_query(sql: str) -> str:
     """Get the query part of an editor command."""
     sql = sql.strip()
@@ -169,7 +154,6 @@ def get_editor_query(sql: str) -> str:
     return sql
 
 
-@export
 def open_external_editor(filename: str | None = None, sql: str | None = None) -> tuple[str, str | None]:
     """Open external editor, wait for the user to type in their query, return
     the query.
@@ -204,7 +188,6 @@ def open_external_editor(filename: str | None = None, sql: str | None = None) ->
     return (query, None)
 
 
-@export
 def clip_command(command: str) -> bool:
     """Is this a clip command?
 
@@ -216,7 +199,6 @@ def clip_command(command: str) -> bool:
     return command.strip().endswith("\\clip") or command.strip().startswith("\\clip")
 
 
-@export
 def get_clip_query(sql: str) -> str:
     """Get the query part of a clip command."""
     sql = sql.strip()
@@ -230,7 +212,6 @@ def get_clip_query(sql: str) -> str:
     return sql
 
 
-@export
 def copy_query_to_clipboard(sql: str | None = None) -> str | None:
     """Send query to the clipboard."""
 
@@ -245,7 +226,6 @@ def copy_query_to_clipboard(sql: str | None = None) -> str | None:
     return message
 
 
-@export
 def set_redirect(command_part: str | None, file_operator_part: str | None, file_part: str | None) -> list[tuple]:
     if command_part:
         if file_part:
@@ -405,7 +385,6 @@ def set_tee(arg: str, **_) -> list[tuple]:
     return [(None, None, None, "")]
 
 
-@export
 def close_tee() -> None:
     global tee_file
     if tee_file:
@@ -419,7 +398,6 @@ def no_tee(arg: str, **_) -> list[tuple]:
     return [(None, None, None, "")]
 
 
-@export
 def write_tee(output: str) -> None:
     global tee_file
     if tee_file:
@@ -441,12 +419,10 @@ def set_once(arg: str, **_) -> list[tuple]:
     return [(None, None, None, "")]
 
 
-@export
 def is_redirected() -> bool:
     return bool(once_file or PIPE_ONCE['process'])
 
 
-@export
 def write_once(output: str) -> None:
     global once_file, written_to_once_file
     if output and once_file:
@@ -456,7 +432,6 @@ def write_once(output: str) -> None:
         written_to_once_file = True
 
 
-@export
 def unset_once_if_written(post_redirect_command: str) -> None:
     """Unset the once file, if it has been written to."""
     global once_file, written_to_once_file
@@ -506,13 +481,11 @@ def set_pipe_once(arg: str, **_) -> list[tuple]:
     return [(None, None, None, "")]
 
 
-@export
 def write_pipe_once(line: str) -> None:
     if line and PIPE_ONCE['process']:
         PIPE_ONCE['stdin'].append(line)
 
 
-@export
 def flush_pipe_once_if_written(post_redirect_command: str) -> None:
     """Flush the pipe_once cmd, if lines have been written."""
     if not PIPE_ONCE['process']:
@@ -608,18 +581,15 @@ def watch_query(arg: str, **kwargs) -> Generator[tuple, None, None]:
             set_pager_enabled(old_pager_enabled)
 
 
-@export
 @special_command("delimiter", None, "Change SQL delimiter.")
 def set_delimiter(arg: str, **_) -> list[tuple]:
     return delimiter_command.set(arg)
 
 
-@export
 def get_current_delimiter() -> str:
     return delimiter_command.current
 
 
-@export
 def split_queries(input_str: str) -> Generator[str, None, None]:
     for query in delimiter_command.queries_iter(input_str):
         yield query

--- a/mycli/packages/special/llm.py
+++ b/mycli/packages/special/llm.py
@@ -13,7 +13,6 @@ import click
 import llm
 from llm.cli import cli
 
-from mycli.packages.special import export
 from mycli.packages.special.main import Verbosity, parse_special_command
 
 log = logging.getLogger(__name__)
@@ -91,7 +90,6 @@ def get_completions(tokens, tree=COMMAND_TREE):
     return list(tree.keys()) if tree else []
 
 
-@export
 class FinishIteration(Exception):
     def __init__(self, results=None):
         self.results = results
@@ -161,7 +159,6 @@ def ensure_mycli_template(replace=False):
     return
 
 
-@export
 def handle_llm(text, cur) -> Tuple[str, Optional[str], float]:
     _, verbosity, arg = parse_special_command(text)
     if not arg.strip():
@@ -217,13 +214,11 @@ def handle_llm(text, cur) -> Tuple[str, Optional[str], float]:
         raise RuntimeError(e)
 
 
-@export
 def is_llm_command(command) -> bool:
     cmd, _, _ = parse_special_command(command)
     return cmd in ("\\llm", "\\ai")
 
 
-@export
 def sql_using_llm(cur, question=None) -> Tuple[str, Optional[str]]:
     if cur is None:
         raise RuntimeError("Connect to a database and try again.")

--- a/mycli/packages/special/main.py
+++ b/mycli/packages/special/main.py
@@ -1,11 +1,11 @@
+from __future__ import annotations
+
 from collections import namedtuple
 from enum import Enum
 import logging
 from typing import Callable
 
 from pymysql.cursors import Cursor
-
-from mycli.packages.special import export
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,6 @@ class ArgType(Enum):
     RAW_QUERY = 2
 
 
-@export
 class CommandNotFound(Exception):
     pass
 
@@ -42,7 +41,6 @@ class Verbosity(Enum):
     VERBOSE = "verbose"
 
 
-@export
 def parse_special_command(sql: str) -> tuple[str, Verbosity, str]:
     command, _, arg = sql.partition(" ")
     verbosity = Verbosity.NORMAL
@@ -54,10 +52,9 @@ def parse_special_command(sql: str) -> tuple[str, Verbosity, str]:
     return (command, verbosity, arg.strip())
 
 
-@export
 def special_command(
     command: str,
-    shortcut: str,
+    shortcut: str | None,
     description: str,
     arg_type: ArgType = ArgType.PARSED_QUERY,
     hidden: bool = False,
@@ -80,11 +77,10 @@ def special_command(
     return wrapper
 
 
-@export
 def register_special_command(
     handler: Callable,
     command: str,
-    shortcut: str,
+    shortcut: str | None,
     description: str,
     arg_type: ArgType = ArgType.PARSED_QUERY,
     hidden: bool = False,
@@ -114,7 +110,6 @@ def register_special_command(
         )
 
 
-@export
 def execute(cur: Cursor, sql: str) -> list[tuple]:
     """Execute a special command and return the results. If the special command
     is not supported a CommandNotFound will be raised.

--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -1104,7 +1104,7 @@ class SQLCompleter(Completer):
     def get_completions(
         self,
         document: Document,
-        complete_event: CompleteEvent,
+        complete_event: CompleteEvent | None,
         smart_completion: bool | None = None,
     ) -> Iterable[Completion]:
         word_before_cursor = document.get_word_before_cursor(WORD=True)


### PR DESCRIPTION
## Description

 * typehint >80% of `main.py`
 * requiring additional hints and fixes in `config.py` and `sqlexecute.py`, `packages/parseutils.py`, and others
 * typehint unhinted portions of `sqlexecute.py`
 * remove `@export` decorator and import explicitly into `special`
 * recast some uninformative variable names
 * assert that a connection is available before using it
 * take more care with: ssl config, port, and ssh_port types/defaults before creating a connection
 * `local_infile` is a boolean, not a string
 * ensure `get_password_from_file()` returns a value
 * assert that a `PromptSession` is available before invoking methods on it
 * set a fallback col/row size in case a prompt session is not available
 * declare and type `self.conn` in `SQLExecute` much earlier
 * take more care to distinguish falsey values from `None`s in `SQLExecute` `connect()`
 * improve defaults passed to `pymysql.connect(`), matching them to the pymysql docs
 * test that `self.conn` is not `None` rather than checking for a `conn` attribute, before invoking `close()`
 * remove Python 2.x-compat Unicode literals trick for click
 * better catch empty database names in `change_db()`
 * take more care for edge-case values of `text` in `one_iteration()`
 * don't return `None` for `connection_id_to_kill`
 * clarify overlapping `e` variables
 * don't use `self.sqlexecute` when `sqlexecute` is already available
 * `is_dropping_database()` takes a string, not a list
 * typehint unhinted function in `packages/parseutils.py`
 * use only `chain()` for `format_output()` output
 * test `isinstance(…, Cursor`) rather than `hasattr(…, "description")`
 * set `start = time()` before `try` block
 * don't `return output_res(…)` when no return value is expected
 * update changelog

@amjith I tried to keep the cute `@export` decorator but it is too dynamic for a static checker to understand.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv ruff check && uv ruff format` to lint and format the code.
