### PR TITLE
Put special commands first in the list of completion candidates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Features
 Bug Fixes
 --------
 * Fix CamelCase fuzzy matching.
+* Place special commands first in the list of completion candidates, and remove duplicates.
 
 
 1.45.0 (2026/01/20)

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -61,7 +61,7 @@ def test_empty_string_completion(completer, complete_event):
     text = ""
     position = 0
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
-    assert list(map(Completion, completer.keywords + completer.special_commands)) == result
+    assert list(map(Completion, completer.special_commands + completer.keywords)) == result
 
 
 def test_select_keyword_completion(completer, complete_event):
@@ -471,6 +471,20 @@ def test_grant_on_suggets_tables_and_schemata(completer, complete_event):
         Completion(text='time_zone_name', start_position=0),
         Completion(text='time_zone_transition', start_position=0),
         Completion(text='time_zone_transition_type', start_position=0),
+    ]
+
+
+# todo: this test belongs more logically in test_naive_completion.py, but it didn't work there:
+#       multiple completion candidates were not suggested.
+def test_deleted_keyword_completion(completer, complete_event):
+    text = "exi"
+    position = len("exi")
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == [
+        Completion(text="exit", start_position=-3),
+        Completion(text='exists', start_position=-3),
+        Completion(text='expire', start_position=-3),
+        Completion(text='explain', start_position=-3),
     ]
 
 


### PR DESCRIPTION
## Description

Put special commands first in the list of completion candidates and suppress any duplication between pygments keywords and special commands, preferring special commands over pygments keywords.

Example: whereas "exit" previously appeared twice, once as "EXIT" and once as "exit", it now appears only once, and at the top of the completion candidates.

Followup to #1447.

<img width="464" height="180" alt="last image" src="https://github.com/user-attachments/assets/f62fa2a9-23d4-4398-b878-008a0abc7c01" />

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
