### PR TITLE
Simplify binary value rendering

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ Features
 * Right-align numeric columns, and make the behavior configurable.
 
 
+Bug Fixes
+--------
+* Render binary values more consistently as hex literals.
+
+
 1.47.0 (2026/01/24)
 ==============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "sqlparse>=0.3.0,<0.6.0",
     "sqlglot[rs] == 27.*",
     "configobj >= 5.0.5",
-    "cli_helpers[styles] >= 2.8.0",
+    "cli_helpers[styles] >= 2.8.1",
     "pyperclip >= 1.8.1",
     "pycryptodomex",
     "pyfzf >= 0.3.1",


### PR DESCRIPTION
## Description

Simplify binary value rendering by upgrading `cli_helpers` to v2.8.1.  The previous version of `cli_helpers` attempted to UTF-8 decode binary values, leading to treating some values differently than others.

Fixes #1010.

xref https://github.com/dbcli/cli_helpers/pull/98

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
