### PR TITLE
Modernize history file `open()`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@ Internal
 * Improve pull request template lint commands.
 * Complete typehinting the non-test codebase.
 * Modernization: conversion to f-strings.
+* Modernization: remove more Python 2 compatibility logic.
 
 
 1.37.1 (2025/07/28)

--- a/mycli/packages/toolkit/history.py
+++ b/mycli/packages/toolkit/history.py
@@ -36,10 +36,8 @@ class FileHistoryWithTimestamp(FileHistory):
                 history_with_timestamp.append((string, timestamp))
 
         if os.path.exists(self.filename):
-            with open(self.filename, "rb") as f:
-                for line_bytes in f:
-                    line = line_bytes.decode("utf-8", errors="replace")
-
+            with open(self.filename, 'r', encoding='utf-8') as f:
+                for line in f:
                     if line.startswith("#"):
                         # Extract timestamp
                         timestamp = line[2:].strip()


### PR DESCRIPTION
## Description
`open()` with 'r' is preferable to 'rb' with `decode()`.  We can set `encoding='utf-8'` just to be sure of compatibility with prompt_toolkit.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
