### PR TITLE
Support Truecolor in prompt_toolkit sessions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Features
 * Optionally defer auto-completions until a minimum number of characters is typed.
 * Make the completion interface more responsive using a background thread.
 * Option to suppress control-d exit behavior.
+* Better support Truecolor terminals.
 
 
 Bug Fixes

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -42,6 +42,7 @@ from prompt_toolkit.key_binding.bindings.named_commands import register as promp
 from prompt_toolkit.key_binding.key_processor import KeyPressEvent
 from prompt_toolkit.layout.processors import ConditionalProcessor, HighlightMatchingBracketProcessor
 from prompt_toolkit.lexers import PygmentsLexer
+from prompt_toolkit.output import ColorDepth
 from prompt_toolkit.shortcuts import CompleteStyle, PromptSession
 import pymysql
 from pymysql.constants.ER import HANDSHAKE_ERROR
@@ -1168,6 +1169,7 @@ class MyCli:
                 editing_mode = EditingMode.EMACS
 
             self.prompt_app = PromptSession(
+                color_depth=ColorDepth.DEPTH_24_BIT if 'truecolor' in os.getenv('COLORTERM', '').lower() else None,
                 lexer=PygmentsLexer(MyCliLexer),
                 reserve_space_for_menu=self.get_reserved_space(),
                 message=get_message,


### PR DESCRIPTION
## Description
Support Truecolor in prompt_toolkit sessions if the environment variable `$COLORTERM` contains "truecolor"; otherwise fall back to 8-bit color depth, the prompt_tookit default.

I must admit that between this and https://github.com/dbcli/cli_helpers/pull/102 I cannot yet see a difference.  But there was a request for it, which is reasonable.

It would be great if someone attached some screenshots showing the difference.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
