### PR TITLE
Enable lint rule B904: raise within `except` using `from`

### DIFF
--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -380,7 +380,7 @@ def set_tee(arg: str, **_) -> list[tuple]:
     try:
         tee_file = open(*parseargfile(arg))
     except (IOError, OSError) as e:
-        raise OSError(f"Cannot write to file '{e.filename}': {e.strerror}")
+        raise OSError(f"Cannot write to file '{e.filename}': {e.strerror}") from e
 
     return [(None, None, None, "")]
 
@@ -413,7 +413,7 @@ def set_once(arg: str, **_) -> list[tuple]:
     try:
         once_file = open(*parseargfile(arg))
     except (IOError, OSError) as e:
-        raise OSError(f"Cannot write to file '{e.filename}': {e.strerror}")
+        raise OSError(f"Cannot write to file '{e.filename}': {e.strerror}") from e
     written_to_once_file = False
 
     return [(None, None, None, "")]
@@ -456,7 +456,7 @@ def _run_post_redirect_hook(post_redirect_command: str, filename: str) -> None:
             stderr=subprocess.DEVNULL,
         )
     except Exception as e:
-        raise OSError(f"Redirect post hook failed: {e}")
+        raise OSError(f"Redirect post hook failed: {e}") from e
 
 
 @special_command("\\pipe_once", "\\| command", "Send next result to a subprocess.", aliases=["\\|"])

--- a/mycli/packages/special/llm.py
+++ b/mycli/packages/special/llm.py
@@ -42,16 +42,14 @@ def run_external_cmd(cmd, *args, capture_output=False, restart_cli=False, raise_
                 code = e.code
                 if code != 0 and raise_exception:
                     if capture_output:
-                        raise RuntimeError(buffer.getvalue())
-                    else:
-                        raise RuntimeError(f"Command {cmd} failed with exit code {code}.")
+                        raise RuntimeError(buffer.getvalue()) from e
+                    raise RuntimeError(f"Command {cmd} failed with exit code {code}.") from e
             except Exception as e:
                 code = 1
                 if raise_exception:
                     if capture_output:
-                        raise RuntimeError(buffer.getvalue())
-                    else:
-                        raise RuntimeError(f"Command {cmd} failed: {e}")
+                        raise RuntimeError(buffer.getvalue()) from e
+                    raise RuntimeError(f"Command {cmd} failed: {e}") from e
         if restart_cli and code == 0:
             os.execv(original_exe, [original_exe] + original_args)
         if capture_output:
@@ -211,7 +209,7 @@ def handle_llm(text, cur) -> Tuple[str, Optional[str], float]:
             context = ""
         return (context, sql, end - start)
     except Exception as e:
-        raise RuntimeError(e)
+        raise RuntimeError(e) from e
 
 
 def is_llm_command(command) -> bool:

--- a/mycli/packages/special/main.py
+++ b/mycli/packages/special/main.py
@@ -119,10 +119,10 @@ def execute(cur: Cursor, sql: str) -> list[tuple]:
 
     try:
         special_cmd = COMMANDS[command]
-    except KeyError:
+    except KeyError as exc:
         special_cmd = COMMANDS[command.lower()]
         if special_cmd.case_sensitive:
-            raise CommandNotFound(f'Command not found: {command}')
+            raise CommandNotFound(f'Command not found: {command}') from exc
 
     # "help <SQL KEYWORD> is a special case. We want built-in help, not
     # mycli help here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ ignore = [
     'B006',   # TODO: Mutable data structures for argument defaults
     'B007',   # TODO: Variable unused
     'B015',   # TODO: Pointless comparison
-    'B904',   # TODO: Raise exceptions with "raise ... from err"
     'E401',   # Multiple imports on one line
     'E402',   # Module level import not at top of file
     'PIE808', # range() starting with 0


### PR DESCRIPTION
## Description
Enable lint rule B904: raise within `except` using `from`, incidentally removing some needless `else`s.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
