### PR TITLE
Double editor-command test timeouts to 4 seconds

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Internal
 --------
 * Add mypy to Pull Request template.
 * Enable flake8-bugbear lint rules.
+* Fix flaky editor-command tests in CI.
 
 
 1.40.0 (2025/10/14)

--- a/test/features/steps/iocommands.py
+++ b/test/features/steps/iocommands.py
@@ -14,8 +14,8 @@ def step_edit_file(context):
     if os.path.exists(context.editor_file_name):
         os.remove(context.editor_file_name)
     context.cli.sendline(f"\\e {os.path.basename(context.editor_file_name)}")
-    wrappers.expect_exact(context, 'Entering Ex mode.  Type "visual" to go to Normal mode.', timeout=2)
-    wrappers.expect_exact(context, "\r\n:", timeout=2)
+    wrappers.expect_exact(context, 'Entering Ex mode.  Type "visual" to go to Normal mode.', timeout=4)
+    wrappers.expect_exact(context, "\r\n:", timeout=4)
 
 
 @when('we type "{query}" in the editor')
@@ -23,13 +23,13 @@ def step_edit_type_sql(context, query):
     context.cli.sendline("i")
     context.cli.sendline(query)
     context.cli.sendline(".")
-    wrappers.expect_exact(context, "\r\n:", timeout=2)
+    wrappers.expect_exact(context, "\r\n:", timeout=4)
 
 
 @when("we exit the editor")
 def step_edit_quit(context):
     context.cli.sendline("x")
-    wrappers.expect_exact(context, "written", timeout=2)
+    wrappers.expect_exact(context, "written", timeout=4)
 
 
 @then('we see "{query}" in prompt')


### PR DESCRIPTION
## Description
Double editor-command test timeouts to 4 seconds, in an attempt to fix a flaky test in GitHub Actions

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
