### PR TITLE
Allow history file location to be configured

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
 TBD
 ==============
 
+Features
+--------
+* Allow history file location to be configured.
+
 Bug Fixes
 --------
 * Respect `--logfile` when using `--execute` or standard input at the shell CLI.

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -772,7 +772,7 @@ class MyCli:
         if self.smart_completion:
             self.refresh_completions()
 
-        history_file = os.path.expanduser(os.environ.get("MYCLI_HISTFILE", "~/.mycli-history"))
+        history_file = os.path.expanduser(os.environ.get("MYCLI_HISTFILE", self.config.get("history_file", "~/.mycli-history")))
         if dir_path_exists(history_file):
             history = FileHistoryWithTimestamp(history_file)
         else:

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -27,6 +27,9 @@ multi_line = False
 # or "shutdown".
 destructive_warning = True
 
+# interactive query history location.
+history_file = ~/.mycli-history
+
 # log_file location.
 log_file = ~/.mycli.log
 

--- a/test/myclirc
+++ b/test/myclirc
@@ -27,6 +27,9 @@ multi_line = False
 # or "shutdown".
 destructive_warning = True
 
+# interactive query history location.
+history_file = ~/.mycli-history
+
 # log_file location.
 log_file = ~/.mycli.test.log
 


### PR DESCRIPTION
## Description

Allow history file location to be configured in `~/.myclirc`.  Previously it could only be moved with an environment variable.  The environment variable still has precedence.

There are no tests as I couldn't figure out how to test this.

Fixes #1136.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
