### PR TITLE
Remove unused preprocessor for tabular output

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+TBD
+==============
+
+Internal
+--------
+* Remove `align_decimals` preprocessor, which had no effect.
+
+
 1.48.0 (2026/01/27)
 ==============
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1409,10 +1409,7 @@ class MyCli:
 
         if use_formatter.format_name not in sql_format.supported_formats:
             # will run before preprocessors defined as part of the format in cli_helpers
-            output_kwargs["preprocessors"] = (
-                preprocessors.convert_to_undecoded_string,
-                preprocessors.align_decimals,
-            )
+            output_kwargs["preprocessors"] = (preprocessors.convert_to_undecoded_string,)
 
         if title:  # Only print the title if it's not None.
             output = itertools.chain(output, [title])


### PR DESCRIPTION
## Description
This `align_decimals` preprocessor seems to have no effect, and if it did, we wouldn't want that effect.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
