### PR TITLE
Refine typehints in `special/llm.py`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@ Internal
 * Enable flake8-bugbear lint rules.
 * Fix flaky editor-command tests in CI.
 * Require release format of `changelog.md` when making a release.
+* Improve type annotations on LLM driver.
 
 
 1.40.0 (2025/10/14)


### PR DESCRIPTION
## Description
 * `Optional` can be replaced by `| None` in modern Pythons
 * `Tuple` can be replaced by lowercase `tuple` in modern Pythons
 * variable `cur` has a type of `pymysql.cursors.Cursor`
 * typehint contextlib variable `redirect`
 * **change exit code to `int(e.code or 0)`, a semantic change**
 * split `build_command_tree()` using an inner `_build_command_tree()` to simplify the return type
 * don't pass mutable `COMMAND_TREE` as an argument default
 * typehint almost all function arguments
 * typehint all return types
 * remove a needless `return` statement
 * reformat many parameter lists as vertical

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
