### PR TITLE
Place `--password-file` higher in precedence rules

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Features
 Bug Fixes
 --------
 * Refactor completions for special commands, with minor casing fixes.
+* Raise `--password-file` higher in the precedence of password specification.
 
 
 Internal


### PR DESCRIPTION
## Description
As an alternative to `--password`, this should have roughly the same precedence as `--password`.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
