### PR TITLE
Upgrade `click` to v8.3.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
-Upcoming (TBD)
+1.41.1 (2025/11/15)
 ==============
+
+Bug Fixes
+--------
+* Upgrade `click` to v8.3.1, resolving a longstanding pager bug.
+
 
 Internal
 --------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [{ name = "Mycli Core Team", email = "mycli-dev@googlegroups.com" }]
 urls = { homepage = "http://mycli.net" }
 
 dependencies = [
-    "click >= 7.0,<8.1.8",
+    "click >= 8.3.1",
     "cryptography >= 1.0.0",
     "Pygments>=1.6",
     "prompt_toolkit>=3.0.6,<4.0.0",


### PR DESCRIPTION
## Description
Upgrade `click` to v8.3.1, resolving a longstanding pager bug, and prepare changelog for a release.


## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
