### PR TITLE
Store/retrieve passwords with the system keyring

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Features
 * "Eager" completions for the `source` command, limited to `*.sql` files.
 * Suggest column names from all tables in the current database after SELECT (#212)
 * Put fuzzy completions more often to the bottom of the suggestion list.
+* Store and retrieve passwords using the system keyring.
 
 
 Bug Fixes

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -137,6 +137,13 @@ pager = 'less'
 # character set for connections without --charset being set at the CLI
 default_character_set = utf8mb4
 
+# Whether to store and retrieve passwords from the system keyring.
+# See the documentation for https://pypi.org/project/keyring/ for your OS.
+# Note that the hostname is considered to be different if short or qualified.
+# This can be overridden with --use-keyring= at the CLI.
+# A password can be reset with --use-keyring=reset at the CLI.
+use_keyring = False
+
 [keys]
 # possible values: auto, fzf, reverse_isearch
 control_r = auto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "pycryptodomex",
     "pyfzf >= 0.3.1",
     "rapidfuzz ~= 3.14.3",
+    "keyring ~= 25.7.0",
 ]
 
 [build-system]

--- a/test/myclirc
+++ b/test/myclirc
@@ -135,6 +135,13 @@ pager = less
 # character set for connections without --charset being set at the CLI
 default_character_set = utf8mb4
 
+# Whether to store and retrieve passwords from the system keyring.
+# See the documentation for https://pypi.org/project/keyring/ for your OS.
+# Note that the hostname is considered to be different if short or qualified.
+# This can be overridden with --use-keyring= at the CLI.
+# A password can be reset with --use-keyring=reset at the CLI.
+use_keyring = False
+
 [keys]
 # possible values: auto, fzf, reverse_isearch
 control_r = auto

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -656,7 +656,10 @@ def test_dsn(monkeypatch):
             pass
 
     class MockMyCli:
-        config = {"alias_dsn": {}}
+        config = {
+            "main": {},
+            "alias_dsn": {},
+        }
 
         def __init__(self, **args):
             self.logger = Logger()
@@ -718,7 +721,10 @@ def test_dsn(monkeypatch):
         and MockMyCli.connect_args["database"] == "arg_database"
     )
 
-    MockMyCli.config = {"alias_dsn": {"test": "mysql://alias_dsn_user:alias_dsn_passwd@alias_dsn_host:4/alias_dsn_database"}}
+    MockMyCli.config = {
+        "main": {},
+        "alias_dsn": {"test": "mysql://alias_dsn_user:alias_dsn_passwd@alias_dsn_host:4/alias_dsn_database"},
+    }
     MockMyCli.connect_args = None
 
     # When a user uses a DSN from the configuration file (alias_dsn),
@@ -733,7 +739,10 @@ def test_dsn(monkeypatch):
         and MockMyCli.connect_args["database"] == "alias_dsn_database"
     )
 
-    MockMyCli.config = {"alias_dsn": {"test": "mysql://alias_dsn_user:alias_dsn_passwd@alias_dsn_host:4/alias_dsn_database"}}
+    MockMyCli.config = {
+        "main": {},
+        "alias_dsn": {"test": "mysql://alias_dsn_user:alias_dsn_passwd@alias_dsn_host:4/alias_dsn_database"},
+    }
     MockMyCli.connect_args = None
 
     # When a user uses a DSN from the configuration file (alias_dsn)
@@ -821,7 +830,10 @@ def test_ssh_config(monkeypatch):
             pass
 
     class MockMyCli:
-        config = {"alias_dsn": {}}
+        config = {
+            "main": {},
+            "alias_dsn": {},
+        }
 
         def __init__(self, **args):
             self.logger = Logger()


### PR DESCRIPTION
## Description
 * Off by default.
 * Can be enabled by setting `use_keyring = True` in `~/.myclirc`.
 * Can be enabled on a per-connection basis with `--use-keyring=true` at invocation time.
 * Note that the hostname is considered to be different if short or qualified.
 * A password can be reset with `--use-keyring=reset` at invocation time, or (not documented) using the `keyring` CLI tool.

Fixes #1496.

This was super easy to implement!  But realistic tests look quite difficult.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
