### PR TITLE
Convert to f-strings in the test directory

### DIFF
--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -48,7 +48,7 @@ def before_all(context):
 
     vi = "_".join([str(x) for x in sys.version_info[:3]])
     db_name = get_db_name_from_context(context)
-    db_name_full = "{0}_{1}".format(db_name, vi)
+    db_name_full = f"{db_name}_{vi}"
 
     # Store get params from config/environment variables
     context.conf = {
@@ -67,9 +67,8 @@ def before_all(context):
     _, my_cnf = mkstemp()
     with open(my_cnf, "w") as f:
         f.write(
-            "[client]\npager={0} {1} {2}\n".format(
-                sys.executable, os.path.join(context.package_root, "test/features/wrappager.py"), context.conf["pager_boundary"]
-            )
+            f'[client]\npager={sys.executable} '
+            f'{os.path.join(context.package_root, "test/features/wrappager.py")} {context.conf["pager_boundary"]}\n'
         )
     context.conf["defaults-file"] = my_cnf
     context.conf["myclirc"] = os.path.join(context.package_root, "test", "myclirc")
@@ -128,7 +127,7 @@ def after_scenario(context, _):
             user = context.conf["user"]
             host = context.conf["host"]
             dbname = context.currentdb
-            context.cli.expect_exact("{0}@{1}:{2}>".format(user, host, dbname), timeout=5)
+            context.cli.expect_exact(f"{user}@{host}:{dbname}>", timeout=5)
         context.cli.sendcontrol("c")
         context.cli.sendcontrol("d")
         context.cli.expect_exact(pexpect.EOF, timeout=5)

--- a/test/features/steps/auto_vertical.py
+++ b/test/features/steps/auto_vertical.py
@@ -19,7 +19,7 @@ def step_execute_small_query(context):
 
 @when("we execute a large query")
 def step_execute_large_query(context):
-    context.cli.sendline("select {}".format(",".join([str(n) for n in range(1, 50)])))
+    context.cli.sendline(f"select {','.join([str(n) for n in range(1, 50)])}")
 
 
 @then("we see small results in horizontal format")
@@ -41,8 +41,9 @@ def step_see_small_results(context):
 
 @then("we see large results in vertical format")
 def step_see_large_results(context):
-    rows = ["{n:3}| {n}".format(n=str(n)) for n in range(1, 50)]
-    expected = "***************************[ 1. row ]***************************\r\n" + "{}\r\n".format("\r\n".join(rows) + "\r\n")
+    rows = [f"{str(n):3}| {n}" for n in range(1, 50)]
+    delimited_rows = '\r\n'.join(rows) + '\r\n'
+    expected = "***************************[ 1. row ]***************************\r\n" + delimited_rows + "\r\n"
 
     wrappers.expect_pager(context, expected, timeout=10)
     wrappers.expect_exact(context, "1 row in set", timeout=2)

--- a/test/features/steps/basic_commands.py
+++ b/test/features/steps/basic_commands.py
@@ -58,7 +58,7 @@ def step_send_source_command(context):
     with tempfile.NamedTemporaryFile() as f:
         f.write(b"\\?")
         f.flush()
-        context.cli.sendline("\\. {0}".format(f.name))
+        context.cli.sendline(f"\\. {f.name}")
         wrappers.expect_exact(context, context.conf["pager_boundary"] + "\r\n", timeout=5)
 
 

--- a/test/features/steps/crud_database.py
+++ b/test/features/steps/crud_database.py
@@ -15,7 +15,7 @@ import wrappers
 @when("we create database")
 def step_db_create(context):
     """Send create database."""
-    context.cli.sendline("create database {0};".format(context.conf["dbname_tmp"]))
+    context.cli.sendline(f"create database {context.conf['dbname_tmp']};")
 
     context.response = {"database_name": context.conf["dbname_tmp"]}
 
@@ -23,7 +23,7 @@ def step_db_create(context):
 @when("we drop database")
 def step_db_drop(context):
     """Send drop database."""
-    context.cli.sendline("drop database {0};".format(context.conf["dbname_tmp"]))
+    context.cli.sendline(f"drop database {context.conf['dbname_tmp']};")
 
 
 @when("we connect to test database")
@@ -31,7 +31,7 @@ def step_db_connect_test(context):
     """Send connect to database."""
     db_name = context.conf["dbname"]
     context.currentdb = db_name
-    context.cli.sendline("use {0};".format(db_name))
+    context.cli.sendline(f"use {db_name};")
 
 
 @when("we connect to quoted test database")
@@ -39,7 +39,7 @@ def step_db_connect_quoted_tmp(context):
     """Send connect to database."""
     db_name = context.conf["dbname"]
     context.currentdb = db_name
-    context.cli.sendline("use `{0}`;".format(db_name))
+    context.cli.sendline(f"use `{db_name}`;")
 
 
 @when("we connect to tmp database")
@@ -47,7 +47,7 @@ def step_db_connect_tmp(context):
     """Send connect to database."""
     db_name = context.conf["dbname_tmp"]
     context.currentdb = db_name
-    context.cli.sendline("use {0}".format(db_name))
+    context.cli.sendline(f"use {db_name}")
 
 
 @when("we connect to dbserver")
@@ -69,7 +69,7 @@ def step_see_prompt(context):
     user = context.conf["user"]
     host = context.conf["host"]
     dbname = context.currentdb
-    wrappers.wait_prompt(context, "{0}@{1}:{2}> ".format(user, host, dbname))
+    wrappers.wait_prompt(context, f"{user}@{host}:{dbname}> ")
 
 
 @then("we see help output")
@@ -99,7 +99,7 @@ def step_see_db_dropped_no_default(context):
     context.currentdb = None
 
     wrappers.expect_exact(context, "Query OK, 0 rows affected", timeout=2)
-    wrappers.wait_prompt(context, "{0}@{1}:{2}>".format(user, host, database))
+    wrappers.wait_prompt(context, f"{user}@{host}:{database}>")
 
 
 @then("we see database connected")
@@ -107,4 +107,4 @@ def step_see_db_connected(context):
     """Wait to see drop database output."""
     wrappers.expect_exact(context, 'You are now connected to database "', timeout=2)
     wrappers.expect_exact(context, '"', timeout=2)
-    wrappers.expect_exact(context, ' as user "{0}"'.format(context.conf["user"]), timeout=2)
+    wrappers.expect_exact(context, f' as user "{context.conf["user"]}"', timeout=2)

--- a/test/features/steps/iocommands.py
+++ b/test/features/steps/iocommands.py
@@ -10,10 +10,10 @@ import wrappers
 @when("we start external editor providing a file name")
 def step_edit_file(context):
     """Edit file with external editor."""
-    context.editor_file_name = os.path.join(context.package_root, "test_file_{0}.sql".format(context.conf["vi"]))
+    context.editor_file_name = os.path.join(context.package_root, f"test_file_{context.conf['vi']}.sql")
     if os.path.exists(context.editor_file_name):
         os.remove(context.editor_file_name)
-    context.cli.sendline("\\e {0}".format(os.path.basename(context.editor_file_name)))
+    context.cli.sendline(f"\\e {os.path.basename(context.editor_file_name)}")
     wrappers.expect_exact(context, 'Entering Ex mode.  Type "visual" to go to Normal mode.', timeout=2)
     wrappers.expect_exact(context, "\r\n:", timeout=2)
 
@@ -45,26 +45,26 @@ def step_edit_done_sql(context, query):
 
 @when("we tee output")
 def step_tee_ouptut(context):
-    context.tee_file_name = os.path.join(context.package_root, "tee_file_{0}.sql".format(context.conf["vi"]))
+    context.tee_file_name = os.path.join(context.package_root, f"tee_file_{context.conf['vi']}.sql")
     if os.path.exists(context.tee_file_name):
         os.remove(context.tee_file_name)
-    context.cli.sendline("tee {0}".format(os.path.basename(context.tee_file_name)))
+    context.cli.sendline(f"tee {os.path.basename(context.tee_file_name)}")
 
 
 @when('we select "select {param}"')
 def step_query_select_number(context, param):
-    context.cli.sendline("select {}".format(param))
+    context.cli.sendline(f"select {param}")
     wrappers.expect_pager(
         context,
         dedent(
-            """\
-        +{dashes}+\r
+            f"""\
+        +{'-' * (len(param) + 2)}+\r
         | {param} |\r
-        +{dashes}+\r
+        +{'-' * (len(param) + 2)}+\r
         | {param} |\r
-        +{dashes}+\r
+        +{'-' * (len(param) + 2)}+\r
         \r
-        """.format(param=param, dashes="-" * (len(param) + 2))
+        """
         ),
         timeout=5,
     )
@@ -73,12 +73,12 @@ def step_query_select_number(context, param):
 
 @then('we see tabular result "{result}"')
 def step_see_tabular_result(context, result):
-    wrappers.expect_exact(context, '| {} |'.format(result), timeout=2)
+    wrappers.expect_exact(context, f'| {result} |', timeout=2)
 
 
 @then('we see csv result "{result}"')
 def step_see_csv_result(context, result):
-    wrappers.expect_exact(context, '"{}"'.format(result), timeout=2)
+    wrappers.expect_exact(context, f'"{result}"', timeout=2)
 
 
 @when('we query "{query}"')
@@ -127,4 +127,4 @@ def step_see_space_6_in_command_ouput(context):
 
 @then('delimiter is set to "{delimiter}"')
 def delimiter_is_set(context, delimiter):
-    wrappers.expect_exact(context, "Changed delimiter to {}".format(delimiter), timeout=2)
+    wrappers.expect_exact(context, f"Changed delimiter to {delimiter}", timeout=2)

--- a/test/features/steps/wrappers.py
+++ b/test/features/steps/wrappers.py
@@ -18,25 +18,27 @@ def expect_exact(context, expected, timeout):
         # Strip color codes out of the output.
         actual = re.sub(r"\x1b\[([0-9A-Za-z;?])+[m|K]?", "", context.cli.before)
         raise Exception(
-            textwrap.dedent("""\
+            textwrap.dedent(
+                f"""\
                 Expected:
                 ---
-                {0!r}
+                {expected!r}
                 ---
                 Actual:
                 ---
-                {1!r}
+                {actual!r}
                 ---
                 Full log:
                 ---
-                {2!r}
+                {context.logfile.getvalue()!r}
                 ---
-            """).format(expected, actual, context.logfile.getvalue())
+                """
+            )
         )
 
 
 def expect_pager(context, expected, timeout):
-    expect_exact(context, "{0}\r\n{1}{0}\r\n".format(context.conf["pager_boundary"], expected), timeout=timeout)
+    expect_exact(context, f"{context.conf['pager_boundary']}\r\n{expected}{context.conf['pager_boundary']}\r\n", timeout=timeout)
 
 
 def run_cli(context, run_args=None, exclude_args=None):
@@ -79,7 +81,7 @@ def run_cli(context, run_args=None, exclude_args=None):
     try:
         cli_cmd = context.conf["cli_command"]
     except KeyError:
-        cli_cmd = ('{0!s} -c "import coverage ; coverage.process_startup(); import mycli.main; mycli.main.cli()"').format(sys.executable)
+        cli_cmd = f'{sys.executable} -c "import coverage ; coverage.process_startup(); import mycli.main; mycli.main.cli()"'
 
     cmd_parts = [cli_cmd] + rendered_args
     cmd = " ".join(cmd_parts)
@@ -96,6 +98,6 @@ def wait_prompt(context, prompt=None):
         user = context.conf["user"]
         host = context.conf["host"]
         dbname = context.currentdb
-        prompt = ("{0}@{1}:{2}>".format(user, host, dbname),)
+        prompt = (f"{user}@{host}:{dbname}>",)
     expect_exact(context, prompt, timeout=5)
     context.atprompt = True

--- a/test/test_completion_engine.py
+++ b/test/test_completion_engine.py
@@ -317,7 +317,7 @@ def test_sub_select_dot_col_name_completion():
 @pytest.mark.parametrize("join_type", ["", "INNER", "LEFT", "RIGHT OUTER"])
 @pytest.mark.parametrize("tbl_alias", ["", "foo"])
 def test_join_suggests_tables_and_schemas(tbl_alias, join_type):
-    text = "SELECT * FROM abc {0} {1} JOIN ".format(tbl_alias, join_type)
+    text = f"SELECT * FROM abc {tbl_alias} {join_type} JOIN "
     suggestion = suggest_type(text, text)
     assert sorted_dicts(suggestion) == sorted_dicts([{"type": "table", "schema": []}, {"type": "view", "schema": []}, {"type": "schema"}])
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -171,16 +171,16 @@ def test_strip_quotes_with_matching_quotes():
     """Test that a string with matching quotes is unquoted."""
 
     s = "May the force be with you."
-    assert s == strip_matching_quotes('"{}"'.format(s))
-    assert s == strip_matching_quotes("'{}'".format(s))
+    assert s == strip_matching_quotes(f'"{s}"')
+    assert s == strip_matching_quotes(f"'{s}'")
 
 
 def test_strip_quotes_with_unmatching_quotes():
     """Test that a string with unmatching quotes is not unquoted."""
 
     s = "May the force be with you."
-    assert '"' + s == strip_matching_quotes('"{}'.format(s))
-    assert s + "'" == strip_matching_quotes("{}'".format(s))
+    assert '"' + s == strip_matching_quotes(f'"{s}')
+    assert s + "'" == strip_matching_quotes(f"{s}'")
 
 
 def test_strip_quotes_with_empty_string():

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -101,7 +101,7 @@ def test_tee_command_error():
     with pytest.raises(OSError):
         with tempfile.NamedTemporaryFile() as f:
             os.chmod(f.name, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
-            mycli.packages.special.execute(None, "tee {}".format(f.name))
+            mycli.packages.special.execute(None, f"tee {f.name}")
 
 
 @dbtest
@@ -109,7 +109,7 @@ def test_tee_command_error():
 def test_favorite_query():
     with db_connection().cursor() as cur:
         query = 'select "✔"'
-        mycli.packages.special.execute(cur, "\\fs check {0}".format(query))
+        mycli.packages.special.execute(cur, f"\\fs check {query}")
         assert next(mycli.packages.special.execute(cur, "\\f check"))[0] == "> " + query
 
 
@@ -198,8 +198,8 @@ def test_watch_query_iteration():
     """Test that a single iteration of the result of `watch_query` executes
     the desired query and returns the given results."""
     expected_value = "1"
-    query = "SELECT {0!s}".format(expected_value)
-    expected_title = "> {0!s}".format(query)
+    query = f"SELECT {expected_value}"
+    expected_title = f"> {query}"
     with db_connection().cursor() as cur:
         result = next(mycli.packages.special.iocommands.watch_query(arg=query, cur=cur))
     assert result[0] == expected_title
@@ -221,12 +221,12 @@ def test_watch_query_full():
     watch_seconds = 0.3
     wait_interval = 1
     expected_value = "1"
-    query = "SELECT {0!s}".format(expected_value)
-    expected_title = "> {0!s}".format(query)
+    query = f"SELECT {expected_value}"
+    expected_title = f"> {query}"
     expected_results = [4, 5]
     ctrl_c_process = send_ctrl_c(wait_interval)
     with db_connection().cursor() as cur:
-        results = list(mycli.packages.special.iocommands.watch_query(arg="{0!s} {1!s}".format(watch_seconds, query), cur=cur))
+        results = list(mycli.packages.special.iocommands.watch_query(arg=f"{watch_seconds} {query}", cur=cur))
     ctrl_c_process.join(1)
     assert len(results) in expected_results
     for result in results:
@@ -283,14 +283,14 @@ def test_watch_query_interval_clear(clear_mock):
     seconds = 1.0
     watch_query = mycli.packages.special.iocommands.watch_query
     with db_connection().cursor() as cur:
-        test_asserts(watch_query("{0!s} -c select 1;".format(seconds), cur=cur))
-        test_asserts(watch_query("-c {0!s} select 1;".format(seconds), cur=cur))
+        test_asserts(watch_query(f"{seconds} -c select 1;", cur=cur))
+        test_asserts(watch_query(f"-c {seconds} select 1;", cur=cur))
 
 
 def test_split_sql_by_delimiter():
     for delimiter_str in (";", "$", "😀"):
         mycli.packages.special.set_delimiter(delimiter_str)
-        sql_input = "select 1{} select \ufffc2".format(delimiter_str)
+        sql_input = f"select 1{delimiter_str} select \ufffc2"
         queries = ("select 1", "select \ufffc2")
         for query, parsed_query in zip(queries, mycli.packages.special.split_queries(sql_input)):
             assert query == parsed_query

--- a/test/test_sqlexecute.py
+++ b/test/test_sqlexecute.py
@@ -12,7 +12,7 @@ from test.utils import dbtest, is_expanded_output, run, set_expanded_output
 def assert_result_equal(result, title=None, rows=None, headers=None, status=None, auto_status=True, assert_contains=False):
     """Assert that an sqlexecute.run() result matches the expected values."""
     if status is None and auto_status and rows:
-        status = "{} row{} in set".format(len(rows), "s" if len(rows) > 1 else "")
+        status = f"{len(rows)} row{'s' if len(rows) > 1 else ''} in set"
     fields = {"title": title, "rows": rows, "headers": headers, "status": status}
 
     if assert_contains:
@@ -208,14 +208,14 @@ def test_system_command_output(executor):
     eol = os.linesep
     test_dir = os.path.abspath(os.path.dirname(__file__))
     test_file_path = os.path.join(test_dir, "test.txt")
-    results = run(executor, "system cat {0}".format(test_file_path))
+    results = run(executor, f"system cat {test_file_path}")
     assert_result_equal(results, status=f"mycli rocks!{eol}")
 
 
 @dbtest
 def test_cd_command_current_dir(executor):
     test_path = os.path.abspath(os.path.dirname(__file__))
-    run(executor, "system cd {0}".format(test_path))
+    run(executor, f"system cd {test_path}")
     assert os.getcwd() == test_path
 
 


### PR DESCRIPTION
## Description
Convert uses of `.format()` to f-strings in the test directory.

No `%` interpolations found.

No functional change.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
