### PR TITLE
[chore] Remove SQLResult get_output method and switch to accessing the fields directly

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -820,7 +820,10 @@ class MyCli:
             nonlocal mutating
             result_count = 0
             for result in results:
-                title, cur, headers, status = result.get_output()
+                title = result.title
+                cur = result.results
+                headers = result.headers
+                status = result.status
                 command = result.command
                 logger.debug("title: %r", title)
                 logger.debug("headers: %r", headers)
@@ -837,7 +840,7 @@ class MyCli:
                         except ValueError as e:
                             self.echo(f"Invalid watch sleep time provided ({e}).", err=True, fg="red")
                             sys.exit(1)
-                if is_select(status) and cur and cur.rowcount > threshold:
+                if is_select(status) and isinstance(cur, Cursor) and cur.rowcount > threshold:
                     self.echo(
                         f"The result set has more than {threshold} rows.",
                         fg="red",
@@ -887,7 +890,10 @@ class MyCli:
                 if self.show_warnings and isinstance(cur, Cursor) and cur.warning_count > 0:
                     warnings = sqlexecute.run("SHOW WARNINGS")
                     for warning in warnings:
-                        title, cur, headers, status = warning.get_output()
+                        title = warning.title
+                        cur = warning.results
+                        headers = warning.headers
+                        status = warning.status
                         formatted = self.format_output(
                             title,
                             cur,
@@ -1351,7 +1357,9 @@ class MyCli:
         assert self.sqlexecute is not None
         results = self.sqlexecute.run(query)
         for result in results:
-            title, cur, headers, _status = result.get_output()
+            title = result.title
+            cur = result.results
+            headers = result.headers
             self.main_formatter.query = query
             self.redirect_formatter.query = query
             output = self.format_output(
@@ -1369,7 +1377,9 @@ class MyCli:
             if self.show_warnings and isinstance(cur, Cursor) and cur.warning_count > 0:
                 warnings = self.sqlexecute.run("SHOW WARNINGS")
                 for warning in warnings:
-                    title, cur, headers, _status = warning.get_output()
+                    title = warning.title
+                    cur = warning.results
+                    headers = warning.headers
                     output = self.format_output(
                         title,
                         cur,
@@ -1385,7 +1395,7 @@ class MyCli:
         self,
         title: str | None,
         cur: Cursor | list[tuple] | None,
-        headers: list[str] | None,
+        headers: list[str] | str | None,
         expanded: bool = False,
         is_redirected: bool = False,
         null_string: str | None = None,

--- a/mycli/packages/sqlresult.py
+++ b/mycli/packages/sqlresult.py
@@ -11,9 +11,6 @@ class SQLResult:
     status: str | None = None
     command: dict[str, str | float] | None = None
 
-    def get_output(self):
-        return self.title, self.results, self.headers, self.status
-
     def __iter__(self):
         return self
 

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -491,8 +491,12 @@ class SQLExecute:
         try:
             results = self.run("select connection_id()")
             for result in results:
-                _title, cur, _headers, _status = result.get_output()
-                self.connection_id = cur.fetchone()[0]
+                cur = result.results
+                if isinstance(cur, Cursor):
+                    v = cur.fetchone()
+                    self.connection_id = v[0] if v is not None else -1
+                else:
+                    raise ValueError
         except Exception as e:
             # See #1054
             self.connection_id = -1

--- a/test/utils.py
+++ b/test/utils.py
@@ -51,12 +51,10 @@ def run(executor, sql, rows_as_list=True):
     results = []
 
     for result in executor.run(sql):
-        (
-            title,
-            rows,
-            headers,
-            status,
-        ) = result.get_output()
+        title = result.title
+        rows = result.results
+        headers = result.headers
+        status = result.status
         rows = list(rows) if (rows_as_list and rows) else rows
         results.append({"title": title, "rows": rows, "headers": headers, "status": status})
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Removed the `SQLResult.get_output()` method that was previously used to set title/cursor/headers/status via a tuple, and instead switched to setting those variables using the SQLResult fields directly.


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [X] I've added this contribution to the `changelog.md`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
- [X] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
