### PR TITLE
Let `GRANT ... ON` forms offer schema names as completions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ Bug Fixes
 * Respect `--logfile` when using `--execute` or standard input at the shell CLI.
 * Gracefully catch Paramiko parsing errors on `--list-ssh-config`.
 * Downgrade to Paramiko 3.5.1 to avoid crashing on DSA SSH keys.
+* Offer schema name completions in `GRANT ... ON` forms.
 
 
 1.44.2 (2026/01/13)

--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -338,8 +338,9 @@ def suggest_based_on_last_token(
 
             # The lists of 'aliases' could be empty if we're trying to complete
             # a GRANT query. eg: GRANT SELECT, INSERT ON <tab>
-            # In that case we just suggest all tables.
+            # In that case we just suggest all schemata and all tables.
             if not aliases:
+                suggest.append({"type": "database"})
                 suggest.append({"type": "table", "schema": parent})
             return suggest
 

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -462,6 +462,19 @@ def test_un_escaped_table_names(completer, complete_event):
     )
 
 
+# todo: the fixtures are insufficient; the database name should also appear in the result
+def test_grant_on_suggets_tables_and_schemata(completer, complete_event):
+    text = "GRANT ALL ON "
+    position = len(text)
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == [
+        Completion(text='users', start_position=0),
+        Completion(text='orders', start_position=0),
+        Completion(text='`select`', start_position=0),
+        Completion(text='`réveillé`', start_position=0),
+    ]
+
+
 def dummy_list_path(dir_name):
     dirs = {
         "/": [


### PR DESCRIPTION
## Description

Let `GRANT ... ON` forms offer schema names as completions instead of only table names.

Fixes #578 .

As the commentary notes, the test fixtures are insufficient to test the change, but it can be verified interactively.  See image.

One thing that is confusing in the code is the use of "database" vs "schema".  Here the "type" is "database".

<img width="658" height="160" alt="last image" src="https://github.com/user-attachments/assets/82a1f896-9c4e-4021-b15c-a5ffd5aea9ae" />


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
