### PR TITLE
Offer completions on `CREATE TABLE ... LIKE`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,16 +5,13 @@ Features
 --------
 * Right-align numeric columns, and make the behavior configurable.
 * Add completions for stored procedures.
+* Offer completions on `CREATE TABLE ... LIKE`.
 
 
 Bug Fixes
 --------
 * Better respect case when `keyword_casing` is `auto`.
 * Let favorite queries contain special commands.
-
-
-Bug Fixes
---------
 * Render binary values more consistently as hex literals.
 
 

--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -292,8 +292,12 @@ def suggest_based_on_last_token(
                 {"type": "alias", "aliases": aliases},
                 {"type": "keyword"},
             ]
-    elif (token_v.endswith("join") and isinstance(token, Token) and token.is_keyword) or (
-        token_v in ("copy", "from", "update", "into", "describe", "truncate", "desc", "explain")
+    elif (
+        (token_v.endswith("join") and isinstance(token, Token) and token.is_keyword)
+        or (token_v in ("copy", "from", "update", "into", "describe", "truncate", "desc", "explain"))
+        # todo: the create table regex fails to match on multi-statement queries, which
+        # suggests a bug above in suggest_type()
+        or (token_v == "like" and re.match(r'^\s*create\s+table\s', full_text, re.IGNORECASE))
     ):
         schema = (identifier and identifier.get_parent_name()) or []
 

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -556,3 +556,16 @@ def test_auto_case_heuristic(completer, complete_event):
         'join',
         'json',
     ]
+
+
+def test_create_table_like_completion(completer, complete_event):
+    text = "CREATE TABLE foo LIKE ti"
+    position = len(text)
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert [x.text for x in result] == [
+        'time_zone',
+        'time_zone_name',
+        'time_zone_transition',
+        'time_zone_leap_second',
+        'time_zone_transition_type',
+    ]


### PR DESCRIPTION
## Description

Offer completions on `CREATE TABLE ... LIKE`, completing with a table name.

Fixes #44.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
