### PR TITLE
Fix tests on "GRANTS ... ON" completions

### DIFF
--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -466,6 +466,11 @@ def test_grant_on_suggets_tables_and_schemata(completer, complete_event):
         Completion(text='orders', start_position=0),
         Completion(text='`select`', start_position=0),
         Completion(text='`réveillé`', start_position=0),
+        Completion(text='time_zone', start_position=0),
+        Completion(text='time_zone_leap_second', start_position=0),
+        Completion(text='time_zone_name', start_position=0),
+        Completion(text='time_zone_transition', start_position=0),
+        Completion(text='time_zone_transition_type', start_position=0),
     ]
 
 


### PR DESCRIPTION
## Description

The "GRANTS ... ON" PR probably needed to be rebased before merging to detect this.  The test still doesn't look right however, as the comment suggests.

I'll merge if this passes since CI is broken.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
