### PR TITLE
Micro followups to `\dt+ <table>` fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,14 @@
 Upcoming (TBD)
 ==============
 
-Bug Fixes
----------
-* Fix `\dt+ table_name` returning empty results.
-
 Features
 --------
 * Add all `~/.myclirc` entries/sections to startup tips.
+
+
+Bug Fixes
+---------
+* Fix `\dt+ table_name` returning empty results.
 
 
 Internal

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -41,6 +41,8 @@ def list_tables(
         logger.debug(query)
         cur.execute(query)
         if one := cur.fetchone():
+            # Returning the SHOW CREATE TABLE as a "status" keeps it unformatted,
+            # which is a hack.  There should be an unformmatted_results argument.
             status = one[1]
 
     return [SQLResult(results=results, headers=headers, status=status)]


### PR DESCRIPTION
## Description
 * commentary
 * standard changelog order

Micro followups to #1539, to avoid quibbling on the review.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
