### PR TITLE
Fix traditional repeated reverse isearch when not using fzf

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming Release (TBD)
 Bug Fixes
 --------
 * Improve missing ssh-extras message.
+* Fix repeated control-r in traditional reverse isearch.
 
 
 Internal

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -1,7 +1,7 @@
 import logging
 
 from prompt_toolkit.enums import EditingMode
-from prompt_toolkit.filters import completion_is_selected, emacs_mode
+from prompt_toolkit.filters import completion_is_selected, control_is_searchable, emacs_mode
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.key_processor import KeyPressEvent
 
@@ -140,7 +140,7 @@ def mycli_bindings(mycli) -> KeyBindings:
 
         event.app.current_buffer.insert_text(shortcuts.server_datetime(mycli.sqlexecute, quoted=True))
 
-    @kb.add("c-r", filter=emacs_mode)
+    @kb.add("c-r", filter=control_is_searchable)
     def _(event: KeyPressEvent) -> None:
         """Search history using fzf or reverse incremental search."""
         _logger.debug("Detected <C-r> key.")
@@ -150,7 +150,7 @@ def mycli_bindings(mycli) -> KeyBindings:
         else:
             search_history(event)
 
-    @kb.add("escape", "r", filter=emacs_mode)
+    @kb.add("escape", "r", filter=control_is_searchable)
     def _(event: KeyPressEvent) -> None:
         """Search history using fzf when available."""
         _logger.debug("Detected <alt-r> key.")


### PR DESCRIPTION
## Description

According to

 * https://github.com/prompt-toolkit/python-prompt-toolkit/blob/3374ae9dd56f0265b41022e81341fd062092e2f0/src/prompt_toolkit/key_binding/bindings/search.py#L47-L53

it looks like we need to set the `control_is_searchable` filter in order to map control-r (and escape-r) only when _outside_ the isearch mini-mode keymap.

It isn't clear how to specify both `emacs_mode` and `control_is_searchable` as filters, so `emacs_mode` was removed.

Closes #1310.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
