### PR TITLE
Support a `--checkpoint` file for batch input

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 Upcoming (TBD)
 ==============
 
+Features
+--------
+* Add a `--checkpoint=` argument to log successful queries in batch mode.
+
+
 Bug Fixes
 --------
 * Fix timediff output when the result is a negative value (#1113).


### PR DESCRIPTION
## Description

Support a `--checkpoint` file for batch input which saves only successful queries, not results.

The motivation is that a checkpoint file allows an operator to resume an interrupted script.  The `--logfile` option is inconvenient for this since it logs results.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
