### PR TITLE
Refine Windows documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,21 @@ sudo dnf install mycli
 
 ### Windows
 
+#### Option 1: Native Windows
+
+Install the `less` pager, for example by `scoop install less`.
+
 Follow the instructions on this blogpost: http://web.archive.org/web/20221006045208/https://www.codewall.co.uk/installing-using-mycli-on-windows/
+
+**Mycli is not tested on Windows**, but the libraries used in the app are Windows-compatible.
+This means it should work without any modifications, but isn't supported.
+
+PRs to add native Windows testing to Mycli CI would be welcome!
+
+#### Option 2: WSL
+
+Everything should work as expected in WSL.  This is a good option for using
+Mycli on Windows.
 
 
 ### Thanks:
@@ -128,9 +142,6 @@ Thanks to [PyMysql](https://github.com/PyMySQL/PyMySQL) for a pure python adapte
 
 Mycli is tested on macOS and Linux, and requires Python 3.10 or better.
 
-**Mycli is not tested on Windows**, but the libraries used in this app are Windows-compatible.
-This means it should work without any modifications. If you're unable to run it
-on Windows, please [file a bug](https://github.com/dbcli/mycli/issues/new).
 
 ### Configuration and Usage
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,10 +5,16 @@ Features
 --------
 * Update query processing functions to allow automatic show_warnings to work for more code paths like DDL
 
+
 Bug Fixes
 --------
 * Update the prompt display logic to handle an edge case where a socket is used without
   a host being parsed from any other method (#707).
+
+
+Internal
+--------
+* Refine documentation for Windows.
 
 
 1.42.0 (2025/12/20)


### PR DESCRIPTION
## Description

 * Mycli expects the "less" pager to be available (closes #1088).
 * Merge two different Windows discussions into the same section.
 * Remove the suggestion for Windows users to file issues, and instead say that native Windows isn't supported, which is the current practical truth.
 * Add a plea for Native Windows testing in CI, which would be a good first step for Windows support.
 * Delineate Native Windows vs WSL and nudge toward WSL.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
