### PR TITLE
Accept multiple `--execute` options and run each specified query in turn

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+TBD
+==============
+
+Features
+--------
+* Accept multiple `--execute` arguments, running each query in turn.
+
+
 1.47.0 (2026/01/24)
 ==============
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -347,6 +347,21 @@ def test_execute_arg(executor):
 
 
 @dbtest
+def test_multiple_execute_arg(executor):
+    run(executor, "create table test (a text)")
+    run(executor, 'insert into test values("abc")')
+
+    sql_1 = "select * from test;"
+    sql_2 = "select 1234;"
+    runner = CliRunner()
+    result = runner.invoke(cli, args=CLI_ARGS + ["-e", sql_1, "-e", sql_2])
+
+    assert result.exit_code == 0
+    assert "abc" in result.output
+    assert "1234" in result.output
+
+
+@dbtest
 def test_execute_arg_with_checkpoint(executor):
     run(executor, "create table test (a text)")
     run(executor, 'insert into test values("abc")')


### PR DESCRIPTION
## Description

Accept multiple `--execute` options and run each specified query in turn

The current behavior is to accept multiple `--execute` options, but to only execute the last one: a bug.

Since there are multiple values, we can also support `--throttle`, per the discussion in https://github.com/dbcli/mycli/pull/1460.

One inconsistency between STDIN and `--execute` is that `--execute` does not support warning on destructive queries.  This should probably be resolved in the direction of removing the warning from scripts on STDIN.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
