### PR TITLE
Refactor completions for special commands

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ Features
 * "Eager" completions for the `source` command, limited to `*.sql` files.
 
 
+Bug Fixes
+--------
+* Refactor completions for special commands, with minor casing fixes.
+
+
 Internal
 --------
 * Remove `align_decimals` preprocessor, which had no effect.

--- a/test/test_completion_engine.py
+++ b/test/test_completion_engine.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from mycli.packages import special
 from mycli.packages.completion_engine import suggest_type
 
 
@@ -538,6 +539,13 @@ def test_specials_included_for_initial_completion(initial_text):
     assert sorted_dicts(suggestions) == sorted_dicts([{"type": "keyword"}, {"type": "special"}])
 
 
+@pytest.mark.parametrize('initial_text', ['REDIRECT'])
+def test_specials_included_with_caps(initial_text):
+    suggestions = suggest_type(initial_text, initial_text)
+
+    assert sorted_dicts(suggestions) == sorted_dicts([{'type': 'keyword'}, {'type': 'special'}])
+
+
 def test_specials_not_included_after_initial_token():
     suggestions = suggest_type("create table foo (dt d", "create table foo (dt d")
 
@@ -593,6 +601,8 @@ def test_after_as(expression):
     ],
 )
 def test_source_is_file(expression):
+    # "source" has to be registered by hand because that usually happens inside MyCLI in mycli/main.py
+    special.register_special_command(..., 'source', '\\. filename', 'Execute commands from file.', aliases=['\\.'])
     suggestions = suggest_type(expression, expression)
     assert suggestions == [{"type": "file_name"}]
 


### PR DESCRIPTION
## Description
 * read `SPECIAL_COMMANDS` from `special.main` instead of hardcoding, moving the hardcoding needed for tests to the test suite
 * move `use`/`connect` to `suggest_special()` alongside their backslash aliases
 * move `tableformat` to `suggest_special()` alongside its backslash alias,
 * move `redirectformat` to `suggest_special()` alongside its backslash alias
 * complete `source` even if the keyword is uppercase
 * commentary

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
