### PR TITLE
Enable lint rule B006: mutable function defaults

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -407,7 +407,7 @@ class MyCli:
         socket: str | None = "",
         charset: str | None = "",
         local_infile: bool = False,
-        ssl: dict[str, Any] | None = {},
+        ssl: dict[str, Any] | None = None,
         ssh_user: str | None = "",
         ssh_host: str | None = "",
         ssh_port: int = 22,

--- a/mycli/packages/special/main.py
+++ b/mycli/packages/special/main.py
@@ -57,7 +57,7 @@ def special_command(
     arg_type: ArgType = ArgType.PARSED_QUERY,
     hidden: bool = False,
     case_sensitive: bool = False,
-    aliases: list[str] = [],
+    aliases: list[str] | None = None,
 ) -> Callable:
     def wrapper(wrapped):
         register_special_command(
@@ -83,7 +83,7 @@ def register_special_command(
     arg_type: ArgType = ArgType.PARSED_QUERY,
     hidden: bool = False,
     case_sensitive: bool = False,
-    aliases: list[str] = [],
+    aliases: list[str] | None = None,
 ) -> None:
     cmd = command.lower() if not case_sensitive else command
     COMMANDS[cmd] = SpecialCommand(
@@ -95,6 +95,7 @@ def register_special_command(
         hidden=hidden,
         case_sensitive=case_sensitive,
     )
+    aliases = [] if aliases is None else aliases
     for alias in aliases:
         cmd = alias.lower() if not case_sensitive else alias
         COMMANDS[cmd] = SpecialCommand(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ line-length = 140
 select = ['A', 'B', 'I', 'E', 'W', 'F', 'C4', 'PIE', 'TID']
 ignore = [
     'B005',   # Multi-character strip()
-    'B006',   # TODO: Mutable data structures for argument defaults
     'E401',   # Multiple imports on one line
     'E402',   # Module level import not at top of file
     'PIE808', # range() starting with 0


### PR DESCRIPTION
## Description
B006 violations are usually bugs waiting to happen.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
