### PR TITLE
[fix] Show user in password prompt

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ Bug Fixes
 --------
 * Refactor completions for special commands, with minor casing fixes.
 * Raise `--password-file` higher in the precedence of password specification.
+* Fix regression: show username in password prompt.
 
 
 Internal

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -539,8 +539,8 @@ class MyCli:
         # 5. cnf (.my.cnf / etc)
 
         # if no password was found from all of the above sources, ask for a password
-        if passwd is None:
-            passwd = click.prompt("Enter password", hide_input=True, show_default=False, default='', type=str, err=True)
+        if passwd is None or passwd == "MYCLI_ASK_PASSWORD":
+            passwd = click.prompt(f"Enter password for {user}", hide_input=True, show_default=False, default='', type=str, err=True)
 
         # Connect to the database.
         def _connect() -> None:
@@ -1621,13 +1621,9 @@ def cli(
             click.secho(f"Error reading password file '{password_file}': {str(e)}", err=True, fg="red")
             sys.exit(1)
 
-    # if user passes the --p* flag, ask for the password right away
-    # to reduce lag as much as possible
-    if password == "MYCLI_ASK_PASSWORD":
-        password = click.prompt("Enter password", hide_input=True, show_default=False, default='', type=str, err=True)
     # if the password value looks like a DSN, treat it as such and
     # prompt for password
-    elif database is None and password is not None and "://" in password:
+    if database is None and password is not None and "://" in password:
         # check if the scheme is valid. We do not actually have any logic for these, but
         # it will most usefully catch the case where we erroneously catch someone's
         # password, and give them an easy error message to follow / report
@@ -1636,11 +1632,12 @@ def cli(
             click.secho(f"Error: Unknown connection scheme provided for DSN URI ({scheme}://)", err=True, fg="red")
             sys.exit(1)
         database = password
-        password = click.prompt("Enter password", hide_input=True, show_default=False, default='', type=str, err=True)
+        password = "MYCLI_ASK_PASSWORD"
 
-    # if the passwd is not specified try to set it using the password_file option
+    # if the password is not specified try to set it using the password_file option
     if password is None and password_file:
-        if password_from_file := get_password_from_file(password_file):
+        password_from_file = get_password_from_file(password_file)
+        if password_from_file is not None:
             password = password_from_file
 
     # getting the envvar ourselves because the envvar from a click

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -11,7 +11,8 @@ import click
 from click.testing import CliRunner
 from pymysql.err import OperationalError
 
-from mycli.main import MyCli, cli, is_valid_connection_scheme, thanks_picker
+from mycli.main import MyCli, cli, thanks_picker
+from mycli.packages.parseutils import is_valid_connection_scheme
 import mycli.packages.special
 from mycli.packages.special.main import COMMANDS as SPECIAL_COMMANDS
 from mycli.sqlexecute import ServerInfo, SQLExecute


### PR DESCRIPTION
## Description
Re-add the user to the password prompt. Was previously removed due to the way the new password prompting worked, and lack of user info early on in the application runtime.

This delays the user requested password prompt `(--password/-p)` until after the my.cnf related config is loaded. This technically delays password prompt time, however almost the entirety of the delay is from startup, so in reality the difference is moot currently.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [X] I've added this contribution to the `changelog.md`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
- [X] I ran `uv run ruff check && uv run ruff format && uv run mypy --install-types .` to lint and format the code.
