### PR TITLE
SQL quote test fix

### DIFF
--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -316,7 +316,7 @@ def test_auto_escaped_col_names(completer, complete_event):
         Completion(text="id", start_position=0),
         Completion(text="`insert`", start_position=0),
         Completion(text="`ABC`", start_position=0),
-    ] + list(map(Completion, completer.functions)) + [Completion(text="select", start_position=0)] + list(
+    ] + list(map(Completion, completer.functions)) + [Completion(text="`select`", start_position=0)] + list(
         map(Completion, completer.keywords)
     )
 


### PR DESCRIPTION
## Description

SQL quote test fix

I got this patch from the Fedora package maintainer terjeros:
https://src.fedoraproject.org/rpms/mycli/blob/rawhide/f/0001-SQL-quote-test-fix.patch

Not sure if this is a good idea, please leave your comments in the PR

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
- [ ] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
