### PR TITLE
Limit Alt-R to Emacs mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,14 @@
 Upcoming (TBD)
 ==============
 
+Bug Fixes
+--------
+* Limit Alt-R bindings to Emacs mode.
+
+
 Internal
 --------
-* Only read "my" configuration files once, rather than once per call to read_my_cnf_files
+* Only read "my" configuration files once, rather than once per call to read_my_cnf_files.
 
 
 1.38.3 (2025/08/21)

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -150,7 +150,7 @@ def mycli_bindings(mycli) -> KeyBindings:
         else:
             search_history(event)
 
-    @kb.add("escape", "r", filter=control_is_searchable)
+    @kb.add("escape", "r", filter=control_is_searchable & emacs_mode)
     def _(event: KeyPressEvent) -> None:
         """Search history using fzf when available."""
         _logger.debug("Detected <alt-r> key.")


### PR DESCRIPTION
## Description

Since Alt-R is implemented as the sequence Esc R, and since vi mode has other uses for Esc, limit the Alt-R binding to Emacs mode.

Testing shows that Control-R is available in vi bindings, whether or not that is a good thing, so it is left unmodified.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
