### PR TITLE
Require changelog.md to be in release form when making a release.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,19 @@ permissions:
   contents: read
 
 jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+    - name: Require release changelog form
+      run: |
+        if grep -q TBD changelog.md; then false; fi
+
   test:
     runs-on: ubuntu-latest
+    needs: [docs]
 
     strategy:
       matrix:

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Internal
 * Add mypy to Pull Request template.
 * Enable flake8-bugbear lint rules.
 * Fix flaky editor-command tests in CI.
+* Require release format of `changelog.md` when making a release.
 
 
 1.40.0 (2025/10/14)


### PR DESCRIPTION
## Description
Require `changelog.md` to be in release form when making a release.  The TBD section should be replaced with a version and date.

The only problem with this is that a new tag will be created before we get to this stopping point.

I would also like to suppress the flaky external editor test when making a release.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format` to lint and format the code.
