### PR TITLE
Move `ssl_mode` to `[connection]` section

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features
 --------
 * Options to limit size of LLM prompts; cache LLM prompt data.
 * Add startup usage tips.
+* Move `main.ssl_mode` config option to `connection.default_ssl_mode`.
 
 
 Bug Fixes

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -180,7 +180,7 @@ class MyCli:
             self.llm_prompt_section_truncate = 0
 
         # set ssl_mode if a valid option is provided in a config file, otherwise None
-        ssl_mode = c["main"].get("ssl_mode", None)
+        ssl_mode = c["main"].get("ssl_mode", None) or c["connection"].get("default_ssl_mode", None)
         if ssl_mode not in ("auto", "on", "off", None):
             self.echo(f"Invalid config option provided for ssl_mode ({ssl_mode}); ignoring.", err=True, fg="red")
             self.ssl_mode = None

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -5,13 +5,6 @@
 # after executing a SQL statement when applicable.
 show_warnings = False
 
-# Sets the desired behavior for handling secure connections to the database server.
-# Possible values:
-# auto = SSL is preferred. Will attempt to connect via SSL, but will fallback to cleartext as needed.
-# on = SSL is required. Will attempt to connect via SSL and will fail if a secure connection is not established.
-# off = do not use SSL. Will fail if the server requires a secure connection.
-ssl_mode = auto
-
 # Enables context sensitive auto-completion. If this is disabled the all
 # possible completions will be listed.
 smart_completion = True
@@ -156,6 +149,13 @@ default_character_set = utf8mb4
 
 # whether to enable LOAD DATA LOCAL INFILE for connections without --local-infile being set
 default_local_infile = False
+
+# Sets the desired behavior for handling secure connections to the database server.
+# Possible values:
+# auto = SSL is preferred. Will attempt to connect via SSL, but will fallback to cleartext as needed.
+# on = SSL is required. Will attempt to connect via SSL and will fail if a secure connection is not established.
+# off = do not use SSL. Will fail if the server requires a secure connection.
+default_ssl_mode = auto
 
 # SSL CA file for connections without --ssl-ca being set
 default_ssl_ca =

--- a/test/myclirc
+++ b/test/myclirc
@@ -5,13 +5,6 @@
 # after executing a SQL statement when applicable.
 show_warnings = False
 
-# Sets the desired behavior for handling secure connections to the database server.
-# Possible values:
-# auto = SSL is preferred. Will attempt to connect via SSL, but will fallback to cleartext as needed.
-# on = SSL is required. Will attempt to connect via SSL and will fail if a secure connection is not established.
-# off = do not use SSL. Will fail if the server requires a secure connection.
-ssl_mode = auto
-
 # Enables context sensitive auto-completion. If this is disabled the all
 # possible completions will be listed.
 smart_completion = True
@@ -154,6 +147,13 @@ default_character_set = utf8mb4
 
 # whether to enable LOAD DATA LOCAL INFILE for connections without --local-infile being set
 default_local_infile = False
+
+# Sets the desired behavior for handling secure connections to the database server.
+# Possible values:
+# auto = SSL is preferred. Will attempt to connect via SSL, but will fallback to cleartext as needed.
+# on = SSL is required. Will attempt to connect via SSL and will fail if a secure connection is not established.
+# off = do not use SSL. Will fail if the server requires a secure connection.
+default_ssl_mode = auto
 
 # SSL CA file for connections without --ssl-ca being set
 default_ssl_ca =


### PR DESCRIPTION
## Description
 * move to new section
 * change the name to `default_ssl_mode`
 * place with other SSL options
 * continue to silently accept the old spelling in `[main]`

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
