### PR TITLE
Typehinting pass on main.py and others

### DIFF
--- a/mycli/clitoolbar.py
+++ b/mycli/clitoolbar.py
@@ -14,7 +14,7 @@ def create_toolbar_tokens_func(mycli, show_fish_help: Callable) -> Callable:
         result = [("class:bottom-toolbar", " ")]
 
         if mycli.multi_line:
-            delimiter = special.get_current_delimiter()  # type: ignore
+            delimiter = special.get_current_delimiter()
             result.append((
                 "class:bottom-toolbar",
                 " ({} [{}] will end the line) ".format("Semi-colon" if delimiter == ";" else "Delimiter", delimiter),

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -699,7 +699,7 @@ class MyCli:
         # mutating if any one of the component statements is mutating
         mutating = False
 
-        def output_res(res, start):
+        def output_res(res: Generator[tuple], start: float) -> None:
             nonlocal mutating
             result_count = 0
             for title, cur, headers, status in res:
@@ -717,7 +717,10 @@ class MyCli:
                         break
 
                 if self.auto_vertical_output:
-                    max_width = self.prompt_app.output.get_size().columns
+                    if self.prompt_app is not None:
+                        max_width = self.prompt_app.output.get_size().columns
+                    else:
+                        max_width = DEFAULT_WIDTH
                 else:
                     max_width = None
 
@@ -749,7 +752,6 @@ class MyCli:
                 start = time()
                 result_count += 1
                 mutating = mutating or is_mutating(status)
-            return
 
         def one_iteration(text: str | None = None) -> None:
             if text is None:
@@ -1336,7 +1338,7 @@ def cli(
     init_command,
     charset,
     password_file,
-):
+) -> None:
     """A MySQL terminal client with auto-completion and syntax highlighting.
 
     \b
@@ -1428,28 +1430,28 @@ def cli(
         else:
             dsn_params = {}
 
-        if dsn_params.get('ssl'):
-            ssl_enable = ssl_enable or (dsn_params.get('ssl')[0].lower() == 'true')
-        if dsn_params.get('ssl_ca'):
-            ssl_ca = ssl_ca or dsn_params.get('ssl_ca')[0]
+        if params := dsn_params.get('ssl'):
+            ssl_enable = ssl_enable or (params[0].lower() == 'true')
+        if params := dsn_params.get('ssl_ca'):
+            ssl_ca = ssl_ca or params[0]
             ssl_enable = True
-        if dsn_params.get('ssl_capath'):
-            ssl_capath = ssl_capath or dsn_params.get('ssl_capath')[0]
+        if params := dsn_params.get('ssl_capath'):
+            ssl_capath = ssl_capath or params[0]
             ssl_enable = True
-        if dsn_params.get('ssl_cert'):
-            ssl_cert = ssl_cert or dsn_params.get('ssl_cert')[0]
+        if params := dsn_params.get('ssl_cert'):
+            ssl_cert = ssl_cert or params[0]
             ssl_enable = True
-        if dsn_params.get('ssl_key'):
-            ssl_key = ssl_key or dsn_params.get('ssl_key')[0]
+        if params := dsn_params.get('ssl_key'):
+            ssl_key = ssl_key or params[0]
             ssl_enable = True
-        if dsn_params.get('ssl_cipher'):
-            ssl_cipher = ssl_cipher or dsn_params.get('ssl_cipher')[0]
+        if params := dsn_params.get('ssl_cipher'):
+            ssl_cipher = ssl_cipher or params[0]
             ssl_enable = True
-        if dsn_params.get('tls_version'):
-            tls_version = tls_version or dsn_params.get('tls_version')[0]
+        if params := dsn_params.get('tls_version'):
+            tls_version = tls_version or params[0]
             ssl_enable = True
-        if dsn_params.get('ssl_verify_server_cert'):
-            ssl_verify_server_cert = ssl_verify_server_cert or (dsn_params.get('ssl_verify_server_cert')[0].lower() == 'true')
+        if params := dsn_params.get('ssl_verify_server_cert'):
+            ssl_verify_server_cert = ssl_verify_server_cert or (params[0].lower() == 'true')
             ssl_enable = True
 
     ssl = {
@@ -1477,7 +1479,7 @@ def cli(
 
     ssh_key_filename = ssh_key_filename and os.path.expanduser(ssh_key_filename)
     # Merge init-commands: global, DSN-specific, then CLI
-    init_cmds = []
+    init_cmds: list[str] = []
     # 1) Global init-commands
     global_section = mycli.config.get("init-commands", {})
     for _, val in global_section.items():

--- a/mycli/packages/shortcuts.py
+++ b/mycli/packages/shortcuts.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from mycli.sqlexecute import SQLExecute  # type: ignore
+from mycli.sqlexecute import SQLExecute
 
 
 def server_date(sqlexecute: SQLExecute, quoted: bool = False) -> str:


### PR DESCRIPTION
## Description
 * remove `type: ignore` comments where no longer needed after hinting
 * typehint `output_res()`
 * check that `self.prompt_app` is not `None` before finding width from it
 * remove needless `return` statement
 * typehint `cli()`, except for arguments
 * help mypy understand operations on SSL DSN parameters

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
