### PR TITLE
Coerce `check_hostname` to a Boolean

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ Bug Fixes
 * Improve missing ssh-extras message.
 * Fix repeated control-r in traditional reverse isearch.
 * Fix spelling of `ssl-verify-server-cert` option.
+* Improve handling of `ssl-verify-server-cert` False values.
 
 
 Internal

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -384,7 +384,7 @@ class MyCli:
             # special case because PyMySQL argument is significantly different
             # from commandline
             if k == "ssl-verify-server-cert":
-                merged["check_hostname"] = v
+                merged["check_hostname"] = str_to_bool(v)
             else:
                 # use argument name just strip "ssl-" prefix
                 arg = k[len(prefix) :]


### PR DESCRIPTION
## Description

aka `--ssl-verify-server-cert`.  Since _eg_ "false" is a truthy string, when we later do

```python
# prune lone check_hostname=False
if not any(v for v in ssl_config.values()):
    ssl_config_or_none = None
```

the pruning might not happen according to what the comment describes.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
