### PR TITLE
Add true fuzzy-match completions with rapidfuzz

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Features
 * Remove suggested quoting on completions for identifiers with uppercase.
 * Allow table names to be completed with leading schema names.
 * Soft deprecate the built-in SSH features.
+* Add true fuzzy-match completions with rapidfuzz.
 
 
 Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pyperclip >= 1.8.1",
     "pycryptodomex",
     "pyfzf >= 0.3.1",
+    "rapidfuzz ~= 3.14.3",
 ]
 
 [build-system]

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -422,6 +422,18 @@ def test_table_names_inter_partial(completer, complete_event):
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
     assert result == [
         Completion(text="time_zone_leap_second", start_position=-9),
+        Completion(text='time_zone_name', start_position=-9),
+        Completion(text='time_zone_transition', start_position=-9),
+        Completion(text='time_zone_transition_type', start_position=-9),
+    ]
+
+
+def test_table_names_fuzzy(completer, complete_event):
+    text = "SELECT * FROM tim_leap"
+    position = len("SELECT * FROM tim_leap")
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == [
+        Completion(text="time_zone_leap_second", start_position=-8),
     ]
 
 


### PR DESCRIPTION
## Description
 * Don't attempt true fuzzy matches until the given text is 4+ characters.
 * Require a rapidfuzz WRatio score of ~80+~ 75+.
 * Limit rapidfuzz candidates to 20 or fewer.
 * Don't report rapidfuzz candidates which are much shorter than the given text.

Example:
<img width="538" height="118" alt="last image" src="https://github.com/user-attachments/assets/2f00d38a-9420-4815-9063-c7f38eb81422" />


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
