### PR TITLE
Catch `getpwuid()` `KeyError` on an unknown user id

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming (TBD)
 Bug Fixes
 --------
 * Don't offer autocomplete suggestions when the cursor is within a string.
+* Catch `getpwuid` error on unknown socket owner.
 
 
 1.54.0 (2026/02/16)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -722,7 +722,10 @@ class MyCli:
 
         try:
             if not WIN and socket:
-                socket_owner = getpwuid(os.stat(socket).st_uid).pw_name
+                try:
+                    socket_owner = getpwuid(os.stat(socket).st_uid).pw_name
+                except KeyError:
+                    socket_owner = '<unknown>'
                 self.echo(f"Connecting to socket {socket}, owned by user {socket_owner}", err=True)
                 try:
                     _connect()


### PR DESCRIPTION
## Description
Fixes #1567, if `KeyError` is the correct exception.

This can happen in the Docker context.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
