### PR TITLE
Better solution for binary value rendering

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1408,7 +1408,11 @@ class MyCli:
             output_kwargs['missing_value'] = null_string
 
         if use_formatter.format_name not in sql_format.supported_formats:
-            output_kwargs["preprocessors"] = (preprocessors.align_decimals,)
+            # will run before preprocessors defined as part of the format in cli_helpers
+            output_kwargs["preprocessors"] = (
+                preprocessors.convert_to_undecoded_string,
+                preprocessors.align_decimals,
+            )
 
         if title:  # Only print the title if it's not None.
             output = itertools.chain(output, [title])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "sqlparse>=0.3.0,<0.6.0",
     "sqlglot[rs] == 27.*",
     "configobj >= 5.0.5",
-    "cli_helpers[styles] >= 2.8.1",
+    "cli_helpers[styles] >= 2.9.0",
     "pyperclip >= 1.8.1",
     "pycryptodomex",
     "pyfzf >= 0.3.1",

--- a/test/test_tabular_output.py
+++ b/test/test_tabular_output.py
@@ -112,3 +112,7 @@ def test_sql_output(mycli):
               ('abc', 1, NULL, 10.0e0, X'aa')
             , ('d', 456, '1', 0.5e0, X'aabb')
             ;""")
+    # Test binary output format is a hex string
+    assert list(mycli.change_table_format("psql")) == [SQLResult(None, None, None, "Changed table format to psql")]
+    output = mycli.format_output(None, FakeCursor(), headers, False, False)
+    assert '0xaabb' in '\n'.join(output)


### PR DESCRIPTION
## Description
After https://github.com/dbcli/cli_helpers/pull/100 we can use the new `convert_to_undecoded_string` preprocessor to guarantee that binary values are rendered as hex literals.

It would be neat if in a future PR we added an option to _never_ render binaries as hex literals (but just emit their contents).

The `align_decimals` preprocessor would seem to have no effect and should be removed in a separate commit.

The bugfix here is covered under the existing changelog entry.

Fixes https://github.com/dbcli/mycli/issues/1010 .

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
