### PR TITLE
Optionally defer completions until N characters have been typed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Features
 * Add many CLI flags to startup tips.
 * Accept all special commands without trailing semicolons in multi-line mode.
 * Add prompt format strings for socket connections.
+* Optionally defer auto-completions until a minimum number of characters is typed.
 
 
 Bug Fixes

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -9,6 +9,10 @@ show_warnings = False
 # possible completions will be listed.
 smart_completion = True
 
+# Minimum characters typed before offering completion suggestions.
+# Suggestion: 3.
+min_completion_trigger = 1
+
 # Multi-line mode allows breaking up the sql statements into multiple lines. If
 # this is set to True, then the end of the statements must have a semi-colon.
 # If this is set to False then sql statements can't be split into multiple

--- a/test/myclirc
+++ b/test/myclirc
@@ -9,6 +9,10 @@ show_warnings = False
 # possible completions will be listed.
 smart_completion = True
 
+# Minimum characters typed before offering completion suggestions.
+# Suggestion: 3.
+min_completion_trigger = 1
+
 # Multi-line mode allows breaking up the sql statements into multiple lines. If
 # this is set to True, then the end of the statements must have a semi-colon.
 # If this is set to False then sql statements can't be split into multiple


### PR DESCRIPTION
## Description
A strong effort is taken for efficiency on reading the trailing characters, since this prompt_toolkit Filter will run on every keystroke.  Though the cost of running the Pygments lexer on every keystroke surely dwarfs this.

If fewer than N characters have been typed, the suggestions can still be summoned by control-space (does not advance into the candidates) or tab (does immediately advance into the candidates).

The motivation is to both reduce distractions and to reduce lag when typing.

There is another way to do this by passing thresholds into `mycli/sqlcompleter.py`, but it doesn't preserve the ability to summon completions when below the trigger threshold.

Tests are a challenge again because we would need a custom myclirc.

I could almost be convinced to change the default trigger threshold to `3` for all users.  It's better!  But changing defaults is a bad practice in principle.

xref #1548

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
