### PR TITLE
[chore] Add tests for hex/utf8 output

### DIFF
--- a/test/test_main.py
+++ b/test/test_main.py
@@ -42,6 +42,84 @@ CLI_ARGS = [
 
 
 @dbtest
+def test_binary_display_hex(executor, capsys):
+    m = MyCli()
+    m.sqlexecute = SQLExecute(
+        None,
+        USER,
+        PASSWORD,
+        HOST,
+        PORT,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    m.explicit_pager = False
+    sqlresult = next(m.sqlexecute.run("select b'01101010' AS binary_test"))
+    formatted = m.format_output(
+        sqlresult.title,
+        sqlresult.results,
+        sqlresult.headers,
+        False,
+        False,
+        "<nope>",
+        "right",
+        "hex",
+        None,
+    )
+    m.output(formatted, sqlresult.status)
+    expected = "+-------------+\n| binary_test |\n+-------------+\n| 0x6a        |\n+-------------+\n1 row in set\n"
+    stdout = capsys.readouterr().out
+    assert expected in stdout
+
+
+@dbtest
+def test_binary_display_utf8(executor, capsys):
+    m = MyCli()
+    m.sqlexecute = SQLExecute(
+        None,
+        USER,
+        PASSWORD,
+        HOST,
+        PORT,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    m.explicit_pager = False
+    sqlresult = next(m.sqlexecute.run("select b'01101010' AS binary_test"))
+    formatted = m.format_output(
+        sqlresult.title,
+        sqlresult.results,
+        sqlresult.headers,
+        False,
+        False,
+        "<nope>",
+        "right",
+        "utf8",
+        None,
+    )
+    m.output(formatted, sqlresult.status)
+    expected = "+-------------+\n| binary_test |\n+-------------+\n| j           |\n+-------------+\n1 row in set\n"
+    stdout = capsys.readouterr().out
+    assert expected in stdout
+
+
+@dbtest
 def test_select_from_empty_table(executor):
     run(executor, """create table t1(id int)""")
     sql = "select * from t1"


### PR DESCRIPTION
## Description
Add tests for hex/utf8 output


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [X] I added this contribution to the `changelog.md` file.
- [X] I added my name to the `AUTHORS` file (or it's already there).
- [X] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
