### PR TITLE
"Eager" completions for the `source` command, limiting to `*.sql` files

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 TBD
 ==============
 
+Features
+--------
+* "Eager" completions for the `source` command, limited to `*.sql` files.
+
+
 Internal
 --------
 * Remove `align_decimals` preprocessor, which had no effect.

--- a/mycli/packages/filepaths.py
+++ b/mycli/packages/filepaths.py
@@ -19,7 +19,11 @@ def list_path(root_dir: str) -> list[str]:
     res = []
     if os.path.isdir(root_dir):
         for name in os.listdir(root_dir):
-            res.append(name)
+            if os.path.isdir(name):
+                res.append(f'{name}/')
+            # if .sql is too restrictive it can be made configurable with some effort
+            elif name.lower().endswith('.sql'):
+                res.append(name)
     return res
 
 
@@ -69,7 +73,16 @@ def suggest_path(root_dir: str) -> list[str]:
 
     """
     if not root_dir:
-        return [os.path.abspath(os.sep), "~", os.curdir, os.pardir]
+        return [
+            os.path.abspath(os.sep),
+            "~",
+            os.curdir,
+            os.pardir,
+            *list_path(os.curdir),
+        ]
+
+    if root_dir[0] not in ('/', '~') and root_dir[0:1] != './':
+        return list_path(os.curdir)
 
     if "~" in root_dir:
         root_dir = os.path.expanduser(root_dir)

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -1,5 +1,6 @@
 # type: ignore
 
+import os.path
 from unittest.mock import patch
 
 from prompt_toolkit.completion import Completion
@@ -589,3 +590,26 @@ def test_create_table_like_completion(completer, complete_event):
         'time_zone_leap_second',
         'time_zone_transition_type',
     ]
+
+
+def test_source_eager_completion(completer, complete_event):
+    text = "source sc"
+    position = len(text)
+    script_filename = 'script_for_test_suite.sql'
+    f = open(script_filename, 'w')
+    f.close()
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    success = True
+    error = 'unknown'
+    try:
+        assert [x.text for x in result] == [
+            'screenshots/',
+            script_filename,
+        ]
+    except AssertionError as e:
+        success = False
+        error = e
+    if os.path.exists(script_filename):
+        os.remove(script_filename)
+    if not success:
+        raise AssertionError(error)


### PR DESCRIPTION
## Description
 * Complete immediately on files in the current directory, even if the text to complete does not start with `.`.
 * This resolves a minor bug in which files in the cwd beginning with `.` were offered as suggestions before the user had typed `./`.
 * Complete only files that end in `.sql` (and directories).
 * Append `/` to suggested directory names.
 * Otherwise continue to complete on paths beginning with `./`, `~`, and `/` in the same way, and continue to offer the punctuation suggestions.

If the restriction to completion on files that end in `.sql` is too restrictive, we could make it configurable, as noted in a comment.

The user can still source a file that does not end in `.sql`.  It just won't be offered as a completion.

Example (first do `touch script.sql`):

<img width="552" height="154" alt="last image" src="https://github.com/user-attachments/assets/d1a91d0e-90af-4edc-8ba5-22c7c7634ebf" />

Old (shows history suggestion, but not popup completions):

<img width="474" height="130" alt="Screenshot 2026-01-27 at 5 38 07 AM" src="https://github.com/user-attachments/assets/ebc23105-2fa1-4d0a-9213-568e91b45052" />



## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
