### PR TITLE
Ability to request Codex reviews with a PR label

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -2,11 +2,11 @@ name: Codex Review
 
 on:
   pull_request_target:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, labeled, reopened, ready_for_review]
 
 jobs:
   codex-review:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false or (github.event.action == 'labeled' and contains(github.event.pull_request.labels.*.name, 'codex'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@ Bug Fixes
 * Catch `getpwuid` error on unknown socket owner.
 
 
+Internal
+--------
+* Tune Codex reviews.
+
+
 1.54.0 (2026/02/16)
 ==============
 


### PR DESCRIPTION
## Description
Not 100% sure I have this right, but want to test.  The intention is that we can request a review at any point in the PR lifecycle by adding a label.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
