### PR TITLE
Configurable numeric alignment in tabular output

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+TBD
+==============
+
+Features
+--------
+* Right-align numeric columns, and make the behavior configurable.
+
+
 1.47.0 (2026/01/24)
 ==============
 

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -73,6 +73,9 @@ redirect_format = csv
 # empty string, and JSON formats use native nulls.
 null_string = <null>
 
+# How to align numeric data in tabular output: right or left.
+numeric_alignment = right
+
 # A command to run after a successful output redirect, with {} to be replaced
 # with the escaped filename.  Mac example: echo {} | pbcopy.  Escaping is not
 # reliable/safe on Windows.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "sqlparse>=0.3.0,<0.6.0",
     "sqlglot[rs] == 27.*",
     "configobj >= 5.0.5",
-    "cli_helpers[styles] >= 2.7.0",
+    "cli_helpers[styles] >= 2.8.0",
     "pyperclip >= 1.8.1",
     "pycryptodomex",
     "pyfzf >= 0.3.1",

--- a/test/myclirc
+++ b/test/myclirc
@@ -71,6 +71,9 @@ redirect_format = csv
 # empty string, and JSON formats use native nulls.
 null_string = <nope>
 
+# How to align numeric data in tabular output: right or left.
+numeric_alignment = right
+
 # A command to run after a successful output redirect, with {} to be replaced
 # with the escaped filename.  Mac example: echo {} | pbcopy.  Escaping is not
 # reliable/safe on Windows.

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -438,7 +438,7 @@ def test_batch_mode_table(executor):
         +----------+
         | count(*) |
         +----------+
-        | 3        |
+        |        3 |
         +----------+
         +-----+
         | a   |


### PR DESCRIPTION
## Description

After https://github.com/dbcli/cli_helpers/pull/97 we can set the alignment on a per-column basis using the `colalign` parameter.

In this PR we upgrade `cli_helpers` and set `colalign` for columns with a numeric type.  This is more performant than using tabulate's numparse capability, and unlike numparse, works on nullable numeric columns.

The default alignment for numeric columns is changed from left to right, on the basis that this is the default for the vendor client. However, the user is free to change it back in `~/.myclirc` .

Fixes #1102 .

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
