### PR TITLE
Graceful failure for `--list-ssh-config`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,9 +5,11 @@ Features
 --------
 * Allow history file location to be configured.
 
+
 Bug Fixes
 --------
 * Respect `--logfile` when using `--execute` or standard input at the shell CLI.
+* Gracefully catch Paramiko parsing errors on `--list-ssh-config`.
 
 
 1.44.2 (2026/01/13)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1644,12 +1644,17 @@ def cli(
         sys.exit(0)
     if list_ssh_config:
         ssh_config = read_ssh_config(ssh_config_path)
-        for host in ssh_config.get_hostnames():
+        try:
+            host_entries = ssh_config.get_hostnames()
+        except KeyError:
+            click.secho('Error reading ssh config', err=True, fg="red")
+            sys.exit(1)
+        for host_entry in host_entries:
             if verbose:
-                host_config = ssh_config.lookup(host)
-                click.secho(f"{host} : {host_config.get('hostname')}")
+                host_config = ssh_config.lookup(host_entry)
+                click.secho(f"{host_entry} : {host_config.get('hostname')}")
             else:
-                click.secho(host)
+                click.secho(host_entry)
         sys.exit(0)
     # Choose which ever one has a valid value.
     database = dbname or database


### PR DESCRIPTION
## Description

If `~/.ssh/config` is nontrivial, Paramiko can easily fail to parse it. Catch the failure and exit informatively rather than with a backtrace.

We should be open to the alternative of removing `--list-ssh-config`, `--ssh-config-path`, and `--ssh-config-host`.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
