### PR TITLE
Stream input from stdin, rather than reading the entire script into memory.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features
 --------
 * Add `--unbuffered` mode which fetches rows as needed, to save memory.
 * Default to standards-compliant `utf8mb4` character set.
+* Stream input from STDIN to consume less memory, adding `--noninteractive` and `--format=` CLI arguments.
 
 
 Bug Fixes


### PR DESCRIPTION
## Description
 * Stream STDIN input, running queries a line at a time.
 * Remove `MemoryError` check, and recommendation for the vendor client.
 * Use CSV/TSV formats with headers for the first line only.
 * Exit with an error code if we are unable to open `/dev/tty`.
 * Add `--noninteractive` flag to suppress the destructive-warning prompt from the CLI.
 * Add `--format=` option to control output formats, leaving the default format as "extra headers pseudo TSV".
 * Commentary on edge cases and followups.

Fixes #1184.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
