### PR TITLE
Permit empty-string passwords at the prompt

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ Bug Fixes
 * Guard against missing contributors file on startup.
 * Friendlier errors on password-file failures.
 * Better handle empty-string passwords.
+* Permit empty-string passwords at the interactive prompt.
 
 
 Internal

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -488,7 +488,9 @@ class MyCli:
                     if password_from_file is not None:
                         new_passwd = password_from_file
                     else:
-                        new_passwd = click.prompt(f"Password for {user}", hide_input=True, show_default=False, type=str, err=True)
+                        new_passwd = click.prompt(
+                            f"Password for {user}", hide_input=True, show_default=False, default='', type=str, err=True
+                        )
                     self.sqlexecute = SQLExecute(
                         database,
                         user,


### PR DESCRIPTION
## Description
Previously the behavior was to keep prompting until a nonempty value was entered, disallowing the empty string as a password.


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
