### PR TITLE
Enable lint rule B007: variable unused

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -887,7 +887,7 @@ class MyCli:
                     # Restart connection to the database
                     sqlexecute.connect()
                     try:
-                        for title, cur, headers, status in sqlexecute.run(f"kill {connection_id_to_kill}"):
+                        for _title, _cur, _headers, status in sqlexecute.run(f"kill {connection_id_to_kill}"):
                             status_str = str(status).lower()
                             if status_str.find("ok") > -1:
                                 logger.debug("cancelled query, connection id: %r, sql: %r", connection_id_to_kill, text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ select = ['A', 'B', 'I', 'E', 'W', 'F', 'C4', 'PIE', 'TID']
 ignore = [
     'B005',   # Multi-character strip()
     'B006',   # TODO: Mutable data structures for argument defaults
-    'B007',   # TODO: Variable unused
     'B015',   # TODO: Pointless comparison
     'B904',   # TODO: Raise exceptions with "raise ... from err"
     'E401',   # Multiple imports on one line


### PR DESCRIPTION
## Description
Prefixing with underscore is just a good practice.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
