### PR TITLE
Add the ability to send app-layer keepalive pings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Features
 * Make the completion interface more responsive using a background thread.
 * Option to suppress control-d exit behavior.
 * Better support Truecolor terminals.
+* Ability to send app-layer keepalive pings to the server.
 
 
 Bug Fixes

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -159,6 +159,10 @@ default_character_set = utf8mb4
 # whether to enable LOAD DATA LOCAL INFILE for connections without --local-infile being set
 default_local_infile = False
 
+# How often to send periodic background pings to the server when input is idle.  Ticks are
+# roughly in seconds, but may be faster.  Set to zero to disable.  Suggestion: 300.
+default_keepalive_ticks = 0
+
 # Sets the desired behavior for handling secure connections to the database server.
 # Possible values:
 # auto = SSL is preferred. Will attempt to connect via SSL, but will fallback to cleartext as needed.

--- a/test/myclirc
+++ b/test/myclirc
@@ -157,6 +157,10 @@ default_character_set = utf8mb4
 # whether to enable LOAD DATA LOCAL INFILE for connections without --local-infile being set
 default_local_infile = False
 
+# How often to send periodic background pings to the server when input is idle.  Ticks are
+# roughly in seconds, but may be faster.  Set to zero to disable.  Suggestion: 300.
+default_keepalive_ticks = 0
+
 # Sets the desired behavior for handling secure connections to the database server.
 # Possible values:
 # auto = SSL is preferred. Will attempt to connect via SSL, but will fallback to cleartext as needed.


### PR DESCRIPTION
## Description
The config option is named with `default_` under the `[connection]` section on the theory that it might one day be configurable by individual connections.

It may be hard to prove when this works/does something useful.  But I have the issue of frequent reconnections with some servers, and this feature seems to be provided by MySQL Workbench:

* https://stackoverflow.com/questions/31811517/mysql-workbench-drops-connection-when-idle/37890150#37890150

<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/2f149df8-9ce6-4e06-87c9-af01162b0379" />


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
