### PR TITLE
Typehint most of magic.py

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,7 +21,7 @@ Bug Fixes
 Internal
 --------
 * Improve pull request template lint commands.
-* Continue typehinting the non-test codebase.
+* Complete typehinting the non-test codebase.
 
 
 1.37.1 (2025/07/28)

--- a/mycli/magic.py
+++ b/mycli/magic.py
@@ -1,16 +1,17 @@
-# type: ignore
+from __future__ import annotations
 
 import logging
+from typing import Any
 
 import sql.connection
 import sql.parse
 
-from mycli.main import MyCli
+from mycli.main import MyCli, Query
 
-_logger = logging.getLogger(__name__)
+_logger: logging.Logger = logging.getLogger(__name__)
 
 
-def load_ipython_extension(ipython):
+def load_ipython_extension(ipython) -> None:
     # This is called via the ipython command '%load_ext mycli.magic'.
 
     # First, load the sql magic if it isn't already loaded.
@@ -21,9 +22,9 @@ def load_ipython_extension(ipython):
     ipython.register_magic_function(mycli_line_magic, "line", "mycli")
 
 
-def mycli_line_magic(line):
+def mycli_line_magic(line: str):
     _logger.debug("mycli magic called: %r", line)
-    parsed = sql.parse.parse(line, {})
+    parsed: dict[str, Any] = sql.parse.parse(line, {})
     # "get" was renamed to "set" in ipython-sql:
     # https://github.com/catherinedevlin/ipython-sql/commit/f4283c65aaf68f961e84019e8b939e4a3c501d43
     if hasattr(sql.connection.Connection, "get"):
@@ -36,7 +37,7 @@ def mycli_line_magic(line):
             conn = sql.connection.Connection.set(parsed["connection"], False)
     try:
         # A corresponding mycli object already exists
-        mycli = conn._mycli
+        mycli: MyCli = conn._mycli
         _logger.debug("Reusing existing mycli")
     except AttributeError:
         mycli = MyCli()
@@ -57,11 +58,11 @@ def mycli_line_magic(line):
     if not mycli.query_history:
         return
 
-    q = mycli.query_history[-1]
+    q: Query = mycli.query_history[-1]
     if q.mutating:
         _logger.debug("Mutating query detected -- ignoring")
         return
 
     if q.successful:
-        ipython = get_ipython()  # noqa: F821
+        ipython = get_ipython()  # type: ignore # noqa: F821
         return ipython.run_cell_magic("sql", line, q.query)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -43,7 +43,7 @@ import sqlparse
 
 from mycli import __version__
 from mycli.clibuffer import cli_is_multiline
-from mycli.clistyle import style_factory, style_factory_output  # type: ignore[attr-defined]
+from mycli.clistyle import style_factory, style_factory_output
 from mycli.clitoolbar import create_toolbar_tokens_func
 from mycli.compat import WIN
 from mycli.completion_refresher import CompletionRefresher
@@ -404,7 +404,7 @@ class MyCli:
         ssh_port: int = 22,
         ssh_password: str | None = "",
         ssh_key_filename: str | None = "",
-        init_command: str = "",
+        init_command: str | None = "",
         password_file: str | None = "",
     ) -> None:
         cnf = {


### PR DESCRIPTION
 ## Description

Changes
 * add type hints and needed imports
 * account for `magic.py` passing `init_command=None` to `connect()`, instead of `str`
 * doubly ignore undefined `get_ipython()`
 * update the changelog entry to reflect that typehinting is complete, outside of the test suite

Incidentally remove a `type: ignore` comment from `main.py` which is no longer needed.

No meaningful return value was deduced for `mycli_line_magic()`.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
