### PR TITLE
Prepare changelog for release v1.39.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-Upcoming (TBD)
+1.39.0 (2025/10/30)
 ==============
 
 Features
@@ -10,6 +10,11 @@ Bug Fixes
 --------
 * Fixes use of incorrect ssl config after retrying connection with prompted password.
 * Fix ssl_context always created.
+
+
+Internal
+--------
+Typing fix for `pymysql.connect()`.
 
 
 1.38.4 (2025/09/06)


### PR DESCRIPTION
## Description
Calling this a feature release because we drop Python 3.9 support.
