### PR TITLE
Let sqlparse accept arbitrarily-large queries

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Bug Fixes
+--------
+* Let `sqlparse` accept arbitrarily-large queries.
+
+
 1.44.0 (2026/01/08)
 ==============
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -70,6 +70,8 @@ try:
 except ImportError:
     from mycli.packages.paramiko_stub import paramiko  # type: ignore[no-redef]
 
+sqlparse.engine.grouping.MAX_GROUPING_DEPTH = None  # type: ignore[assignment]
+sqlparse.engine.grouping.MAX_GROUPING_TOKENS = None  # type: ignore[assignment]
 
 # Query tuples are used for maintaining history
 Query = namedtuple("Query", ["query", "successful", "mutating"])

--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -7,6 +7,9 @@ from sqlparse.sql import Comparison, Identifier, Token, Where
 from mycli.packages.parseutils import extract_tables, find_prev_keyword, last_word
 from mycli.packages.special.main import parse_special_command
 
+sqlparse.engine.grouping.MAX_GROUPING_DEPTH = None  # type: ignore[assignment]
+sqlparse.engine.grouping.MAX_GROUPING_TOKENS = None  # type: ignore[assignment]
+
 _ENUM_VALUE_RE = re.compile(
     r"(?P<lhs>(?:`[^`]+`|[\w$]+)(?:\.(?:`[^`]+`|[\w$]+))?)\s*=\s*$",
     re.IGNORECASE,

--- a/mycli/packages/parseutils.py
+++ b/mycli/packages/parseutils.py
@@ -8,6 +8,9 @@ import sqlparse
 from sqlparse.sql import Function, Identifier, IdentifierList, Token, TokenList
 from sqlparse.tokens import DML, Keyword, Punctuation
 
+sqlparse.engine.grouping.MAX_GROUPING_DEPTH = None  # type: ignore[assignment]
+sqlparse.engine.grouping.MAX_GROUPING_TOKENS = None  # type: ignore[assignment]
+
 cleanup_regex: dict[str, re.Pattern] = {
     # This matches only alphanumerics and underscores.
     "alphanum_underscore": re.compile(r"(\w+)$"),

--- a/mycli/packages/special/delimitercommand.py
+++ b/mycli/packages/special/delimitercommand.py
@@ -5,6 +5,9 @@ from typing import Generator
 
 import sqlparse
 
+sqlparse.engine.grouping.MAX_GROUPING_DEPTH = None  # type: ignore[assignment]
+sqlparse.engine.grouping.MAX_GROUPING_TOKENS = None  # type: ignore[assignment]
+
 
 class DelimiterCommand:
     def __init__(self) -> None:

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -22,6 +22,9 @@ from mycli.packages.special.favoritequeries import FavoriteQueries
 from mycli.packages.special.main import ArgType, special_command
 from mycli.packages.special.utils import handle_cd_command
 
+sqlparse.engine.grouping.MAX_GROUPING_DEPTH = None  # type: ignore[assignment]
+sqlparse.engine.grouping.MAX_GROUPING_TOKENS = None  # type: ignore[assignment]
+
 TIMING_ENABLED = False
 use_expanded_output = False
 force_horizontal_output = False


### PR DESCRIPTION
## Description

The `sqlparse` dependency is blocking large queries as of v0.5.5, but we don't need this DOS defense.

Fixes #1432.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
