### PR TITLE
Remove quoting on uppercase-identifier completions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Features
 * Add `--unbuffered` mode which fetches rows as needed, to save memory.
 * Default to standards-compliant `utf8mb4` character set.
 * Stream input from STDIN to consume less memory, adding `--noninteractive` and `--format=` CLI arguments.
+* Remove suggested quoting on completions for identifiers with uppercase.
 
 
 Bug Fixes

--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -782,7 +782,7 @@ class SQLCompleter(Completer):
         self.reserved_words = set()
         for x in self.keywords:
             self.reserved_words.update(x.split())
-        self.name_pattern = re.compile(r"^[_a-z][_a-z0-9\$]*$")
+        self.name_pattern = re.compile(r"^[_a-zA-Z][_a-zA-Z0-9\$]*$")
 
         self.special_commands: list[str] = []
         self.table_formats = supported_formats

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -433,7 +433,7 @@ def test_auto_escaped_col_names(completer, complete_event):
         Completion(text="*", start_position=0),
         Completion(text="id", start_position=0),
         Completion(text="`insert`", start_position=0),
-        Completion(text="`ABC`", start_position=0),
+        Completion(text="ABC", start_position=0),
     ] + list(map(Completion, completer.functions)) + [Completion(text="select", start_position=0)] + list(
         map(Completion, completer.keywords)
     )
@@ -448,7 +448,7 @@ def test_un_escaped_table_names(completer, complete_event):
             Completion(text="*", start_position=0),
             Completion(text="id", start_position=0),
             Completion(text="`insert`", start_position=0),
-            Completion(text="`ABC`", start_position=0),
+            Completion(text="ABC", start_position=0),
         ]
         + list(map(Completion, completer.functions))
         + [Completion(text="réveillé", start_position=0)]


### PR DESCRIPTION
## Description

Mandatory quoting is retained for identifiers which have any non-alphanumeric characters, but an uppercase character alone does not activate the suggested quoting.

The original logic looks intentional but doesn't seem to be needed.  Maybe this was because the list of keywords was limited, and capitalization was a proxy for keyword?  After #1447, we have a much more complete list of keywords.

Fixes #620.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
