### PR TITLE
Offer `SELECT *` completion if no tables in database

### DIFF
--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -1259,7 +1259,7 @@ class SQLCompleter(Completer):
         if len(scoped_tbls) == 0 and self.dbname:
             for table in meta["tables"][self.dbname]:
                 columns.extend(meta["tables"][self.dbname][table])
-            return columns
+            return columns or ['*']
 
         # query includes tables, so use those to populate columns
         for tbl in scoped_tbls:


### PR DESCRIPTION
## Description
For a naked `SELECT`, on the edge case that there are no tables in the current database, still offer `*` as a column name.

This can go under the existing Feature changelog item for naked `SELECT`.

Later we can offer database names as well!

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
