### PR TITLE
Don't emit keyring-saved message unless needed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Features
 Bug Fixes
 --------
 * Link to `--ssl`/`--no-ssl` GitHub issue in deprecation warning.
+* Don't emit keyring-updated message unless needed.
 
 
 1.49.0 (2026/02/02)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -614,10 +614,12 @@ class MyCli:
 
         if reset_keyring or (use_keyring and not keychain_retrieved):
             try:
-                keyring.set_password(keychain_domain, keychain_user, passwd)
-                click.secho('Password saved to the system keychain', err=True)
+                saved_pw = keyring.get_password(keychain_domain, keychain_user)
+                if passwd != saved_pw or reset_keyring:
+                    keyring.set_password(keychain_domain, keychain_user, passwd)
+                    click.secho('Password saved to the system keyring', err=True)
             except Exception as e:
-                click.secho(f'Password not saved to the system keychain: {e}', err=True, fg='red')
+                click.secho(f'Password not saved to the system keyring: {e}', err=True, fg='red')
 
         # Connect to the database.
         def _connect() -> None:


### PR DESCRIPTION
## Description
Don't emit keyring-saved message unless needed

Incidentally update message wordings to match CLI option: "keyring" rather than "keychain".

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
