### PR TITLE
fix: ssl check wrong

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+* Fix ssl_context always created.
+
 1.38.4 (2025/09/06)
 ==============
 

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -107,6 +107,7 @@ Contributors:
   * Mohamed Rezk
   * Ryosuke Kazami
   * Cornel Cruceru
+  * Sherlock Holo
 
 
 Created by:

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -224,7 +224,7 @@ class SQLExecute:
             client_flag |= pymysql.constants.CLIENT.MULTI_STATEMENTS
 
         ssl_context = None
-        if ssl:
+        if ssl and ssl.get('enable') is True:
             ssl_context = self._create_ssl_ctx(ssl)
 
         conn = pymysql.connect(


### PR DESCRIPTION
## Description

when sqlexecutre check if user use ssl, it just check the ssl variable is not None, but if user use ssl actually, the ssl map will have a key 'enable' and value will be True
this will fix when using plain connection mode(without ssl), even use correct password, mycli still return error Bad Handshake

we can confirm it by using wireshark to capture the login request package, with this fix, the `Switch to SSL after handshake` will be `not set`



## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
