### PR TITLE
Let CI ignore SPONSORS and TIPS documentation files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     paths-ignore:
       - '**.md'
       - 'AUTHORS'
+      - 'SPONSORS'
+      - 'TIPS'
 
 jobs:
   tests:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,8 @@ on:
     paths-ignore:
       - '**.md'
       - 'AUTHORS'
+      - 'SPONSORS'
+      - 'TIPS'
 
 jobs:
   linters:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -5,6 +5,8 @@ on:
     paths-ignore:
       - '**.md'
       - 'AUTHORS'
+      - 'SPONSORS'
+      - 'TIPS'
 
 jobs:
   typecheck:

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+TBD
+==============
+
+Internal
+--------
+* Let CI ignore additional documentation files.
+
+
 1.51.1 (2026/02/09)
 ==============
 


### PR DESCRIPTION
## Description
There is no reason to run CI for documentation files.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
