### PR TITLE
Allow table names to be completed with leading schema names

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ Features
 * Default to standards-compliant `utf8mb4` character set.
 * Stream input from STDIN to consume less memory, adding `--noninteractive` and `--format=` CLI arguments.
 * Remove suggested quoting on completions for identifiers with uppercase.
+* Allow table names to be completed with leading schema names.
 
 
 Bug Fixes

--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -301,7 +301,7 @@ def suggest_based_on_last_token(
 
         if not schema:
             # Suggest schemas
-            suggest.insert(0, {"type": "schema"})
+            suggest.append({"type": "database"})
 
         # Only tables can be TRUNCATED, otherwise suggest views
         if token_v != "truncate":

--- a/test/test_completion_engine.py
+++ b/test/test_completion_engine.py
@@ -134,7 +134,11 @@ def test_select_suggests_cols_and_funcs():
 )
 def test_expression_suggests_tables_views_and_schemas(expression):
     suggestions = suggest_type(expression, expression)
-    assert sorted_dicts(suggestions) == sorted_dicts([{"type": "table", "schema": []}, {"type": "view", "schema": []}, {"type": "schema"}])
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "table", "schema": []},
+        {"type": "view", "schema": []},
+        {"type": "database"},
+    ])
 
 
 @pytest.mark.parametrize(
@@ -152,17 +156,25 @@ def test_expression_suggests_tables_views_and_schemas(expression):
 )
 def test_expression_suggests_qualified_tables_views_and_schemas(expression):
     suggestions = suggest_type(expression, expression)
-    assert sorted_dicts(suggestions) == sorted_dicts([{"type": "table", "schema": "sch"}, {"type": "view", "schema": "sch"}])
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "table", "schema": "sch"},
+        {"type": "view", "schema": "sch"},
+    ])
 
 
 def test_truncate_suggests_tables_and_schemas():
     suggestions = suggest_type("TRUNCATE ", "TRUNCATE ")
-    assert sorted_dicts(suggestions) == sorted_dicts([{"type": "table", "schema": []}, {"type": "schema"}])
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "table", "schema": []},
+        {"type": "database"},
+    ])
 
 
 def test_truncate_suggests_qualified_tables():
     suggestions = suggest_type("TRUNCATE sch.", "TRUNCATE sch.")
-    assert sorted_dicts(suggestions) == sorted_dicts([{"type": "table", "schema": "sch"}])
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "table", "schema": "sch"},
+    ])
 
 
 def test_distinct_suggests_cols():
@@ -182,12 +194,20 @@ def test_col_comma_suggests_cols():
 
 def test_table_comma_suggests_tables_and_schemas():
     suggestions = suggest_type("SELECT a, b FROM tbl1, ", "SELECT a, b FROM tbl1, ")
-    assert sorted_dicts(suggestions) == sorted_dicts([{"type": "table", "schema": []}, {"type": "view", "schema": []}, {"type": "schema"}])
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "database"},
+        {"type": "table", "schema": []},
+        {"type": "view", "schema": []},
+    ])
 
 
 def test_into_suggests_tables_and_schemas():
     suggestion = suggest_type("INSERT INTO ", "INSERT INTO ")
-    assert sorted_dicts(suggestion) == sorted_dicts([{"type": "table", "schema": []}, {"type": "view", "schema": []}, {"type": "schema"}])
+    assert sorted_dicts(suggestion) == sorted_dicts([
+        {"type": "database"},
+        {"type": "table", "schema": []},
+        {"type": "view", "schema": []},
+    ])
 
 
 def test_insert_into_lparen_suggests_cols():
@@ -293,7 +313,11 @@ def test_outer_table_reference_in_exists_subquery_suggests_columns():
 )
 def test_sub_select_table_name_completion(expression):
     suggestion = suggest_type(expression, expression)
-    assert sorted_dicts(suggestion) == sorted_dicts([{"type": "table", "schema": []}, {"type": "view", "schema": []}, {"type": "schema"}])
+    assert sorted_dicts(suggestion) == sorted_dicts([
+        {"type": "database"},
+        {"type": "table", "schema": []},
+        {"type": "view", "schema": []},
+    ])
 
 
 def test_sub_select_col_name_completion():
@@ -330,7 +354,11 @@ def test_sub_select_dot_col_name_completion():
 def test_join_suggests_tables_and_schemas(tbl_alias, join_type):
     text = f"SELECT * FROM abc {tbl_alias} {join_type} JOIN "
     suggestion = suggest_type(text, text)
-    assert sorted_dicts(suggestion) == sorted_dicts([{"type": "table", "schema": []}, {"type": "view", "schema": []}, {"type": "schema"}])
+    assert sorted_dicts(suggestion) == sorted_dicts([
+        {"type": "database"},
+        {"type": "table", "schema": []},
+        {"type": "view", "schema": []},
+    ])
 
 
 @pytest.mark.parametrize(
@@ -440,7 +468,11 @@ def test_two_join_alias_dot_suggests_cols1(sql):
 
 def test_2_statements_2nd_current():
     suggestions = suggest_type("select * from a; select * from ", "select * from a; select * from ")
-    assert sorted_dicts(suggestions) == sorted_dicts([{"type": "table", "schema": []}, {"type": "view", "schema": []}, {"type": "schema"}])
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "table", "schema": []},
+        {"type": "view", "schema": []},
+        {"type": "database"},
+    ])
 
     suggestions = suggest_type("select * from a; select  from b", "select * from a; select ")
     assert sorted_dicts(suggestions) == sorted_dicts([
@@ -452,12 +484,20 @@ def test_2_statements_2nd_current():
 
     # Should work even if first statement is invalid
     suggestions = suggest_type("select * from; select * from ", "select * from; select * from ")
-    assert sorted_dicts(suggestions) == sorted_dicts([{"type": "table", "schema": []}, {"type": "view", "schema": []}, {"type": "schema"}])
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "table", "schema": []},
+        {"type": "view", "schema": []},
+        {"type": "database"},
+    ])
 
 
 def test_2_statements_1st_current():
     suggestions = suggest_type("select * from ; select * from b", "select * from ")
-    assert sorted_dicts(suggestions) == sorted_dicts([{"type": "table", "schema": []}, {"type": "view", "schema": []}, {"type": "schema"}])
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "database"},
+        {"type": "table", "schema": []},
+        {"type": "view", "schema": []},
+    ])
 
     suggestions = suggest_type("select  from a; select * from b", "select ")
     assert sorted_dicts(suggestions) == sorted_dicts([
@@ -470,7 +510,11 @@ def test_2_statements_1st_current():
 
 def test_3_statements_2nd_current():
     suggestions = suggest_type("select * from a; select * from ; select * from c", "select * from a; select * from ")
-    assert sorted_dicts(suggestions) == sorted_dicts([{"type": "table", "schema": []}, {"type": "view", "schema": []}, {"type": "schema"}])
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "database"},
+        {"type": "table", "schema": []},
+        {"type": "view", "schema": []},
+    ])
 
     suggestions = suggest_type("select * from a; select  from b; select * from c", "select * from a; select ")
     assert sorted_dicts(suggestions) == sorted_dicts([
@@ -516,7 +560,11 @@ def test_handle_pre_completion_comma_gracefully(text):
 def test_cross_join():
     text = "select * from v1 cross join v2 JOIN v1.id, "
     suggestions = suggest_type(text, text)
-    assert sorted_dicts(suggestions) == sorted_dicts([{"type": "table", "schema": []}, {"type": "view", "schema": []}, {"type": "schema"}])
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {"type": "database"},
+        {"type": "table", "schema": []},
+        {"type": "view", "schema": []},
+    ])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Allow table names to be completed with a leading schema name as in

    schema.table

Note however that the table names can only be successfully completed if they are in the currently-selected schema.  Completing table names in another schema is still a todo.

This is a one-line fix that appears to be due to a confusion between the strings "database" and "schema" in the completion code.

Strictly speaking this fixes #1142, but not #109.

## Checklist

- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
