### PR TITLE
Pin dependencies more tightly, updating versions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@ Internal
 * Sync prompt format string commentary with web.
 * Add a GitHub Actions workflow to run Codex review on pull requests.
 * Remove vim-style exit sequence which had no effect.
+* Pin dependencies more tightly in `pyproject.toml`.
 
 
 1.53.0 (2026/02/12)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,18 +9,18 @@ authors = [{ name = "Mycli Core Team", email = "mycli-dev@googlegroups.com" }]
 urls = { homepage = "http://mycli.net" }
 
 dependencies = [
-    "click >= 8.3.1",
-    "cryptography >= 1.0.0",
+    "click ~= 8.3.1",
+    "cryptography ~= 46.0.5",
     "Pygments ~= 2.19.2",
     "prompt_toolkit>=3.0.6,<4.0.0",
-    "PyMySQL >= 0.9.2",
+    "PyMySQL ~= 1.1.2",
     "sqlparse>=0.3.0,<0.6.0",
     "sqlglot[rs] == 27.*",
-    "configobj >= 5.0.5",
-    "cli_helpers[styles] >= 2.10.0",
-    "pyperclip >= 1.8.1",
-    "pycryptodomex",
-    "pyfzf >= 0.3.1",
+    "configobj ~= 5.0.9",
+    "cli_helpers[styles] ~= 2.10.0",
+    "pyperclip ~= 1.11.0",
+    "pycryptodomex ~= 3.23.0",
+    "pyfzf ~= 0.3.1",
     "rapidfuzz ~= 3.14.3",
     "keyring ~= 25.7.0",
 ]
@@ -34,33 +34,33 @@ build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
 ssh = [
-    "paramiko~=3.5.1",
-    "sshtunnel",
+    "paramiko ~= 3.5.1",
+    "sshtunnel ~= 0.4.0",
 ]
 llm = [
-    "llm>=0.19.0",
-    "setuptools",                   # Required by llm commands to install models
-    "pip",
+    "llm ~= 0.28.0",
+    "setuptools == 82.*",                   # Required by llm commands to install models
+    "pip == 26.*",
 ]
 all = [
   "mycli[ssh]",
   "mycli[llm]",
 ]
 dev = [
-    "behave>=1.2.6",
-    "coverage>=7.2.7",
-    "mypy~=1.18.1",
-    "pexpect>=4.9.0",
-    "pytest>=7.4.4",
-    "pytest-cov>=4.1.0",
-    "tox>=4.8.0",
-    "pdbpp>=0.10.3",
-    "paramiko~=3.5.1",
-    "sshtunnel",
-    "llm>=0.19.0",
-    "setuptools",                   # Required by llm commands to install models
-    "pip",
-    "ruff~=0.15.0",
+    "behave ~= 1.3.3",
+    "coverage ~= 7.13.4",
+    "mypy ~= 1.19.1",
+    "pexpect ~= 4.9.0",
+    "pytest ~= 9.0.2",
+    "pytest-cov ~= 7.0.0",
+    "tox ~= 4.35.0",
+    "pdbpp ~= 0.11.7",
+    "paramiko ~= 3.5.1",
+    "sshtunnel ~= 0.4.0",
+    "llm ~= 0.28.0",
+    "setuptools == 82.*",                   # Required by llm commands to install models
+    "pip == 26.*",
+    "ruff ~= 0.15.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Description
Some dependencies had no versioning; others used `>=` which is prone to breakage as libraries have breaking changes.

This way means more maintenance but is safer against breakage.

Some projects also check in the lockfile for perfect reproducibility.

Where a `>=` was used, the version was generally updated to the latest, which is probably what was being used in practice.

The `~=` operator allows the patch version to increment.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
