### PR TITLE
Use 0x-style hex literals in SQL output formats

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Features
 * Right-align numeric columns, and make the behavior configurable.
 * Add completions for stored procedures.
 * Offer completions on `CREATE TABLE ... LIKE`.
+* Use 0x-style hex literals for binaries in SQL output formats.
 
 
 Bug Fixes

--- a/mycli/packages/tabular_output/sql_format.py
+++ b/mycli/packages/tabular_output/sql_format.py
@@ -22,7 +22,7 @@ formatter: TabularOutputFormatter
 
 def escape_for_sql_statement(value: Union[bytes, str]) -> str:
     if isinstance(value, bytes):
-        return f"X'{value.hex()}'"
+        return f"0x{value.hex()}"
     else:
         return formatter.mycli.sqlexecute.conn.escape(value)
 

--- a/test/test_tabular_output.py
+++ b/test/test_tabular_output.py
@@ -58,13 +58,13 @@ def test_sql_output(mycli):
               `number` = 1
             , `optional` = NULL
             , `float` = 10.0e0
-            , `binary` = X'aa'
+            , `binary` = 0xaa
             WHERE `letters` = 'abc';
             UPDATE `DUAL` SET
               `number` = 456
             , `optional` = '1'
             , `float` = 0.5e0
-            , `binary` = X'aabb'
+            , `binary` = 0xaabb
             WHERE `letters` = 'd';""")
     # Test sql-update-2 output format
     assert list(mycli.change_table_format("sql-update-2")) == [SQLResult(None, None, None, "Changed table format to sql-update-2")]
@@ -75,12 +75,12 @@ def test_sql_output(mycli):
             UPDATE `DUAL` SET
               `optional` = NULL
             , `float` = 10.0e0
-            , `binary` = X'aa'
+            , `binary` = 0xaa
             WHERE `letters` = 'abc' AND `number` = 1;
             UPDATE `DUAL` SET
               `optional` = '1'
             , `float` = 0.5e0
-            , `binary` = X'aabb'
+            , `binary` = 0xaabb
             WHERE `letters` = 'd' AND `number` = 456;""")
     # Test sql-insert output format (without table name)
     assert list(mycli.change_table_format("sql-insert")) == [SQLResult(None, None, None, "Changed table format to sql-insert")]
@@ -89,8 +89,8 @@ def test_sql_output(mycli):
     output = mycli.format_output(None, FakeCursor(), headers, False, False)
     assert "\n".join(output) == dedent("""\
             INSERT INTO `DUAL` (`letters`, `number`, `optional`, `float`, `binary`) VALUES
-              ('abc', 1, NULL, 10.0e0, X'aa')
-            , ('d', 456, '1', 0.5e0, X'aabb')
+              ('abc', 1, NULL, 10.0e0, 0xaa)
+            , ('d', 456, '1', 0.5e0, 0xaabb)
             ;""")
     # Test sql-insert output format (with table name)
     assert list(mycli.change_table_format("sql-insert")) == [SQLResult(None, None, None, "Changed table format to sql-insert")]
@@ -99,8 +99,8 @@ def test_sql_output(mycli):
     output = mycli.format_output(None, FakeCursor(), headers, False, False)
     assert "\n".join(output) == dedent("""\
             INSERT INTO table (`letters`, `number`, `optional`, `float`, `binary`) VALUES
-              ('abc', 1, NULL, 10.0e0, X'aa')
-            , ('d', 456, '1', 0.5e0, X'aabb')
+              ('abc', 1, NULL, 10.0e0, 0xaa)
+            , ('d', 456, '1', 0.5e0, 0xaabb)
             ;""")
     # Test sql-insert output format (with database + table name)
     assert list(mycli.change_table_format("sql-insert")) == [SQLResult(None, None, None, "Changed table format to sql-insert")]
@@ -109,6 +109,6 @@ def test_sql_output(mycli):
     output = mycli.format_output(None, FakeCursor(), headers, False, False)
     assert "\n".join(output) == dedent("""\
             INSERT INTO database.table (`letters`, `number`, `optional`, `float`, `binary`) VALUES
-              ('abc', 1, NULL, 10.0e0, X'aa')
-            , ('d', 456, '1', 0.5e0, X'aabb')
+              ('abc', 1, NULL, 10.0e0, 0xaa)
+            , ('d', 456, '1', 0.5e0, 0xaabb)
             ;""")


### PR DESCRIPTION
## Description

Use 0x-style hex literals for binary values in SQL output formats, for consistency with tabular output formats.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
