### PR TITLE
Ability to suppress control-d exit behavior

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ Features
 * Add prompt format strings for socket connections.
 * Optionally defer auto-completions until a minimum number of characters is typed.
 * Make the completion interface more responsive using a background thread.
+* Option to suppress control-d exit behavior.
 
 
 Bug Fixes

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -197,6 +197,10 @@ prompt_field_truncate = None
 prompt_section_truncate = None
 
 [keys]
+
+# possible values: exit, none
+control_d = exit
+
 # possible values: auto, fzf, reverse_isearch
 control_r = auto
 

--- a/test/myclirc
+++ b/test/myclirc
@@ -195,6 +195,10 @@ prompt_field_truncate = None
 prompt_section_truncate = None
 
 [keys]
+
+# possible values: exit, none
+control_d = exit
+
 # possible values: auto, fzf, reverse_isearch
 control_r = auto
 


### PR DESCRIPTION
## Description
Arguably the default should be changed since it can be confusing to new users.  But exiting on control-d/EOF is also the default for _eg_ bash.

Ringing the bell when no action can be taken is consistent with other control keys on the empty line.

Tests would be nice!  But would require an alternate myclirc and simulated keypresses, which I don't know how to do.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
