### PR TITLE
Link to `--ssl`/`--no-ssl` deprecation issue in warning

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ Features
 * Deprecate reading configuration values from `my.cnf` files.
 
 
+Bug Fixes
+--------
+* Link to `--ssl`/`--no-ssl` GitHub issue in deprecation warning.
+
+
 1.49.0 (2026/02/02)
 ==============
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1761,7 +1761,8 @@ def cli(
     if ssl_enable is not None:
         click.secho(
             "Warning: The --ssl/--no-ssl CLI options are deprecated and will be removed in a future release. "
-            "Please use the ssl_mode config or --ssl-mode CLI options instead.",
+            "Please use the ssl_mode config or --ssl-mode CLI options instead. "
+            "See issue https://github.com/dbcli/mycli/issues/1507",
             err=True,
             fg="yellow",
         )


### PR DESCRIPTION
## Description
Link to `--ssl`/`--no-ssl` deprecation issue in warning, for completeness.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
