### PR TITLE
Don't offer completions within strings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Bug Fixes
+--------
+* Don't offer autocomplete suggestions when the cursor is within a string.
+
+
 1.54.0 (2026/02/16)
 ==============
 

--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -995,12 +995,6 @@ class SQLCompleter(Completer):
 
         completions: list[tuple[str, int]] = []
 
-        def empty_generator():
-            yield from []
-
-        if re.match(r'^[\d\.]', text):
-            return empty_generator()
-
         if fuzzy:
             regex = ".{0,3}?".join(map(re.escape, text))
             pat = re.compile(f'({regex})')

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -695,3 +695,38 @@ def test_source_eager_completion(completer, complete_event):
         os.remove(script_filename)
     if not success:
         raise AssertionError(error)
+
+
+def test_string_no_completion(completer, complete_event):
+    text = 'select "json'
+    position = len(text)
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == []
+
+
+def test_string_no_completion_single_quote(completer, complete_event):
+    text = "select 'json"
+    position = len(text)
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == []
+
+
+def test_string_no_completion_spaces(completer, complete_event):
+    text = 'select "nocomplete json'
+    position = len(text)
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == []
+
+
+def test_string_no_completion_spaces_inner_1(completer, complete_event):
+    text = 'select "json nocomplete'
+    position = len('select "json')
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == []
+
+
+def test_string_no_completion_spaces_inner_2(completer, complete_event):
+    text = 'select "json nocomplete'
+    position = len('select "json ')
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == []


### PR DESCRIPTION
## Description
 * Don't offer completions when the cursor is within a string.
 * Move the similar implementation for numbers to a better location, next to the string check.

It would be great if `suggest_based_on_last_token()` was refactored to use named parameters.

Example of the behavior solved by this PR:

<img width="534" height="184" alt="Screenshot 2026-02-14 at 6 35 42 AM" src="https://github.com/user-attachments/assets/a53a2758-5d0b-404e-aaf3-42115dd6cbaa" />

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
