### PR TITLE
Correct parameterization for completion queries

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ Features
 * Add many CLI flags to startup tips.
 
 
+Bug Fixes
+---------
+* Correct parameterization for completion queries.
+
+
 Internal
 --------
 * Prefer `yield from` over yielding in a loop.

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -97,17 +97,17 @@ class SQLExecute:
     users_query = """SELECT CONCAT("'", user, "'@'",host,"'") FROM mysql.user"""
 
     functions_query = '''SELECT ROUTINE_NAME FROM INFORMATION_SCHEMA.ROUTINES
-    WHERE ROUTINE_TYPE="FUNCTION" AND ROUTINE_SCHEMA = "%s"'''
+    WHERE ROUTINE_TYPE="FUNCTION" AND ROUTINE_SCHEMA = %s'''
 
     procedures_query = '''SELECT ROUTINE_NAME FROM INFORMATION_SCHEMA.ROUTINES
     WHERE ROUTINE_TYPE="PROCEDURE" AND ROUTINE_SCHEMA = %s'''
 
     table_columns_query = """select TABLE_NAME, COLUMN_NAME from information_schema.columns
-                                    where table_schema = '%s'
+                                    where table_schema = %s
                                     order by table_name,ordinal_position"""
 
     enum_values_query = """select TABLE_NAME, COLUMN_NAME, COLUMN_TYPE from information_schema.columns
-                                    where table_schema = '%s' and data_type = 'enum'
+                                    where table_schema = %s and data_type = 'enum'
                                     order by table_name,ordinal_position"""
 
     now_query = """SELECT NOW()"""
@@ -421,7 +421,7 @@ class SQLExecute:
         assert isinstance(self.conn, Connection)
         with self.conn.cursor() as cur:
             _logger.debug("Columns Query. sql: %r", self.table_columns_query)
-            cur.execute(self.table_columns_query % self.dbname)
+            cur.execute(self.table_columns_query, (self.dbname,))
             yield from cur
 
     def enum_values(self) -> Generator[tuple[str, str, list[str]], None, None]:
@@ -429,7 +429,7 @@ class SQLExecute:
         assert isinstance(self.conn, Connection)
         with self.conn.cursor() as cur:
             _logger.debug("Enum Values Query. sql: %r", self.enum_values_query)
-            cur.execute(self.enum_values_query % self.dbname)
+            cur.execute(self.enum_values_query, (self.dbname,))
             for table_name, column_name, column_type in cur:
                 values = self._parse_enum_values(column_type)
                 if values:
@@ -448,7 +448,7 @@ class SQLExecute:
         assert isinstance(self.conn, Connection)
         with self.conn.cursor() as cur:
             _logger.debug("Functions Query. sql: %r", self.functions_query)
-            cur.execute(self.functions_query % self.dbname)
+            cur.execute(self.functions_query, (self.dbname,))
             yield from cur
 
     def procedures(self) -> Generator[tuple, None, None]:


### PR DESCRIPTION
## Description
We should always use query parameters instead of interpolation and quoting by hand.

xref #1542.


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
