### PR TITLE
Add `binary_display` configuration option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features
 --------
 * Deprecate reading configuration values from `my.cnf` files.
 * Add `--checkup` mode to show unconfigured new features.
+* Add `binary_display` configuration option.
 
 
 Bug Fixes

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -168,6 +168,7 @@ class MyCli:
         self.post_redirect_command = c['main'].get('post_redirect_command')
         self.null_string = c['main'].get('null_string')
         self.numeric_alignment = c['main'].get('numeric_alignment', 'right')
+        self.binary_display = c['main'].get('binary_display')
 
         # set ssl_mode if a valid option is provided in a config file, otherwise None
         ssl_mode = c["main"].get("ssl_mode", None)
@@ -888,6 +889,7 @@ class MyCli:
                     special.is_redirected(),
                     self.null_string,
                     self.numeric_alignment,
+                    self.binary_display,
                     max_width,
                 )
 
@@ -926,6 +928,7 @@ class MyCli:
                             special.is_redirected(),
                             self.null_string,
                             self.numeric_alignment,
+                            self.binary_display,
                             max_width,
                         )
                         self.echo("")
@@ -1404,6 +1407,7 @@ class MyCli:
                 special.is_redirected(),
                 self.null_string,
                 self.numeric_alignment,
+                self.binary_display,
             )
             for line in output:
                 self.log_output(line)
@@ -1424,6 +1428,7 @@ class MyCli:
                         special.is_redirected(),
                         self.null_string,
                         self.numeric_alignment,
+                        self.binary_display,
                     )
                     for line in output:
                         click.echo(line, nl=new_line)
@@ -1440,6 +1445,7 @@ class MyCli:
         is_redirected: bool = False,
         null_string: str | None = None,
         numeric_alignment: str = 'right',
+        binary_display: str | None = None,
         max_width: int | None = None,
     ) -> itertools.chain[str]:
         if is_redirected:
@@ -1461,7 +1467,7 @@ class MyCli:
         if null_string is not None and default_kwargs.get('missing_value') == DEFAULT_MISSING_VALUE:
             output_kwargs['missing_value'] = null_string
 
-        if use_formatter.format_name not in sql_format.supported_formats:
+        if use_formatter.format_name not in sql_format.supported_formats and binary_display != 'utf8':
             # will run before preprocessors defined as part of the format in cli_helpers
             output_kwargs["preprocessors"] = (preprocessors.convert_to_undecoded_string,)
 

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -76,6 +76,11 @@ null_string = <null>
 # How to align numeric data in tabular output: right or left.
 numeric_alignment = right
 
+# How to display binary values in tabular output: "hex", or "utf8".  "utf8"
+# means attempt to render valid UTF-8 sequences as strings, then fall back
+# to hex rendering if not possible.
+binary_display = hex
+
 # A command to run after a successful output redirect, with {} to be replaced
 # with the escaped filename.  Mac example: echo {} | pbcopy.  Escaping is not
 # reliable/safe on Windows.

--- a/test/myclirc
+++ b/test/myclirc
@@ -74,6 +74,11 @@ null_string = <nope>
 # How to align numeric data in tabular output: right or left.
 numeric_alignment = right
 
+# How to display binary values in tabular output: "hex", or "utf8".  "utf8"
+# means attempt to render valid UTF-8 sequences as strings, then fall back
+# to hex rendering if not possible.
+binary_display = hex
+
 # A command to run after a successful output redirect, with {} to be replaced
 # with the escaped filename.  Mac example: echo {} | pbcopy.  Escaping is not
 # reliable/safe on Windows.


### PR DESCRIPTION
## Description

This is the rough equivalent of the vendor `--skip-binary-as-text` CLI option, which has the effect of reversing

 * https://github.com/dbcli/mycli/pull/1483

when set to "utf8".

~I'm still not sure how to write tests for non-default myclirc options, though there may have been a recent example.~ Tests incorporated thanks to @scottnemes .

Fixes #1511.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
