### PR TITLE
Better handle empty-string passwords

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ Bug Fixes
 * Improve handling of `ssl-verify-server-cert` False values.
 * Guard against missing contributors file on startup.
 * Friendlier errors on password-file failures.
+* Better handle empty-string passwords.
 
 
 Internal

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -392,7 +392,7 @@ class MyCli:
         self,
         database: str | None = "",
         user: str | None = "",
-        passwd: str = "",
+        passwd: str | None = "",
         host: str | None = "",
         port: str | int | None = "",
         socket: str | None = "",
@@ -459,7 +459,8 @@ class MyCli:
 
         # if the passwd is not specified try to set it using the password_file option
         password_from_file = self.get_password_from_file(password_file)
-        passwd = passwd or password_from_file
+        passwd = passwd if isinstance(passwd, str) else password_from_file
+        passwd = '' if passwd is None else passwd
 
         # Connect to the database.
 
@@ -484,7 +485,7 @@ class MyCli:
                 )
             except OperationalError as e:
                 if e.args[0] == ERROR_CODE_ACCESS_DENIED:
-                    if password_from_file:
+                    if password_from_file is not None:
                         new_passwd = password_from_file
                     else:
                         new_passwd = click.prompt(f"Password for {user}", hide_input=True, show_default=False, type=str, err=True)
@@ -549,9 +550,9 @@ class MyCli:
             self.echo(str(e), err=True, fg="red")
             sys.exit(1)
 
-    def get_password_from_file(self, password_file: str) -> str:
+    def get_password_from_file(self, password_file: str) -> str | None:
         if not password_file:
-            return ''
+            return None
         try:
             with open(password_file) as fp:
                 password = fp.readline().strip()


### PR DESCRIPTION
## Description

Use `None`s to detect when unset, because the empty string is a valid password.  In particular

    passwd = passwd or password_from_file

would have used `password_from_file` if `passwd` was the (falsey) empty string.

It probably worked as expected because `password_from_file` was also returning the empty string when not available, but that is an awkward place to put the true default.

I'm not yet smart enough to write a meaningful test for the CLI behavior, but did exercise this locally.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
