### PR TITLE
Ignore doc changes for Codex review Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,9 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+      - '**.rst'
       - 'LICENSE.txt'
-      - 'AUTHORS.rst'
-      - 'SPONSORS.rst'
       - 'doc/**/*.txt'
-      - 'doc/**/*.rst'
       - '**/AUTHORS'
       - '**/SPONSORS'
       - '**/TIPS'

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -3,6 +3,14 @@ name: Codex Review
 on:
   pull_request_target:
     types: [opened, labeled, reopened, ready_for_review]
+    paths-ignore:
+      - '**.md'
+      - '**.rst'
+      - 'LICENSE.txt'
+      - 'doc/**/*.txt'
+      - '**/AUTHORS'
+      - '**/SPONSORS'
+      - '**/TIPS'
 
 jobs:
   codex-review:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,11 +4,9 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+      - '**.rst'
       - 'LICENSE.txt'
-      - 'AUTHORS.rst'
-      - 'SPONSORS.rst'
       - 'doc/**/*.txt'
-      - 'doc/**/*.rst'
       - '**/AUTHORS'
       - '**/SPONSORS'
       - '**/TIPS'

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -4,11 +4,9 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+      - '**.rst'
       - 'LICENSE.txt'
-      - 'AUTHORS.rst'
-      - 'SPONSORS.rst'
       - 'doc/**/*.txt'
-      - 'doc/**/*.rst'
       - '**/AUTHORS'
       - '**/SPONSORS'
       - '**/TIPS'


### PR DESCRIPTION
## Description

 * Skip Codex review when the changes are documentation-only.
 * Sync all workflows to the same `paths-ignore` spec.
 * Use a single `**.rst` property.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
