### PR TITLE
Let the Escape key cancel completion popups

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ Features
 * Better support Truecolor terminals.
 * Ability to send app-layer keepalive pings to the server.
 * Add `WITH`, `EXPLAIN`, and `LEFT JOIN` to favorite keyword suggestions.
+* Let the Escape key cancel completion popups.
 
 
 Bug Fixes

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -24,6 +24,12 @@ def ctrl_d_condition() -> bool:
     return not app.current_buffer.text
 
 
+@Condition
+def in_completion() -> bool:
+    app = get_app()
+    return bool(app.current_buffer.complete_state)
+
+
 def mycli_bindings(mycli) -> KeyBindings:
     """Custom key bindings for mycli."""
     kb = KeyBindings()
@@ -60,6 +66,16 @@ def mycli_bindings(mycli) -> KeyBindings:
             b.complete_next()
         else:
             b.start_completion(select_first=True)
+
+    @kb.add("escape", eager=True, filter=in_completion)
+    def _(event: KeyPressEvent) -> None:
+        """Cancel completion menu.
+
+        There will be a lag when canceling Escape due to the processing of
+        Alt- keystrokes as Escape- sequences.
+
+        There will be no lag when using control-g to cancel."""
+        event.app.current_buffer.cancel_completion()
 
     @kb.add("c-space")
     def _(event: KeyPressEvent) -> None:


### PR DESCRIPTION
## Description
There is some lag as compared to canceling with control-g, due to the VT-100 limitation of representing <kbd>Alt</kbd>- keypresses as <kbd>Escape</kbd>- sequences.

Mentioned in #1009.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
