### PR TITLE
Fix TLS deprecation warning in test suite

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ Bug Fixes
 Internal
 --------
 * Remove `align_decimals` preprocessor, which had no effect.
+* Fix TLS deprecation warning in test suite.
 
 
 1.48.0 (2026/01/27)

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -542,8 +542,7 @@ class SQLExecute:
         if "cipher" in sslp:
             ctx.set_ciphers(sslp["cipher"])
 
-        # raise this default to v1.1 or v1.2?
-        ctx.minimum_version = ssl.TLSVersion.TLSv1
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_2
 
         if "tls_version" in sslp:
             tls_version = sslp["tls_version"]


### PR DESCRIPTION
## Description
The warning was:

    DeprecationWarning: ssl.TLSVersion.TLSv1 is deprecated

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
