### PR TITLE
Fallback on procedure completions errors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Features
 Bug Fixes
 --------
 * Reduce duplicated `--checkup` output.
+* Handle errors generating completions on stored procedures.
 
 
 Internal

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -455,15 +455,20 @@ class SQLExecute:
             for row in cur:
                 yield row
 
-    def procedures(self) -> Generator[tuple[str, str], None, None]:
+    def procedures(self) -> Generator[tuple, None, None]:
         """Yields tuples of (procedure_name, )"""
 
         assert isinstance(self.conn, Connection)
         with self.conn.cursor() as cur:
             _logger.debug("Procedures Query. sql: %r", self.procedures_query)
-            cur.execute(self.procedures_query % self.dbname)
-            for row in cur:
-                yield row
+            try:
+                cur.execute(self.procedures_query % self.dbname)
+            except pymysql.DatabaseError as e:
+                _logger.error('No procedure completions due to %r', e)
+                yield ()
+            else:
+                for row in cur:
+                    yield row
 
     def show_candidates(self) -> Generator[tuple, None, None]:
         assert isinstance(self.conn, Connection)


### PR DESCRIPTION
## Description
When the procedures query cannot be executed for whatever reason, yield and empty generator.

Fixes #1531.


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
