### PR TITLE
Let reconnect preserve session state

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ Upcoming (TBD)
 Features
 --------
 * Update query processing functions to allow automatic show_warnings to work for more code paths like DDL.
-* Rework reconnect logic to actually create a new connection instead of simply changing the database (#746).
+* Rework reconnect logic to actually reconnect or create a new connection instead of simply changing the database (#746).
 
 
 Bug Fixes

--- a/test/features/steps/crud_database.py
+++ b/test/features/steps/crud_database.py
@@ -108,6 +108,6 @@ def step_see_db_dropped_no_default(context):
 @then("we see database connected")
 def step_see_db_connected(context):
     """Wait to see drop database output."""
-    wrappers.expect_exact(context, 'You are now connected to database "', timeout=2)
+    wrappers.expect_exact(context, 'connected to database "', timeout=2)
     wrappers.expect_exact(context, '"', timeout=2)
     wrappers.expect_exact(context, f' as user "{context.conf["user"]}"', timeout=2)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -10,6 +10,7 @@ import click
 from click.testing import CliRunner
 
 from mycli.main import MyCli, cli, thanks_picker
+import mycli.packages.special
 from mycli.packages.special.main import COMMANDS as SPECIAL_COMMANDS
 from mycli.sqlexecute import ServerInfo, SQLExecute
 from test.utils import HOST, PASSWORD, PORT, USER, dbtest, run
@@ -38,32 +39,92 @@ CLI_ARGS = [
 
 
 @dbtest
-def test_reconnect_no_database(executor):
-    runner = CliRunner()
+def test_reconnect_no_database(executor, capsys):
+    m = MyCli()
+    m.register_special_commands()
+    m.sqlexecute = SQLExecute(
+        None,
+        USER,
+        PASSWORD,
+        HOST,
+        PORT,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
     sql = "\\r"
-    result = runner.invoke(cli, args=CLI_ARGS, input=sql)
-    expected = "Reconnecting...\nReconnected successfully.\n\n"
-    assert expected in result.output
+    result = next(mycli.packages.special.execute(executor, sql))
+    stdout, _stderr = capsys.readouterr()
+    assert result[-1] is None
+    assert "Already connected" in stdout
 
 
 @dbtest
 def test_reconnect_with_different_database(executor):
-    runner = CliRunner()
-    database = "mysql"
-    sql = f"\\r {database}"
-    result = runner.invoke(cli, args=CLI_ARGS, input=sql)
-    expected = f'Reconnecting...\nReconnected successfully.\n\nYou are now connected to database "{database}" as user "{USER}"\n'
-    assert expected in result.output
+    m = MyCli()
+    m.register_special_commands()
+    m.sqlexecute = SQLExecute(
+        None,
+        USER,
+        PASSWORD,
+        HOST,
+        PORT,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    database_1 = "mycli_test_db"
+    database_2 = "mysql"
+    sql_1 = f"use {database_1}"
+    sql_2 = f"\\r {database_2}"
+    _result_1 = next(mycli.packages.special.execute(executor, sql_1))
+    result_2 = next(mycli.packages.special.execute(executor, sql_2))
+    expected = f'You are now connected to database "{database_2}" as user "{USER}"'
+    assert expected in result_2[-1]
 
 
 @dbtest
 def test_reconnect_with_same_database(executor):
-    runner = CliRunner()
+    m = MyCli()
+    m.register_special_commands()
+    m.sqlexecute = SQLExecute(
+        None,
+        USER,
+        PASSWORD,
+        HOST,
+        PORT,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
     database = "mysql"
-    sql = f"\\u {database}; \\r {database}"
-    result = runner.invoke(cli, args=CLI_ARGS, input=sql)
-    expected = f'Reconnecting...\nReconnected successfully.\n\nYou are already connected to database "{database}" as user "{USER}"\n'
-    assert expected in result.output
+    sql = f"\\u {database}"
+    result = next(mycli.packages.special.execute(executor, sql))
+    sql = f"\\r {database}"
+    result = next(mycli.packages.special.execute(executor, sql))
+    expected = f'You are already connected to database "{database}" as user "{USER}"'
+    assert expected in result[-1]
 
 
 @dbtest


### PR DESCRIPTION
## Description

Followups to `reconnect()` refactor:
 * Before attempting `sqlexecute.connect()`, try `ping(reconnect=True)` to do a true reconnect, preserving the `connection_id()` and other state such as session variables.  This is the important part, which the commentary calls the "second pass".  But it may not have an effect in practice.
 * Also, before attempting `ping(reconnect=True)`, try `ping(reconnect=False)` with fewer feedback messages, which the commentary calls the "first pass".  This pass is helpful to keep chatter down when the user habitually chooses the "connect" verb over "use".  Unlike the second pass, it definitely works in practice.
 * Add new explicit feedback around creating a new connection when doing so, including a red tip to the user that session state was lost, either in the second pass or the third pass.
 * Tweak docstring in `manual_reconnect()` _eg_: "real function" -> "utility method"
 * Move db-change logic out of utility method, into `manual_reconnect()` and `change_db()`, keeping the `database` optional argument, as it is still useful for finessing feedback messages.
 * Silently skip changing the database if it equals "``".
 * In the usual case, let `manual_reconnect()` yield the result of `change_db()`, leaving us directly hooked in to the 4-tuple return-value system (instead of iterating on` change_db()` internally and manually handling the `echo()`).
 * Add an assert on `self.sqlexecute.conn` before pinging it.
 * Clarify "database" vs "server" in `reconnect()` docstring. (Pedantically it could be "cluster" or "endpoint").
 * Update changelog, but just piggyback two words onto the previous entry.
 * Update tests to use `mycli.packages.special.execute()` rather than `CliRunner()`.  `CliRunner()` is only capable of testing the first line of output, which is taken up by an initialization statement.

xref https://github.com/dbcli/mycli/pull/1416

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
