### PR TITLE
Provide a way to override the null char in output.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features
 --------
 * Update query processing functions to allow automatic show_warnings to work for more code paths like DDL.
 * Rework reconnect logic to actually reconnect or create a new connection instead of simply changing the database (#746).
+* Allow configuring the string used to display NULL values via myclirc (#1120)
 
 
 Bug Fixes

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -148,6 +148,7 @@ class MyCli:
         self.less_chatty = c["main"].as_bool("less_chatty")
         self.cli_style = c["colors"]
         self.output_style = style_factory_output(self.syntax_style, self.cli_style)
+        self.null_string = c["main"].get("null_string", "<null>")
         self.wider_completion_menu = c["main"].as_bool("wider_completion_menu")
         c_dest_warning = c["main"].as_bool("destructive_warning")
         self.destructive_warning = c_dest_warning if warn is None else warn
@@ -1320,7 +1321,13 @@ class MyCli:
         expanded = expanded or use_formatter.format_name == "vertical"
         output: itertools.chain[str] = itertools.chain()
 
-        output_kwargs = {"dialect": "unix", "disable_numparse": True, "preserve_whitespace": True, "style": self.output_style}
+        output_kwargs = {
+            "dialect": "unix",
+            "disable_numparse": True,
+            "preserve_whitespace": True,
+            "style": self.output_style,
+            "missing_value": self.null_string,
+        }
 
         if use_formatter.format_name not in sql_format.supported_formats:
             output_kwargs["preprocessors"] = (preprocessors.align_decimals,)

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -46,6 +46,9 @@ beep_after_seconds = 0
 # Recommended: ascii.
 table_format = ascii
 
+# The string used in place of a NULL value.
+null_string = '<null>'
+
 # Redirected otuput format
 # Recommended: csv.
 redirect_format = csv

--- a/test/myclirc
+++ b/test/myclirc
@@ -44,6 +44,9 @@ beep_after_seconds = 0
 # Recommended: ascii
 table_format = ascii
 
+# The string used in place of a NULL value.
+null_string = "<null>"
+
 # Redirected otuput format
 # Recommended: csv.
 redirect_format = csv

--- a/test/test_tabular_output.py
+++ b/test/test_tabular_output.py
@@ -4,6 +4,7 @@
 
 from textwrap import dedent
 
+from cli_helpers.utils import strip_ansi
 from pymysql.constants import FIELD_TYPE
 import pytest
 
@@ -16,6 +17,15 @@ def mycli():
     cli = MyCli()
     cli.connect(None, USER, PASSWORD, HOST, PORT, None, init_command=None)
     return cli
+
+
+def test_null_string_config_override(tmp_path):
+    config_path = tmp_path / "myclirc"
+    config_path.write_text("[main]\nnull_string = 'NULLISH'\n", encoding="utf8")
+    cli = MyCli(myclirc=str(config_path))
+    cli.output_style = None
+    output = list(cli.format_output(None, [(None, 1)], ["value", "number"], False, False))
+    assert any("NULLISH" in strip_ansi(line) for line in output)
 
 
 @dbtest


### PR DESCRIPTION
## Description

https://github.com/dbcli/mycli/issues/1120

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
