### PR TITLE
Enable flake8-bugbear ruff lint rules

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming (TBD)
 Internal
 --------
 * Add mypy to Pull Request template.
+* Enable flake8-bugbear lint rules.
 
 
 1.40.0 (2025/10/14)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,13 @@ target-version = 'py39'
 line-length = 140
 
 [tool.ruff.lint]
-select = ['A', 'I', 'E', 'W', 'F', 'C4', 'PIE', 'TID']
+select = ['A', 'B', 'I', 'E', 'W', 'F', 'C4', 'PIE', 'TID']
 ignore = [
+    'B005',   # Multi-character strip()
+    'B006',   # TODO: Mutable data structures for argument defaults
+    'B007',   # TODO: Variable unused
+    'B015',   # TODO: Pointless comparison
+    'B904',   # TODO: Raise exceptions with "raise ... from err"
     'E401',   # Multiple imports on one line
     'E402',   # Module level import not at top of file
     'PIE808', # range() starting with 0


### PR DESCRIPTION
## Description
Enable the flake8-bugbear ruff lint rules, but disable all of the ones which actually occur in the current codebase, so they can be handled one-by-one.

The bugbear lint rules are generally pretty helpful, especially B006: mutable data structures for argument defaults.

We will leave in place the "ignore" for B005: multi-character strip().

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
