### PR TITLE
Enable lint rule B015: pointless comparison

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ select = ['A', 'B', 'I', 'E', 'W', 'F', 'C4', 'PIE', 'TID']
 ignore = [
     'B005',   # Multi-character strip()
     'B006',   # TODO: Mutable data structures for argument defaults
-    'B015',   # TODO: Pointless comparison
     'E401',   # Multiple imports on one line
     'E402',   # Module level import not at top of file
     'PIE808', # range() starting with 0

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -51,9 +51,8 @@ def test_editor_command():
 
     os.environ["EDITOR"] = "true"
     os.environ["VISUAL"] = "true"
-    # Set the editor to Notepad on Windows
     if os.name != "nt":
-        mycli.packages.special.open_external_editor(sql=r"select 1") == "select 1"
+        assert mycli.packages.special.open_external_editor(sql=r"select 1") == ('select 1', None)
     else:
         pytest.skip("Skipping on Windows platform.")
 


### PR DESCRIPTION
## Description
Enable lint rule B015: pointless comparison, catching a missing assert in the test suite.

Incidentally remove an outdated comment.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
