### PR TITLE
Accept special commands without trailing semicolons even in multi-line mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming (TBD)
 Features
 --------
 * Add many CLI flags to startup tips.
+* Accept all special commands without trailing semicolons in multi-line mode.
 
 
 Bug Fixes


### PR DESCRIPTION
## Description
"exit" was always an exception to the multi-line trailing semicolon rule.  At minimum, "help" should likewise be an exception.

This makes _all_ special commands exceptions to the multi-line trailing semicolon requirement, on the theory of consistency, because special commands starting with backslash have also always been exceptions.

Tests seem difficult.  We'd want to do a "behave" test using an alternate configuration.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
