### PR TITLE
Allow a skipped test on Python 3.12 series

### DIFF
--- a/test/features/crud_table.feature
+++ b/test/features/crud_table.feature
@@ -40,7 +40,6 @@ Feature: manipulate tables:
 
    # TODO (amjith). This scenario fails in GH actions but only in 3.12. Unable
    # to reproduce locally.
-   @skip_py312
    Scenario: no destructive warning if disabled in config
      When we run dbcli with --no-warn
       and we query "create table blabla(x integer);"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

I wanted to see if this was fixed in a later version of Python 3.12.  This was logical to try since it _is_ fixed in Python 3.13.  But the test still fails in CI.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
- [ ] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
