### PR TITLE
Fix CamelCase fuzzy completions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+TBD
+==============
+
+Bug Fixes
+--------
+* Fix CamelCase fuzzy matching.
+
+
 1.45.0 (2026/01/20)
 ==============
 

--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -961,7 +961,7 @@ class SQLCompleter(Completer):
             regex = ".{0,3}?".join(map(re.escape, text))
             pat = re.compile(f'({regex})')
             under_words_text = [x for x in text.split('_') if x]
-            case_words_text = re.split(case_change_pat, text)
+            case_words_text = re.split(case_change_pat, last)
 
             for item in collection:
                 r = pat.search(item.lower())
@@ -980,7 +980,7 @@ class SQLCompleter(Completer):
                     completions.append(item)
                     continue
 
-                case_words_item = re.split(case_change_pat, item.lower())
+                case_words_item = re.split(case_change_pat, item)
                 occurrences = 0
                 for elt_word in case_words_text:
                     for elt_item in case_words_item:


### PR DESCRIPTION
## Description
The CamelCase completions were wrongly being derived from lowercased text, so the capitalization boundaries were never found.

<img width="960" height="162" alt="last image" src="https://github.com/user-attachments/assets/86f73bab-adb2-4de6-a2f6-08549487b747" />

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
