### PR TITLE
Reduce size of LLM prompts + cache per-schema context

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,16 @@
+TBD
+==============
+
+Features
+--------
+* Options to limit size of LLM prompts; cache LLM prompt data.
+
+
+Bug Fixes
+--------
+* Correct mangled schema info sent in LLM prompts.
+
+
 1.50.0 (2026/02/07)
 ==============
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -169,6 +169,14 @@ class MyCli:
         self.null_string = c['main'].get('null_string')
         self.numeric_alignment = c['main'].get('numeric_alignment', 'right')
         self.binary_display = c['main'].get('binary_display')
+        if 'llm' in c and re.match(r'^\d+$', c['llm'].get('prompt_field_truncate', '')):
+            self.llm_prompt_field_truncate = int(c['llm'].get('prompt_field_truncate'))
+        else:
+            self.llm_prompt_field_truncate = 0
+        if 'llm' in c and re.match(r'^\d+$', c['llm'].get('prompt_section_truncate', '')):
+            self.llm_prompt_section_truncate = int(c['llm'].get('prompt_section_truncate'))
+        else:
+            self.llm_prompt_section_truncate = 0
 
         # set ssl_mode if a valid option is provided in a config file, otherwise None
         ssl_mode = c["main"].get("ssl_mode", None)
@@ -965,9 +973,16 @@ class MyCli:
                 while special.is_llm_command(text):
                     start = time()
                     try:
+                        assert isinstance(self.sqlexecute, SQLExecute)
                         assert sqlexecute.conn is not None
                         cur = sqlexecute.conn.cursor()
-                        context, sql, duration = special.handle_llm(text, cur)
+                        context, sql, duration = special.handle_llm(
+                            text,
+                            cur,
+                            sqlexecute.dbname or '',
+                            self.llm_prompt_field_truncate,
+                            self.llm_prompt_section_truncate,
+                        )
                         if context:
                             click.echo("LLM Response:")
                             click.echo(context)

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -176,6 +176,17 @@ default_ssl_cipher =
 # --ssl-verify-server-cert being set
 default_ssl_verify_server_cert = False
 
+[llm]
+
+# If set to a positive integer, truncate text/binary fields to that width
+# in bytes when sending sample data, to conserve tokens.  Suggestion: 1024.
+prompt_field_truncate = None
+
+# If set to a positive integer, attempt to truncate various sections of LLM
+# prompt input to that number in bytes, to conserve tokens.  Suggestion:
+# 1000000.
+prompt_section_truncate = None
+
 [keys]
 # possible values: auto, fzf, reverse_isearch
 control_r = auto

--- a/test/myclirc
+++ b/test/myclirc
@@ -174,6 +174,17 @@ default_ssl_cipher =
 # --ssl-verify-server-cert being set
 default_ssl_verify_server_cert = False
 
+[llm]
+
+# If set to a positive integer, truncate text/binary fields to that width
+# in bytes when sending sample data, to conserve tokens.  Suggestion: 1024.
+prompt_field_truncate = None
+
+# If set to a positive integer, attempt to truncate various sections of LLM
+# prompt input to that number in bytes, to conserve tokens.  Suggestion:
+# 1000000.
+prompt_section_truncate = None
+
 [keys]
 # possible values: auto, fzf, reverse_isearch
 control_r = auto


### PR DESCRIPTION
 ## Description
 * truncate text/binary sample data fields to a configurable number of characters
 * truncate entire tables from schema representation if the representation is very large
 * for latency improvement, cache sample data and schema representation, passing the dbname in both cases to invalidate the cache if changing the db
 * add separate progress message when generating sample data
 * fix bug sending first character of schema lines
 * backquote reserved word "schema" when used as alias

We could also apply final size limits to the prompt string, though meaning-preserving truncation at that point is harder.

Addresses #1348.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
