### PR TITLE
Revert to older toml format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 description = "CLI for MySQL Database. With auto-completion and syntax highlighting."
 readme = "README.md"
 requires-python = ">=3.9"
-license = "BSD-3-Clause"
+license = { text = "BSD" }
 authors = [{ name = "Mycli Core Team", email = "mycli-dev@googlegroups.com" }]
 urls = { homepage = "http://mycli.net" }
 


### PR DESCRIPTION
## Description

Revert to older toml format

I got this patch from the Fedora package maintainer terjeros:
https://src.fedoraproject.org/rpms/mycli/blob/rawhide/f/0006-Revert-to-older-toml-format.patch

Not sure if this is a good idea, please leave your comments in the PR

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
- [ ] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
