### PR TITLE
Better `keyword_casing=auto` heuristic.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ Features
 * Right-align numeric columns, and make the behavior configurable.
 
 
+Bug Fixes
+--------
+* Better respect case when `keyword_casing` is `auto`.
+
+
 1.47.0 (2026/01/24)
 ==============
 

--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -1027,7 +1027,7 @@ class SQLCompleter(Completer):
                     completions.append(item)
 
         if casing == "auto":
-            casing = "lower" if last and last[-1].islower() else "upper"
+            casing = "lower" if last and (last[0].islower() or last[-1].islower()) else "upper"
 
         def apply_case(kw: str) -> str:
             if casing == "upper":

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -544,3 +544,15 @@ def test_file_name_completion(completer, complete_event, text, expected):
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
     expected = [Completion(txt, pos) for txt, pos in expected]
     assert result == expected
+
+
+def test_auto_case_heuristic(completer, complete_event):
+    text = "select jon_"
+    position = len("select jon_")
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert [x.text for x in result] == [
+        'json_table',
+        'json_value',
+        'join',
+        'json',
+    ]


### PR DESCRIPTION
## Description
Consider both the first and last letter of the user's text when choosing case for completion candidates when keyword_casing=auto.

The issue is that when the last character typed is non-alphabetic such as underscore, then `islower()` is False.  Better to check both the first and last character of the user's text.  If either of them is lowercase then we complete with lowercase.

Fixes #1462 .

<img width="680" height="152" alt="last image" src="https://github.com/user-attachments/assets/a5a352d1-358f-4d41-b16d-c09318d7cece" />


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
