### PR TITLE
Exclude more documentation files from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+      - 'LICENSE.txt'
+      - 'AUTHORS.rst'
+      - 'SPONSORS.rst'
+      - 'doc/**/*.txt'
+      - 'doc/**/*.rst'
       - '**/AUTHORS'
       - '**/SPONSORS'
       - '**/TIPS'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+      - 'LICENSE.txt'
+      - 'AUTHORS.rst'
+      - 'SPONSORS.rst'
+      - 'doc/**/*.txt'
+      - 'doc/**/*.rst'
       - '**/AUTHORS'
       - '**/SPONSORS'
       - '**/TIPS'

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+      - 'LICENSE.txt'
+      - 'AUTHORS.rst'
+      - 'SPONSORS.rst'
+      - 'doc/**/*.txt'
+      - 'doc/**/*.rst'
       - '**/AUTHORS'
       - '**/SPONSORS'
       - '**/TIPS'

--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@ Internal
 * Add a GitHub Actions workflow to run Codex review on pull requests.
 * Remove vim-style exit sequence which had no effect.
 * Pin dependencies more tightly in `pyproject.toml`.
+* Exclude more documentation files from CI.
 
 
 1.53.0 (2026/02/12)


### PR DESCRIPTION
## Description
Since #1556 needlessly ran the test suite.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
