### PR TITLE
Give friendlier errors on password-file failures instead of backtraces

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ Bug Fixes
 * Fix spelling of `ssl-verify-server-cert` option.
 * Improve handling of `ssl-verify-server-cert` False values.
 * Guard against missing contributors file on startup.
+* Friendlier errors on password-file failures.
 
 
 Internal

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -75,10 +75,6 @@ DEFAULT_WIDTH = 80
 DEFAULT_HEIGHT = 25
 
 
-class PasswordFileError(Exception):
-    """Base exception for errors related to reading password files."""
-
-
 class MyCli:
     default_prompt = "\\t \\u@\\h:\\d> "
     default_prompt_splitln = "\\u@\\h\\n(\\t):\\d>"
@@ -561,13 +557,17 @@ class MyCli:
                 password = fp.readline().strip()
                 return password
         except FileNotFoundError:
-            raise PasswordFileError(f"Password file '{password_file}' not found") from None
+            click.secho(f"Password file '{password_file}' not found", err=True, fg="red")
+            sys.exit(1)
         except PermissionError:
-            raise PasswordFileError(f"Permission denied reading password file '{password_file}'") from None
+            click.secho(f"Permission denied reading password file '{password_file}'", err=True, fg="red")
+            sys.exit(1)
         except IsADirectoryError:
-            raise PasswordFileError(f"Path '{password_file}' is a directory, not a file") from None
+            click.secho(f"Path '{password_file}' is a directory, not a file", err=True, fg="red")
+            sys.exit(1)
         except Exception as e:
-            raise PasswordFileError(f"Error reading password file '{password_file}': {str(e)}") from None
+            click.secho(f"Error reading password file '{password_file}': {str(e)}", err=True, fg="red")
+            sys.exit(1)
 
     def handle_editor_command(self, text: str) -> str:
         r"""Editor command is any query that is prefixed or suffixed by a '\e'.


### PR DESCRIPTION
## Description
This is more in line with other init errors such as bad DSNs.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
