### PR TITLE
Let LLM commands respect `is_timing_enabled` setting

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ Features
 * Make LLM dependencies an optional extra.
 
 
+Bug Fixes
+--------
+* Let LLM commands respect show-timing configuration.
+
+
 Internal
 --------
 * Add mypy to Pull Request template.

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -802,7 +802,8 @@ class MyCli:
                             click.echo("LLM Response:")
                             click.echo(context)
                             click.echo("---")
-                        click.echo(f"Time: {duration:.2f} seconds")
+                        if special.is_timing_enabled():
+                            click.echo(f"Time: {duration:.2f} seconds")
                         text = self.prompt_app.prompt(default=sql or '')
                     except KeyboardInterrupt:
                         return

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -27,7 +27,7 @@ log_level = INFO
 # line below.
 # audit_log = ~/.mycli-audit.log
 
-# Timing of sql statements and table rendering.
+# Timing of SQL statements and table rendering, or LLM commands.
 timing = True
 
 # Beep after long-running queries are completed; 0 to disable.


### PR DESCRIPTION
## Description
Let LLM commands respect `is_timing_enabled` setting, just like queries.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
