### PR TITLE
Update ruff to v0.15.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,15 +17,10 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-        # remember to sync the ruff-check version number with pyproject.toml
       - name: Run ruff check
         uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3.6.1
-        with:
-          version: 0.11.5
 
-        # remember to sync the ruff-check version number with pyproject.toml
       - name: Run ruff format
         uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3.6.1
         with:
-          version: 0.11.5
           args: 'format --check'

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ Bug Fixes
 Internal
 --------
 * Prefer `yield from` over yielding in a loop.
+* Update `ruff` linter and CI.
 
 
 1.53.0 (2026/02/12)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dev = [
     "llm>=0.19.0",
     "setuptools",                   # Required by llm commands to install models
     "pip",
-    "ruff~=0.14.10",
+    "ruff~=0.15.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Description
The official GitHub Action no longer needs a set version, but picks it up from `pyproject.toml`.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
