### PR TITLE
Miscellaneous typing updates to fix CI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming (TBD)
 Internal
 --------
 * Improve robustness for flaky tests when publishing.
+* Improve type annotations for latest mypy/type stubs.
 
 
 1.41.2 (2025/11/24)

--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -77,7 +77,8 @@ def suggest_type(full_text: str, text_before_cursor: str) -> list[dict[str, Any]
 
     last_token = statement and statement.token_prev(len(statement.tokens))[1] or ""
 
-    return suggest_based_on_last_token(last_token, text_before_cursor, full_text, identifier)
+    # todo: unsure about empty string as identifier
+    return suggest_based_on_last_token(last_token, text_before_cursor, full_text, identifier or Identifier(''))
 
 
 def suggest_special(text: str) -> list[dict[str, Any]]:

--- a/mycli/packages/parseutils.py
+++ b/mycli/packages/parseutils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Generator
+from typing import Any, Generator
 
 import sqlglot
 import sqlparse
@@ -77,7 +77,7 @@ def is_subselect(parsed: TokenList) -> bool:
     return False
 
 
-def extract_from_part(parsed: TokenList, stop_at_punctuation: bool = True) -> Generator[str, None, None]:
+def extract_from_part(parsed: TokenList, stop_at_punctuation: bool = True) -> Generator[Any, None, None]:
     tbl_prefix_seen = False
     for item in parsed.tokens:
         if tbl_prefix_seen:
@@ -123,7 +123,7 @@ def extract_from_part(parsed: TokenList, stop_at_punctuation: bool = True) -> Ge
                     break
 
 
-def extract_table_identifiers(token_stream: TokenList) -> Generator[tuple[str | None, str, str], None, None]:
+def extract_table_identifiers(token_stream: Generator[Any, None, None]) -> Generator[tuple[str | None, str, str], None, None]:
     """yields tuples of (schema_name, table_name, table_alias)"""
 
     for item in token_stream:
@@ -187,15 +187,15 @@ def extract_tables_from_complete_statements(sql: str) -> list[tuple[str | None, 
         return []
 
     finely_parsed = []
-    for statement in roughly_parsed:
+    for rough_statement in roughly_parsed:
         try:
-            finely_parsed.append(sqlglot.parse_one(str(statement), read='mysql'))
+            finely_parsed.append(sqlglot.parse_one(str(rough_statement), read='mysql'))
         except sqlglot.errors.ParseError:
             pass
 
     tables = []
-    for statement in finely_parsed:
-        for identifier in statement.find_all(sqlglot.exp.Table):
+    for fine_statement in finely_parsed:
+        for identifier in fine_statement.find_all(sqlglot.exp.Table):
             if identifier.parent_select and identifier.parent_select.sql().startswith('WITH'):
                 continue
             tables.append((

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -255,7 +255,7 @@ def execute_favorite_query(cur: Cursor, arg: str, **_) -> Generator[tuple, None,
         yield (None, None, None, message)
     else:
         query, arg_error = subst_favorite_query_args(query, args)
-        if arg_error:
+        if query is None:
             yield (None, None, None, arg_error)
         else:
             for sql in sqlparse.split(query):


### PR DESCRIPTION
## Description
 * don't reuse a variable name with different types
 * the last argument to `suggest_based_on_last_token()` must be an `Identifier`
 * `extract_from_part()` is a `Generator` of `Any`, which `extract_table_identifiers()` must accept
 * check the first half of the result of `subst_favorite_query_args()`, so that mypy can deduce that `query` does not hold a `None`

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
