### PR TITLE
Refactor completion candidate sorting

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features
 --------
 * "Eager" completions for the `source` command, limited to `*.sql` files.
 * Suggest column names from all tables in the current database after SELECT (#212)
+* Put fuzzy completions more often to the bottom of the suggestion list.
 
 
 Bug Fixes


### PR DESCRIPTION
## Description

Instead of going only in the order of `for suggestion in suggestions:`, retain the implied rank of the order of suggestion types, and the fuzziness of the match from `find_matches()`, and sort by all of fuzziness, rank, and leading match.

Primarily this allows the fuzzy matches to always be demoted to the bottom of the list of candidates.

The sort-key algorithm takes into account fuzziness, suggestion-rank, and leading-match, but how exactly depends on whether the completion string is empty, or the completion string is a leading match.

To implement this, sorting must be moved out of `find_matches()`.

A special case `rigid_sort` is provided so that directories continue to be forced to last in filename sorts.  This could be improved in the future.

The motivation is to make #1497  more able to combine column names and keywords.

~The tests are pretty broken in this draft, part of which is expected.~ fixed.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
