### PR TITLE
Better sorting for filename completions in `source`

### DIFF
--- a/mycli/packages/filepaths.py
+++ b/mycli/packages/filepaths.py
@@ -16,15 +16,19 @@ def list_path(root_dir: str) -> list[str]:
     :return: list
 
     """
-    res = []
-    if os.path.isdir(root_dir):
-        for name in os.listdir(root_dir):
-            if os.path.isdir(name):
-                res.append(f'{name}/')
-            # if .sql is too restrictive it can be made configurable with some effort
-            elif name.lower().endswith('.sql'):
-                res.append(name)
-    return res
+    files = []
+    dirs = []
+    if not os.path.isdir(root_dir):
+        return []
+    for name in sorted(os.listdir(root_dir)):
+        if name.startswith('.'):
+            continue
+        elif os.path.isdir(name):
+            dirs.append(f'{name}/')
+        # if .sql is too restrictive it can be made configurable with some effort
+        elif name.lower().endswith('.sql'):
+            files.append(name)
+    return files + dirs
 
 
 def complete_path(curr_dir: str, last_dir: str) -> str:

--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -1200,7 +1200,7 @@ class SQLCompleter(Completer):
         """
         base_path, last_path, position = parse_path(word)
         paths = suggest_path(word)
-        for name in sorted(paths):
+        for name in paths:
             suggestion = complete_path(name, last_path)
             if suggestion:
                 yield Completion(suggestion, position)

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -603,8 +603,8 @@ def test_source_eager_completion(completer, complete_event):
     error = 'unknown'
     try:
         assert [x.text for x in result] == [
-            'screenshots/',
             script_filename,
+            'screenshots/',
         ]
     except AssertionError as e:
         success = False


### PR DESCRIPTION
## Description
 * Filenames first, except for the special directory candidates which have always been given: `.`, `..`, `/`, `~`.
 * Don't suggest dotfiles.

xref #1488.

Listing the special directory prompts first when there is no content is highly debatable!  I left them there on the theory that those have always been first, and change should be gradual.  That reasoning could be wrong here:

<img width="602" height="332" alt="Screenshot 2026-01-28 at 6 19 10 AM" src="https://github.com/user-attachments/assets/66dfe3c2-1ae9-46b1-8581-e71d8f559c1e" />

Once some letters have been typed that issue is no longer relevant:

<img width="550" height="170" alt="last image" src="https://github.com/user-attachments/assets/8e7905d1-1ef6-461b-ac5e-b91870895ebf" />

We can count this under the existing Feature entry in the changelog for #1488.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
