### PR TITLE
Upgrade cli_helpers to v2.10.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ Internal
 --------
 * Let CI ignore additional documentation files.
 * Add a GitHub Issue template.
+* Upgrade `cli_helpers` library to v2.10.0.
 
 
 1.51.1 (2026/02/09)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "sqlparse>=0.3.0,<0.6.0",
     "sqlglot[rs] == 27.*",
     "configobj >= 5.0.5",
-    "cli_helpers[styles] >= 2.9.0",
+    "cli_helpers[styles] >= 2.10.0",
     "pyperclip >= 1.8.1",
     "pycryptodomex",
     "pyfzf >= 0.3.1",

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -75,7 +75,7 @@ def test_binary_display_hex(executor, capsys):
         None,
     )
     m.output(formatted, sqlresult.status)
-    expected = "+-------------+\n| binary_test |\n+-------------+\n| 0x6a        |\n+-------------+\n1 row in set\n"
+    expected = " 0x6a "
     stdout = capsys.readouterr().out
     assert expected in stdout
 
@@ -114,7 +114,7 @@ def test_binary_display_utf8(executor, capsys):
         None,
     )
     m.output(formatted, sqlresult.status)
-    expected = "+-------------+\n| binary_test |\n+-------------+\n| j           |\n+-------------+\n1 row in set\n"
+    expected = " j "
     stdout = capsys.readouterr().out
     assert expected in stdout
 


### PR DESCRIPTION
## Description
Upgrade cli_helpers to v2.10.0, with TrueColor support.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
