### PR TITLE
Refactor `is_inside_quotes()`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Bug Fixes
 Internal
 --------
 * Tune Codex reviews.
+* Refactor `is_inside_quotes()` detection.
 
 
 1.54.0 (2026/02/16)


### PR DESCRIPTION
## Description
 * Rename without underscore, as it might be used in another file.
 * Recognize backtick quoting, including doubled backticks as escapes.
 * Accept negative numbers for `pos`.
 * `escaped` should not be toggled to `True` unless inside a double- or single-quoted string.
 * Return a string or `False`, typed as Literal.
 * Optimize: `is not in` is much faster than looping.

Motivation: to improve completions which start with backtick.

xref #1564 .

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
