### PR TITLE
Add prompt format strings for socket connections

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features
 --------
 * Add many CLI flags to startup tips.
 * Accept all special commands without trailing semicolons in multi-line mode.
+* Add prompt format strings for socket connections.
 
 
 Bug Fixes

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1401,6 +1401,10 @@ class MyCli:
         string = string.replace("\\r", now.strftime("%I"))
         string = string.replace("\\s", now.strftime("%S"))
         string = string.replace("\\p", str(sqlexecute.port))
+        string = string.replace("\\j", os.path.basename(sqlexecute.socket or '(none)'))
+        string = string.replace("\\J", sqlexecute.socket or '(none)')
+        string = string.replace("\\k", os.path.basename(sqlexecute.socket or str(sqlexecute.port)))
+        string = string.replace("\\K", sqlexecute.socket or str(sqlexecute.port))
         string = string.replace("\\A", self.dsn_alias or "(none)")
         string = string.replace("\\_", " ")
         return string

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -96,15 +96,19 @@ key_bindings = emacs
 wider_completion_menu = False
 
 # MySQL prompt
-# * \D - the full current date, e.g. Sat Feb 14 15:55:48 2026
-# * \R - the current hour in 24-hour time (0–23)
-# * \r - the current hour 12-hour time (1–12)
+# * \D - full current date, e.g. Sat Feb 14 15:55:48 2026
+# * \R - current hour in 24-hour time (00–23)
+# * \r - current hour in 12-hour time (01–12)
 # * \m - minutes of the current time
 # * \s - seconds of the current time
 # * \P - AM/PM
 # * \d - selected database/schema
 # * \h - hostname of the server
-# * \p - the connection port
+# * \p - connection port
+# * \j - connection socket basename
+# * \J - full connection socket path
+# * \k - connection socket basename OR the port
+# * \K - full connection socket path OR the port
 # * \t - database vendor (Percona, MySQL, MariaDB, TiDB)
 # * \u - username
 # * \A - DSN alias

--- a/test/myclirc
+++ b/test/myclirc
@@ -94,15 +94,19 @@ key_bindings = emacs
 wider_completion_menu = False
 
 # MySQL prompt
-# * \D - the full current date, e.g. Sat Feb 14 15:55:48 2026
-# * \R - the current hour in 24-hour time (0–23)
-# * \r - the current hour 12-hour time (1–12)
+# * \D - full current date, e.g. Sat Feb 14 15:55:48 2026
+# * \R - current hour in 24-hour time (00–23)
+# * \r - current hour in 12-hour time (01–12)
 # * \m - minutes of the current time
 # * \s - seconds of the current time
 # * \P - AM/PM
 # * \d - selected database/schema
 # * \h - hostname of the server
-# * \p - the connection port
+# * \p - connection port
+# * \j - connection socket basename
+# * \J - full connection socket path
+# * \k - connection socket basename OR the port
+# * \K - full connection socket path OR the port
 # * \t - database vendor (Percona, MySQL, MariaDB, TiDB)
 # * \u - username
 # * \A - DSN alias

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -338,6 +338,21 @@ def test_prompt_no_host_only_socket(executor):
 
 
 @dbtest
+def test_prompt_socket_overrides_port(executor):
+    mycli = MyCli()
+    mycli.prompt_format = "\\t \\u@\\h:\\k \\d> "
+    mycli.sqlexecute = SQLExecute
+    mycli.sqlexecute.server_info = ServerInfo.from_version_string("8.0.44-0ubuntu0.24.04.1")
+    mycli.sqlexecute.host = None
+    mycli.sqlexecute.socket = "/var/run/mysqld/mysqld.sock"
+    mycli.sqlexecute.user = "root"
+    mycli.sqlexecute.dbname = "mysql"
+    mycli.sqlexecute.port = "3306"
+    prompt = mycli.get_prompt(mycli.prompt_format)
+    assert prompt == "MySQL root@localhost:mysqld.sock mysql> "
+
+
+@dbtest
 def test_enable_show_warnings(executor):
     mycli = MyCli()
     mycli.register_special_commands()
@@ -596,6 +611,7 @@ def output(monkeypatch, terminal_size, testdata, explicit_pager, expect_pager):
         dbname = "test"
         server_info = ServerInfo.from_version_string("unknown")
         port = 0
+        socket = ''
 
         def server_type(self):
             return ["test"]


### PR DESCRIPTION
## Description
 * `\j` - connection socket basename
 * `\J` - full connection socket path
 * `\k` - connection socket basename OR the port
 * `\K` - full connection socket path OR the port

the most handy of which is probably `\k`, which will show the socket basename if it exists, and if not, the port.

Incidentally, further fix up the prompt commentary in myclirc files.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
