### PR TITLE
Add completion candidates for stored procedures

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ TBD
 Features
 --------
 * Right-align numeric columns, and make the behavior configurable.
+* Add completions for stored procedures.
 
 
 Bug Fixes

--- a/mycli/completion_refresher.py
+++ b/mycli/completion_refresher.py
@@ -155,6 +155,11 @@ def refresh_functions(completer: SQLCompleter, executor: SQLExecute) -> None:
         completer.extend_functions(completer.tidb_functions, builtin=True)
 
 
+@refresher("procedures")
+def refresh_procedures(completer: SQLCompleter, executor: SQLExecute) -> None:
+    completer.extend_procedures(executor.procedures())
+
+
 @refresher("special_commands")
 def refresh_special(completer: SQLCompleter, executor: SQLExecute) -> None:
     completer.extend_special_commands(list(COMMANDS.keys()))

--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -254,6 +254,8 @@ def suggest_based_on_last_token(
 
         # We're probably in a function argument list
         return [{"type": "column", "tables": extract_tables(full_text)}]
+    elif token_v in ("call"):
+        return [{"type": "procedure", "schema": []}]
     elif token_v in ("set", "order by", "distinct"):
         return [{"type": "column", "tables": extract_tables(full_text)}]
     elif token_v == "as":

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -99,6 +99,9 @@ class SQLExecute:
     functions_query = '''SELECT ROUTINE_NAME FROM INFORMATION_SCHEMA.ROUTINES
     WHERE ROUTINE_TYPE="FUNCTION" AND ROUTINE_SCHEMA = "%s"'''
 
+    procedures_query = '''SELECT ROUTINE_NAME FROM INFORMATION_SCHEMA.ROUTINES
+    WHERE ROUTINE_TYPE="PROCEDURE" AND ROUTINE_SCHEMA = "%s"'''
+
     table_columns_query = """select TABLE_NAME, COLUMN_NAME from information_schema.columns
                                     where table_schema = '%s'
                                     order by table_name,ordinal_position"""
@@ -449,6 +452,16 @@ class SQLExecute:
         with self.conn.cursor() as cur:
             _logger.debug("Functions Query. sql: %r", self.functions_query)
             cur.execute(self.functions_query % self.dbname)
+            for row in cur:
+                yield row
+
+    def procedures(self) -> Generator[tuple[str, str], None, None]:
+        """Yields tuples of (procedure_name, )"""
+
+        assert isinstance(self.conn, Connection)
+        with self.conn.cursor() as cur:
+            _logger.debug("Procedures Query. sql: %r", self.procedures_query)
+            cur.execute(self.procedures_query % self.dbname)
             for row in cur:
                 yield row
 

--- a/test/test_completion_refresher.py
+++ b/test/test_completion_refresher.py
@@ -29,6 +29,7 @@ def test_ctor(refresher):
         "enum_values",
         "users",
         "functions",
+        "procedures",
         "special_commands",
         "show_commands",
         "keywords",


### PR DESCRIPTION
## Description

Complete stored procedure names after `CALL`.

Fixes #278.

Example:

<img width="556" height="182" alt="Screenshot 2026-01-24 at 11 18 40 AM" src="https://github.com/user-attachments/assets/8ef85056-790d-4e09-baa0-949be3b5aa69" />

It's not clear to me how to add a test.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
