### PR TITLE
Fix spelling of `ssl-verify-server-cert` option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Bug Fixes
 --------
 * Improve missing ssh-extras message.
 * Fix repeated control-r in traditional reverse isearch.
+* Fix spelling of `ssl-verify-server-cert` option.
 
 
 Internal

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -426,7 +426,7 @@ class MyCli:
             "ssl-cert": None,
             "ssl-key": None,
             "ssl-cipher": None,
-            "ssl-verify-serer-cert": None,
+            "ssl-verify-server-cert": None,
         }
 
         cnf = self.read_my_cnf_files(self.cnf_files, list(cnf.keys()))


### PR DESCRIPTION
## Description

The option was missing a "v".


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
