### PR TITLE
Deprecate reading configuration from my.cnf files

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+TBD
+==============
+
+Features
+--------
+* Deprecate reading configuration values from `my.cnf` files.
+
+
 1.49.0 (2026/02/02)
 ==============
 

--- a/mycli/config.py
+++ b/mycli/config.py
@@ -78,10 +78,18 @@ def get_included_configs(config_file: str | IO[str]) -> list[str | IO[str]]:
     return included_configs
 
 
-def read_config_files(files: list[str | IO[str]], list_values: bool = True) -> ConfigObj:
+def read_config_files(
+    files: list[str | IO[str]],
+    list_values: bool = True,
+    ignore_package_defaults: bool = False,
+) -> ConfigObj:
     """Read and merge a list of config files."""
 
-    config = create_default_config(list_values=list_values)
+    if ignore_package_defaults:
+        config = ConfigObj()
+    else:
+        config = create_default_config(list_values=list_values)
+
     _files = copy(files)
     while _files:
         _file = _files.pop(0)

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -134,8 +134,8 @@ enable_pager = True
 # Choose a specific pager
 pager = 'less'
 
-# character set for connections without --charset being set at the CLI
-default_character_set = utf8mb4
+# whether to show verbose warnings about the transition away from reading my.cnf
+my_cnf_transition_done = False
 
 # Whether to store and retrieve passwords from the system keyring.
 # See the documentation for https://pypi.org/project/keyring/ for your OS.
@@ -143,6 +143,33 @@ default_character_set = utf8mb4
 # This can be overridden with --use-keyring= at the CLI.
 # A password can be reset with --use-keyring=reset at the CLI.
 use_keyring = False
+
+[connection]
+
+# character set for connections without --charset being set
+default_character_set = utf8mb4
+
+# whether to enable LOAD DATA LOCAL INFILE for connections without --local-infile being set
+default_local_infile = False
+
+# SSL CA file for connections without --ssl-ca being set
+default_ssl_ca =
+
+# SSL CA directory for connections without --ssl-capath being set
+default_ssl_capath =
+
+# SSL X509 cert path for connections without --ssl-cert being set
+default_ssl_cert =
+
+# SSL X509 key for connections without --ssl-key being set
+default_ssl_key =
+
+# SSL cipher to use for connections without --ssl-cipher being set
+default_ssl_cipher =
+
+# whether to verify server's "Common Name" in its cert, for connections without
+# --ssl-verify-server-cert being set
+default_ssl_verify_server_cert = False
 
 [keys]
 # possible values: auto, fzf, reverse_isearch

--- a/test/myclirc
+++ b/test/myclirc
@@ -132,8 +132,8 @@ enable_pager = True
 # Choose a specific pager
 pager = less
 
-# character set for connections without --charset being set at the CLI
-default_character_set = utf8mb4
+# whether to show verbose warnings about the transition away from reading my.cnf
+my_cnf_transition_done = False
 
 # Whether to store and retrieve passwords from the system keyring.
 # See the documentation for https://pypi.org/project/keyring/ for your OS.
@@ -141,6 +141,33 @@ default_character_set = utf8mb4
 # This can be overridden with --use-keyring= at the CLI.
 # A password can be reset with --use-keyring=reset at the CLI.
 use_keyring = False
+
+[connection]
+
+# character set for connections without --charset being set
+default_character_set = utf8mb4
+
+# whether to enable LOAD DATA LOCAL INFILE for connections without --local-infile being set
+default_local_infile = False
+
+# SSL CA file for connections without --ssl-ca being set
+default_ssl_ca =
+
+# SSL CA directory for connections without --ssl-capath being set
+default_ssl_capath =
+
+# SSL X509 cert path for connections without --ssl-cert being set
+default_ssl_cert =
+
+# SSL X509 key for connections without --ssl-key being set
+default_ssl_key =
+
+# SSL cipher to use for connections without --ssl-cipher being set
+default_ssl_cipher =
+
+# whether to verify server's "Common Name" in its cert, for connections without
+# --ssl-verify-server-cert being set
+default_ssl_verify_server_cert = False
 
 [keys]
 # possible values: auto, fzf, reverse_isearch

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -668,6 +668,7 @@ def test_dsn(monkeypatch):
             self.main_formatter = Formatter()
             self.redirect_formatter = Formatter()
             self.ssl_mode = "auto"
+            self.my_cnf = {"client": {}, "mysqld": {}}
 
         def connect(self, **args):
             MockMyCli.connect_args = args
@@ -842,6 +843,7 @@ def test_ssh_config(monkeypatch):
             self.main_formatter = Formatter()
             self.redirect_formatter = Formatter()
             self.ssl_mode = "auto"
+            self.my_cnf = {"client": {}, "mysqld": {}}
 
         def connect(self, **args):
             MockMyCli.connect_args = args


### PR DESCRIPTION
## Description

 * Create corresponding `~/.myclirc` configuration options for every option which is currently exclusive to my.cnf, using a new `[connection]` section, and prepending every option with `default_`.
 * Move `default_character_set` to the new `[connection]` setting for consistency, but continue to silently read it if present in the `[main]` section.  `default_character_set` also does not activate any warnings, since it already existed.
 * Create a new config property which does not default to the packaged myclirc.
 * Emit a verbose warning if the user has any _controlling_ configuration option in a my.cnf file.
 * Let corresponding CLI arguments always take precedence over configuration.
 * To simplify logic, always create a `[connection]` section in the internal data structure representing `~/.myclirc`, and likewise for [client] and [mysqld] in the my.cnf data structure.
 * Finesse some empty controlling configuration: _eg_ an empty setting for `default_character_set` should default to `utf8mb4`.
 * For consistency, also handle `default_ssl_ca_path` in the `[connection]` section, though it has no my.cnf equivalent.
 * Add a configuration option `my_cnf_transition_done` to allow the user to just ignore all of this.

The very verbose warnings contain instructions on how to create controlling `~/.myclirc` configuration options, the presence of which will suppress the warnings.

It is important to note that the warnings only affect users with files at `/etc/my.cnf`, `/etc/mysql/my.cnf`,  `/usr/local/etc/my.cnf`, or `~/.my.cnf`, with certain options explicitly set, such as `ssl-ca` in the `[client]` section.  If the user does not have a my.cnf file, no warnings will be emitted.

Note also that since the default myclirc content has been updated to contain controlling configuration options, the warnings will never be emitted for fresh installs, only upgrades (which do not overwrite `~/.myclirc`).

~We should consider a CLI option or configuration setting to unconditionally suppress all such warnings, but the downside of that is continuing to accept the CLI option for compatibility after the deprecation cycle is over.  A configuration option could be ignored.~ EDIT: added a configuration option `my_cnf_transition_done`.

Addresses #1490 , which is referenced in the warning message, and should be kept open during the deprecation cycle.

I'm not sure how to write a test for the warning.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
