### PR TITLE
Revert "fix: ssl check wrong"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,12 @@
-1.39.0 (2025/10/30)
+1.39.1 (2025/10/06)
+==============
+
+Bug Fixes
+--------
+* Don't require `--ssl` argument when other SSL arguments are given.
+
+
+1.39.0 (2025/09/30)
 ==============
 
 Features

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -224,7 +224,7 @@ class SQLExecute:
             client_flag |= pymysql.constants.CLIENT.MULTI_STATEMENTS
 
         ssl_context = None
-        if ssl and ssl.get('enable') is True:
+        if ssl:
             ssl_context = self._create_ssl_ctx(ssl)
 
         conn = pymysql.connect(


### PR DESCRIPTION
## Description
This reverts commit e1d601f9e13383596dde063feec5df11898498d5.

Per https://github.com/dbcli/mycli/issues/1367, this breaks some SSL connections unless `--ssl` is given explicitly, which is not per the documentation.

Most likely we will restore this revert later, with some changes to argument processing.


## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
