### PR TITLE
Prefer `yield from` over yielding in a loop

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Internal
+--------
+* Prefer `yield from` over yielding in a loop.
+
+
 1.53.0 (2026/02/12)
 ==============
 

--- a/mycli/packages/parseutils.py
+++ b/mycli/packages/parseutils.py
@@ -132,8 +132,7 @@ def extract_from_part(parsed: TokenList, stop_at_punctuation: bool = True) -> Ge
     for item in parsed.tokens:
         if tbl_prefix_seen:
             if is_subselect(item):
-                for x in extract_from_part(item, stop_at_punctuation):
-                    yield x
+                yield from extract_from_part(item, stop_at_punctuation)
             elif stop_at_punctuation and item.ttype is Punctuation:
                 return None
             # Multiple JOINs in the same query won't work properly since

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -264,8 +264,7 @@ def set_redirect(command_part: str | None, file_operator_part: str | None, file_
 def execute_favorite_query(cur: Cursor, arg: str, **_) -> Generator[SQLResult, None, None]:
     """Returns (title, rows, headers, status)"""
     if arg == "":
-        for result in list_favorite_queries():
-            yield result
+        yield from list_favorite_queries()
 
     # Parse out favorite name and optional substitution parameters
     name, _separator, arg_str = arg.partition(" ")
@@ -628,5 +627,4 @@ def get_current_delimiter() -> str:
 
 
 def split_queries(input_str: str) -> Generator[str, None, None]:
-    for query in delimiter_command.queries_iter(input_str):
-        yield query
+    yield from delimiter_command.queries_iter(input_str)

--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -993,8 +993,7 @@ class SQLCompleter(Completer):
         completions: list[tuple[str, int]] = []
 
         def empty_generator():
-            for item in []:
-                yield item
+            yield from []
 
         if re.match(r'^[\d\.]', text):
             return empty_generator()

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -374,8 +374,7 @@ class SQLExecute:
             cur = self.conn.cursor()
             try:  # Special command
                 _logger.debug("Trying a dbspecial command. sql: %r", sql)
-                for result in execute(cur, sql):
-                    yield result
+                yield from execute(cur, sql)
             except CommandNotFound:  # Regular SQL
                 _logger.debug("Regular sql statement. sql: %r", sql)
                 cur.execute(sql)
@@ -415,8 +414,7 @@ class SQLExecute:
         with self.conn.cursor() as cur:
             _logger.debug("Tables Query. sql: %r", self.tables_query)
             cur.execute(self.tables_query)
-            for row in cur:
-                yield row
+            yield from cur
 
     def table_columns(self) -> Generator[tuple[str, str], None, None]:
         """Yields (table name, column name) pairs"""
@@ -424,8 +422,7 @@ class SQLExecute:
         with self.conn.cursor() as cur:
             _logger.debug("Columns Query. sql: %r", self.table_columns_query)
             cur.execute(self.table_columns_query % self.dbname)
-            for row in cur:
-                yield row
+            yield from cur
 
     def enum_values(self) -> Generator[tuple[str, str, list[str]], None, None]:
         """Yields (table name, column name, enum values) tuples"""
@@ -452,8 +449,7 @@ class SQLExecute:
         with self.conn.cursor() as cur:
             _logger.debug("Functions Query. sql: %r", self.functions_query)
             cur.execute(self.functions_query % self.dbname)
-            for row in cur:
-                yield row
+            yield from cur
 
     def procedures(self) -> Generator[tuple, None, None]:
         """Yields tuples of (procedure_name, )"""
@@ -467,8 +463,7 @@ class SQLExecute:
                 _logger.error('No procedure completions due to %r', e)
                 yield ()
             else:
-                for row in cur:
-                    yield row
+                yield from cur
 
     def show_candidates(self) -> Generator[tuple, None, None]:
         assert isinstance(self.conn, Connection)
@@ -493,8 +488,7 @@ class SQLExecute:
                 _logger.error("No user completions due to %r", e)
                 yield ()
             else:
-                for row in cur:
-                    yield row
+                yield from cur
 
     def now(self) -> datetime.datetime:
         assert isinstance(self.conn, Connection)


### PR DESCRIPTION
## Description
Per https://peps.python.org/pep-0380/ this construct is supposed to be more optimizable (which makes sense).  It is available since Python 3.3.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
