### PR TITLE
Fix timing being printed twice

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming (TBD)
 Bug Fixes
 --------
 * Limit Alt-R bindings to Emacs mode.
+* Fix timing being printed twice.
 
 
 Internal

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -757,7 +757,6 @@ class MyCli:
                         self.bell()
                     if special.is_timing_enabled():
                         self.echo(f"Time: {t:0.03f}s")
-                    self.echo(f"Time: {t:0.03f}s")
                 except KeyboardInterrupt:
                     pass
 


### PR DESCRIPTION
## Description

Timing info was being printed twice.  Fixes #1345.


## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
