### PR TITLE
Include port and socket in keyring identifier

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ Bug Fixes
 --------
 * Link to `--ssl`/`--no-ssl` GitHub issue in deprecation warning.
 * Don't emit keyring-updated message unless needed.
+* Include port and socket in keyring identifier.
 
 
 1.49.0 (2026/02/02)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -600,12 +600,12 @@ class MyCli:
         # 5. cnf (.my.cnf / etc)
         # 6. keyring
 
-        keychain_user = f'{user}@{host}'
+        keychain_identifier = f'{user}@{host}:{int_port}:{socket}'
         keychain_domain = 'mycli.net'
         keychain_retrieved = False
 
         if passwd is None and use_keyring and not reset_keyring:
-            passwd = keyring.get_password(keychain_domain, keychain_user)
+            passwd = keyring.get_password(keychain_domain, keychain_identifier)
             keychain_retrieved = True
 
         # if no password was found from all of the above sources, ask for a password
@@ -614,9 +614,9 @@ class MyCli:
 
         if reset_keyring or (use_keyring and not keychain_retrieved):
             try:
-                saved_pw = keyring.get_password(keychain_domain, keychain_user)
+                saved_pw = keyring.get_password(keychain_domain, keychain_identifier)
                 if passwd != saved_pw or reset_keyring:
-                    keyring.set_password(keychain_domain, keychain_user, passwd)
+                    keyring.set_password(keychain_domain, keychain_identifier, passwd)
                     click.secho('Password saved to the system keyring', err=True)
             except Exception as e:
                 click.secho(f'Password not saved to the system keyring: {e}', err=True, fg='red')


### PR DESCRIPTION
## Description
It is possible to have different credentials when connecting to the same host on different ports, for instance.

Incidentally recast a variable name as `keychain_identifier`.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
