### PR TITLE
[fix] Fix timediff output when the result is a negative value (#1113)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Bug Fixes
+--------
+* Fix timediff output when the result is a negative value (#1113).
+
+
 1.46.0 (2026/01/22)
 ==============
 

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -10,7 +10,7 @@ from typing import Any, Generator, Iterable
 import pymysql
 from pymysql.connections import Connection
 from pymysql.constants import FIELD_TYPE
-from pymysql.converters import conversions, convert_date, convert_datetime, convert_timedelta, decoders
+from pymysql.converters import conversions, convert_date, convert_datetime, convert_time, decoders
 from pymysql.cursors import Cursor
 
 from mycli.packages.special import iocommands
@@ -257,7 +257,7 @@ class SQLExecute:
         conv.update({
             FIELD_TYPE.TIMESTAMP: lambda obj: convert_datetime(obj) or obj,
             FIELD_TYPE.DATETIME: lambda obj: convert_datetime(obj) or obj,
-            FIELD_TYPE.TIME: lambda obj: convert_timedelta(obj) or obj,
+            FIELD_TYPE.TIME: lambda obj: convert_time(obj) or obj,
             FIELD_TYPE.DATE: lambda obj: convert_date(obj) or obj,
         })
 

--- a/test/test_sqlexecute.py
+++ b/test/test_sqlexecute.py
@@ -1,5 +1,6 @@
 # type: ignore
 
+from datetime import time
 import os
 
 import pymysql
@@ -23,6 +24,22 @@ def assert_result_equal(result, title=None, rows=None, headers=None, status=None
     else:
         # Do an exact match on the fields.
         assert result == [fields]
+
+
+@dbtest
+def test_timediff_negative_value(executor):
+    sql = "select timediff('2020-11-11 01:01:01', '2020-11-11 01:02:01')"
+    result = run(executor, sql)
+    # negative value comes back as str
+    assert result[0]["rows"][0][0] == "-00:01:00"
+
+
+@dbtest
+def test_timediff_positive_value(executor):
+    sql = "select timediff('2020-11-11 01:02:01', '2020-11-11 01:01:01')"
+    result = run(executor, sql)
+    # positive value comes back as datetime.time
+    assert result[0]["rows"][0][0] == time(0, 1)
 
 
 @dbtest


### PR DESCRIPTION
## Description
* Fixes output from the timediff function when the result is a negative time value.

Before:
```
select timediff('2020-11-11 01:01:01', '2020-11-11 01:02:01');
-1 day, 23:59:00 
```

After
```
select timediff('2020-11-11 01:01:01', '2020-11-11 01:02:01');
-00:01:00
```

Fixes #1113 

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [X] I've added this contribution to the `changelog.md`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
- [X] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
