### PR TITLE
Configurable string for missing_value in outputs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features
 --------
 * Update query processing functions to allow automatic show_warnings to work for more code paths like DDL.
 * Rework reconnect logic to actually reconnect or create a new connection instead of simply changing the database (#746).
+* Configurable string for missing values (NULLs) in outputs.
 
 
 Bug Fixes

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -50,6 +50,11 @@ table_format = ascii
 # Recommended: csv.
 redirect_format = csv
 
+# How to display the missing value (ie NULL).  Only certain table formats
+# support configuring the missing value.  CSV for example always uses the
+# empty string, and JSON formats use native nulls.
+null_string = <null>
+
 # A command to run after a successful output redirect, with {} to be replaced
 # with the escaped filename.  Mac example: echo {} | pbcopy.  Escaping is not
 # reliable/safe on Windows.

--- a/test/features/fixture_data/help_commands.txt
+++ b/test/features/fixture_data/help_commands.txt
@@ -14,7 +14,7 @@
 | \pipe_once     | \| command                 | Send next result to a subprocess.                          |
 | \timing        | \t                         | Toggle timing of commands.                                 |
 | connect        | \r                         | Reconnect to the database. Optional database argument.     |
-| delimiter      | <null>                     | Change SQL delimiter.                                      |
+| delimiter      | <nope>                     | Change SQL delimiter.                                      |
 | exit           | \q                         | Exit.                                                      |
 | help           | \?                         | Show this help.                                            |
 | nopager        | \n                         | Disable pager, print to stdout.                            |

--- a/test/features/steps/crud_table.py
+++ b/test/features/steps/crud_table.py
@@ -118,7 +118,7 @@ def step_see_null_selected(context):
             +--------+\r
             | NULL   |\r
             +--------+\r
-            | <null> |\r
+            | <nope> |\r
             +--------+
             """
         ).strip()

--- a/test/myclirc
+++ b/test/myclirc
@@ -48,6 +48,11 @@ table_format = ascii
 # Recommended: csv.
 redirect_format = csv
 
+# How to display the missing value (ie NULL).  Only certain table formats
+# support configuring the missing value.  CSV for example always uses the
+# empty string, and JSON formats use native nulls.
+null_string = <nope>
+
 # A command to run after a successful output redirect, with {} to be replaced
 # with the escaped filename.  Mac example: echo {} | pbcopy.  Escaping is not
 # reliable/safe on Windows.


### PR DESCRIPTION
## Description
The default is `<null>`, meaning no change.

This is configurable in pgcli, and there is no reason not to make it configurable here.

The setting only works for tabular outputs which default to the `cli_helpers` default.  Thus the setting does not change the behavior of CSV or JSON formats.

Fixes #1120 .

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
