### PR TITLE
Set default `local_infile` in `pymysql.connect()`

### DIFF
--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -238,7 +238,7 @@ class SQLExecute:
             charset=charset or '',
             autocommit=True,
             client_flag=client_flag,
-            local_infile=local_infile,
+            local_infile=local_infile or False,
             conv=conv,
             ssl=ssl_context,  # type: ignore[arg-type]
             program_name="mycli",


### PR DESCRIPTION
## Description
This parameter cannot be None according to pymysql.  Some update in the type stubs caused this to fail, which is affecting PRs https://github.com/dbcli/mycli/pull/1351 and https://github.com/dbcli/mycli/pull/1349 .

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [ ] ~I've added this contribution to the `changelog.md`.~  Leaving this out of the changelog for now to ease a rebase.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
