### PR TITLE
Add `--throttle` option for batch mode pauses

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming (TBD)
 Features
 --------
 * Add a `--checkpoint=` argument to log successful queries in batch mode.
+* Add `--throttle` option for batch mode.
 
 
 Bug Fixes

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from importlib import resources
 import itertools
 from random import choice
-from time import time
+from time import sleep, time
 from urllib.parse import parse_qs, unquote, urlparse
 
 from cli_helpers.tabular_output import TabularOutputFormatter, preprocessors
@@ -1548,6 +1548,7 @@ class MyCli:
 @click.option(
     '--format', 'batch_format', type=click.Choice(['default', 'csv', 'tsv', 'table']), help='Format for batch or --execute output.'
 )
+@click.option('--throttle', type=float, default=0.0, help='Pause in seconds between queries in batch mode.')
 @click.pass_context
 def cli(
     ctx: click.Context,
@@ -1599,6 +1600,7 @@ def cli(
     password_file: str | None,
     noninteractive: bool,
     batch_format: str | None,
+    throttle: float,
 ) -> None:
     """A MySQL terminal client with auto-completion and syntax highlighting.
 
@@ -1931,6 +1933,8 @@ def cli(
                     sys.exit(1)
             try:
                 if warn_confirmed:
+                    if throttle and counter > 1:
+                        sleep(throttle)
                     mycli.run_query(stdin_text, checkpoint=checkpoint, new_line=True)
             except Exception as e:
                 click.secho(str(e), err=True, fg="red")


### PR DESCRIPTION
## Description

The `--throttle` option adds a pause between queries in batch mode, which can be useful for long or intensive scripts.

Technically we pause between each line of input, which is usually equivalent to one query.

~To reduce conflicts, this branch is based off of #1450 , and will need to be rebased once that is merged.  There's no need to review until that is done.~ Rebased.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
