### PR TITLE
Grammar nit to match incoming mycli.net text

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Features
 Bug Fixes
 ---------
 * Correct parameterization for completion queries.
+* Grammar nits in help display.
 
 
 Internal

--- a/mycli/packages/special/main.py
+++ b/mycli/packages/special/main.py
@@ -196,6 +196,6 @@ def stub():
 
 if LLM_IMPORTED:
 
-    @special_command("\\llm", "\\ai", "Interrogate LLM.", arg_type=ArgType.RAW_QUERY, case_sensitive=True)
+    @special_command("\\llm", "\\ai", "Interrogate an LLM.", arg_type=ArgType.RAW_QUERY, case_sensitive=True)
     def llm_stub():
         raise NotImplementedError

--- a/test/features/fixture_data/help_commands.txt
+++ b/test/features/fixture_data/help_commands.txt
@@ -9,7 +9,7 @@
 | \fd            | \fd [name]                 | Delete a favorite query.                                   |
 | \fs            | \fs name query             | Save a favorite query.                                     |
 | \l             | \l                         | List databases.                                            |
-| \llm           | \ai                        | Interrogate LLM.                                           |
+| \llm           | \ai                        | Interrogate an LLM.                                        |
 | \once          | \o [-o] filename           | Append next result to an output file (overwrite using -o). |
 | \pipe_once     | \| command                 | Send next result to a subprocess.                          |
 | \timing        | \t                         | Toggle timing of commands.                                 |


### PR DESCRIPTION
## Description
"Interrogate **an** LLM" reads better.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
