### PR TITLE
Downgrade to paramiko 3.5.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ Bug Fixes
 --------
 * Respect `--logfile` when using `--execute` or standard input at the shell CLI.
 * Gracefully catch Paramiko parsing errors on `--list-ssh-config`.
+* Downgrade to Paramiko 3.5.1 to avoid crashing on DSA SSH keys.
 
 
 1.44.2 (2026/01/13)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,10 @@ build-backend = "setuptools.build_meta"
 
 
 [project.optional-dependencies]
-ssh = ["paramiko", "sshtunnel"]
+ssh = [
+    "paramiko~=3.5.1",
+    "sshtunnel",
+]
 llm = [
     "llm>=0.19.0",
     "setuptools",                   # Required by llm commands to install models
@@ -50,7 +53,7 @@ dev = [
     "pytest-cov>=4.1.0",
     "tox>=4.8.0",
     "pdbpp>=0.10.3",
-    "paramiko",
+    "paramiko~=3.5.1",
     "sshtunnel",
     "llm>=0.19.0",
     "setuptools",                   # Required by llm commands to install models


### PR DESCRIPTION
## Description

Paramiko 4.x no longer supports DSA keys, and can cause MyCLI to exit with a cryptic error if the user has a DSA key present:

    module 'paramiko' has no attribute 'DSSKey'

See https://github.com/paramiko/paramiko/issues/2537

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
