### PR TITLE
Revert to sqlglot 5.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "prompt_toolkit>=3.0.6,<4.0.0",
     "PyMySQL >= 0.9.2",
     "sqlparse>=0.3.0,<0.6.0",
-    "sqlglot[rs] == 26.*",
+    "sqlglot >= 5.1.3",
     "configobj >= 5.0.5",
     "cli_helpers[styles] >= 2.7.0",
     "pyperclip >= 1.8.1",


### PR DESCRIPTION
## Description

Revert to sqlglot 5.1.3

I got this patch from the Fedora package maintainer terjeros:
https://src.fedoraproject.org/rpms/mycli/blob/rawhide/f/0005-Revert-to-sqlglot-5.1.3.patch

Not sure if this is a good idea, please leave your comments in the PR

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
- [ ] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
