### PR TITLE
Remove vim exit sequence, which has no effect

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@ Internal
 * Update key feature list in `README.md`, syncing with web.
 * Sync prompt format string commentary with web.
 * Add a GitHub Actions workflow to run Codex review on pull requests.
+* Remove vim-style exit sequence which had no effect.
 
 
 1.53.0 (2026/02/12)

--- a/mycli/clibuffer.py
+++ b/mycli/clibuffer.py
@@ -49,9 +49,6 @@ def _multiline_exception(text: str) -> bool:
         # uppercase variants accepted
         first_word.lower() in SPECIAL_COMMANDS
         or
-        # To all teh vim fans out there
-        (first_word == ":q")
-        or
         # just a plain enter without any text
         (first_word == "")
     )


### PR DESCRIPTION
## Description
I've tried to figure this out, but the multiline exception for `:q` seems to have no effect.  Maybe it was an in-joke?

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
