### PR TITLE
Temporary favorite query completion crash fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
-Upcoming Release (TBD)
+1.38.0 (2025/08/19)
 ======================
+
+Bug Fixes
+--------
+* Partially fix Favorite Query completion crash.
+
 
 Internal
 --------

--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -1193,8 +1193,9 @@ class SQLCompleter(Completer):
                 completions.extend(special_m)
 
             elif suggestion["type"] == "favoritequery":
-                queries_m = self.find_matches(word_before_cursor, FavoriteQueries.instance.list(), start_only=False, fuzzy=True)
-                completions.extend(queries_m)
+                if hasattr(FavoriteQueries, 'instance') and hasattr(FavoriteQueries.instance, 'list'):
+                    queries_m = self.find_matches(word_before_cursor, FavoriteQueries.instance.list(), start_only=False, fuzzy=True)
+                    completions.extend(queries_m)
 
             elif suggestion["type"] == "table_format":
                 formats_m = self.find_matches(word_before_cursor, self.table_formats)


### PR DESCRIPTION
## Description
Favorite queries seem to be broken in other ways.  This at least stops a crash while fixing.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
