### PR TITLE
Add startup usage tips

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ TBD
 Features
 --------
 * Options to limit size of LLM prompts; cache LLM prompt data.
+* Add startup usage tips.
 
 
 Bug Fixes

--- a/mycli/TIPS
+++ b/mycli/TIPS
@@ -1,0 +1,103 @@
+set "less_chatty = True" in ~/.myclirc to turn off these tips!
+
+set a fancy table format like "table_format = psql_unicode" in ~/.myclirc!
+
+change the string for NULLs with "null_string = <null>" in ~/.myclirc!
+
+interact with an LLM using the \llm command!
+
+display query result vertically using \G at the end of a query!
+
+copy a query to the clipboard using \clip at the end of the query!
+
+\dt lists tables; \dt <table> describes <table>!
+
+edit a query in an external editor using \e!
+
+edit a query in an external editor using keystrokes control-x + control-e!
+
+toggle smart completion using keystroke F2!
+
+toggle multi-line mode using keystroke F3!
+
+toggle vi mode using keystroke F4!
+
+complete at cursor using the tab key!
+
+prettify a query using keystrokes control-x + p!
+
+un-prettify a query using keystrokes control-x + u!
+
+insert the current date using keystrokes control-o + d!
+
+insert the quoted current date using keystrokes control-o + control-d!
+
+insert the current datetime using keystrokes control-o + t!
+
+insert the quoted current date using keystrokes control-o + control-t!
+
+search query history using keystroke control-r!
+
+\f lists favorite queries; \f <name> executes a favorite!
+
+\fs <name> <query> saves a favorite query!
+
+\fd <name> deletes a saved favorite query!
+
+\l lists databases!
+
+\once <filename> appends the next result to <filename>!
+
+\| <command> sends the next result to a subprocess!
+
+\t toggles timing of commands!
+
+\r or "connect" reconnects to the server!
+
+\delimiter changes the SQL delimiter!
+
+\q, "quit", or "exit" exits from the prompt!
+
+\? or "help" for help!
+
+\n or "nopager" to disable the pager!
+
+use "tee"/"notee" to write/stop-writing results to a output file!
+
+\W or "warnings" enables automatic warnings display!
+
+\w or "nowarnings" disables automatic warnings display!
+
+\P or "pager" sets the pager.  Try "pager less"!
+
+\R or "prompt" changes the prompt format!
+
+\Tr or "redirectformat" changes the table format for redirects!
+
+\# or "rehash" refreshes autocompletions!
+
+\. or "source" executes queries from a file!
+
+\s or "status" requests status information from the server!
+
+use "system <command>" to execute a shell command!
+
+\T or "tableformat" changes the interactive table format!
+
+\u or "use" changes to a new database!
+
+the "watch" command executes a query every N seconds!
+
+redirect query output to a shell command with "$| <command>"!
+
+redirect query output to a file with "$> <filename>"!
+
+append query output to a file with "$>> <filename>"!
+
+choose a color theme with "syntax_style" in ~/.myclirc!
+
+design a prompt with the "prompt" option in ~/.myclirc!
+
+save passwords in the system keyring with "use_keyring" in ~/.myclirc!
+
+check your ~/.myclirc settings using the --checkup flag!

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from io import TextIOWrapper
 import logging
 import os
+import random
 import re
 import shutil
 import sys
@@ -821,7 +822,10 @@ class MyCli:
             print(sqlexecute.server_info)
             print("mycli", __version__)
             print(SUPPORT_INFO)
-            print("Thanks to the contributor -", thanks_picker())
+            if random.random() <= 0.5:
+                print("Thanks to the contributor —", thanks_picker())
+            else:
+                print("Tip —", tips_picker())
 
         def get_message() -> ANSI:
             prompt = self.get_prompt(self.prompt_format)
@@ -2206,17 +2210,39 @@ def thanks_picker() -> str:
     import mycli
 
     lines: str = ""
-    with resources.files(mycli).joinpath("AUTHORS").open('r') as f:
-        lines += f.read()
+    try:
+        with resources.files(mycli).joinpath("AUTHORS").open('r') as f:
+            lines += f.read()
+    except FileNotFoundError:
+        pass
 
-    with resources.files(mycli).joinpath("SPONSORS").open('r') as f:
-        lines += f.read()
+    try:
+        with resources.files(mycli).joinpath("SPONSORS").open('r') as f:
+            lines += f.read()
+    except FileNotFoundError:
+        pass
 
     contents = []
     for line in lines.split("\n"):
         if m := re.match(r"^ *\* (.*)", line):
             contents.append(m.group(1))
     return choice(contents) if contents else 'our sponsors'
+
+
+def tips_picker() -> str:
+    import mycli
+
+    tips = []
+
+    try:
+        with resources.files(mycli).joinpath('TIPS').open('r') as f:
+            for line in f:
+                if tip := line.strip():
+                    tips.append(tip)
+    except FileNotFoundError:
+        pass
+
+    return choice(tips) if tips else r'\? or "help" for help!'
 
 
 @prompt_register("edit-and-execute-command")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dev = [
 mycli = "mycli.main:cli"
 
 [tool.setuptools.package-data]
-mycli = ["myclirc", "AUTHORS", "SPONSORS"]
+mycli = ["myclirc", "AUTHORS", "SPONSORS", "TIPS"]
 
 [tool.setuptools.packages.find]
 include = ["mycli*"]


### PR DESCRIPTION
## Description
Add startup usage tips as a random alternative to contributor thanks.

Incidentally make contributor thanks more robust to missing files, and use an em-dash in the tip/thanks messages.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
