### PR TITLE
Switch from pyaes to pycryptodomex

### DIFF
--- a/mycli/config.py
+++ b/mycli/config.py
@@ -8,7 +8,7 @@ import sys
 from typing import Union, IO
 
 from configobj import ConfigObj, ConfigObjError
-import pyaes
+from Cryptodome.Cipher import AES
 
 try:
     import importlib.resources as resources
@@ -189,7 +189,7 @@ def encrypt_mylogin_cnf(plaintext: IO[str]):
         return bytes(rkey)
 
     def encode_line(plaintext, real_key, buf_len):
-        aes = pyaes.AESModeOfOperationECB(real_key)
+        aes = AES.new(real_key, AES.MODE_ECB)
         text_len = len(plaintext)
         pad_len = buf_len - text_len
         pad_chr = bytes(chr(pad_len), "utf8")
@@ -267,7 +267,7 @@ def read_and_decrypt_mylogin_cnf(f):
 
     # Create a bytes buffer to hold the plaintext.
     plaintext = BytesIO()
-    aes = pyaes.AESModeOfOperationECB(rkey)
+    aes = AES.new(rkey_b, AES.MODE_ECB)
 
     while True:
         # Read the length of the ciphertext.

--- a/release.py
+++ b/release.py
@@ -72,7 +72,7 @@ def upload_distribution_files():
 
 
 def push_to_github():
-    run_step('git', 'push', 'origin', 'master')
+    run_step('git', 'push', 'origin', 'main')
 
 
 def push_tags_to_github():

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requirements = [
     'configobj >= 5.0.5',
     'cli_helpers[styles] >= 2.2.1',
     'pyperclip >= 1.8.1',
-    'pyaes >= 1.6.1'
+    "pycryptodomex",
 ]
 
 if sys.version_info.minor < 9:


### PR DESCRIPTION
## Description

Switch from pyaes to pycryptodomex

I got this patch from the Fedora package maintainer terjeros:
https://src.fedoraproject.org/rpms/mycli/blob/rawhide/f/0002-Switch-from-pyaes-to-pycryptodomex.patch

Not sure if this is a good idea, please leave your comments in the PR

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
- [ ] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
