### PR TITLE
Don't offer completions for numeric text

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Features
 Bug Fixes
 --------
 * Fix timediff output when the result is a negative value (#1113).
+* Don't offer completions for numeric text.
 
 
 1.46.0 (2026/01/22)

--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -961,7 +961,10 @@ class SQLCompleter(Completer):
         # unicode support not possible without adding the regex dependency
         case_change_pat = re.compile("(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
 
-        completions = []
+        completions: list[str] = []
+
+        if re.match(r'^[\d\.]', text):
+            return (Completion(x, -len(text)) for x in completions)
 
         if fuzzy:
             regex = ".{0,3}?".join(map(re.escape, text))

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -500,6 +500,13 @@ def test_deleted_keyword_completion(completer, complete_event):
     ]
 
 
+def test_numbers_no_completion(completer, complete_event):
+    text = "SELECT COUNT(1) FROM time_zone WHERE Time_zone_id = 1"
+    position = len("SELECT COUNT(1) FROM time_zone WHERE Time_zone_id = 1")
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == []  # ie not INT1
+
+
 def dummy_list_path(dir_name):
     dirs = {
         "/": [


### PR DESCRIPTION
## Description

Identifiers which begin with numbers can still be completed by starting the text with a backquote.  That might be a little fragile but works for now. Example:

<img width="1120" height="116" alt="last image" src="https://github.com/user-attachments/assets/eb8899e1-6b2a-40cb-8527-787d13931c69" />

Example of the undesirable old behavior which is fixed in this PR:

<img width="1078" height="106" alt="Screenshot 2026-01-23 at 10 48 53 AM" src="https://github.com/user-attachments/assets/12e7cc04-80d2-4aa1-9c88-2c31bdd6243c" />


## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
