### PR TITLE
Switch from pyaes to pycryptodomex

### DIFF
--- a/mycli/config.py
+++ b/mycli/config.py
@@ -9,7 +9,7 @@ import sys
 from typing import IO, BinaryIO, Literal, TextIO
 
 from configobj import ConfigObj, ConfigObjError
-import pyaes
+from Cryptodome.Cipher import AES
 
 logger = logging.getLogger(__name__)
 
@@ -175,7 +175,7 @@ def encrypt_mylogin_cnf(plaintext: IO[str]) -> BytesIO:
         return bytes(rkey)
 
     def encode_line(plaintext: str, real_key: bytes, buf_len: int) -> bytes:
-        aes = pyaes.AESModeOfOperationECB(real_key)
+        aes = AES.new(real_key, AES.MODE_ECB)
         text_len = len(plaintext)
         pad_len = buf_len - text_len
         pad_chr = bytes(chr(pad_len), "utf8")
@@ -250,7 +250,7 @@ def read_and_decrypt_mylogin_cnf(f: BinaryIO) -> BytesIO | None:
 
     # Create a bytes buffer to hold the plaintext.
     plaintext = BytesIO()
-    aes = pyaes.AESModeOfOperationECB(rkey_b)
+    aes = AES.new(rkey_b, AES.MODE_ECB)
 
     while True:
         # Read the length of the ciphertext.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "configobj >= 5.0.5",
     "cli_helpers[styles] >= 2.7.0",
     "pyperclip >= 1.8.1",
-    "pyaes >= 1.6.1",
+    "pycryptodomex",
     "pyfzf >= 0.3.1",
     "llm>=0.19.0",
     "setuptools",                   # Required by llm commands to install models


### PR DESCRIPTION
## Description

Switch from pyaes to pycryptodomex

I got this patch from the Fedora package maintainer terjeros:
https://src.fedoraproject.org/rpms/mycli/blob/rawhide/f/0002-Switch-from-pyaes-to-pycryptodomex.patch

Not sure if this is a good idea, please leave your comments in the PR

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
- [ ] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
