### PR TITLE
Improve completion suggestions inside backticks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming (TBD)
 Features
 ---------
 * `--checkup` now checks for external executables.
+* Improve completion suggestions within backticks.
 
 
 Bug Fixes
@@ -11,6 +12,7 @@ Bug Fixes
 * Watch command now returns correct time when ran as part of a multi-part query (#1565)
 * Don't diagnose free-entry sections such as `[favorite_queries]` in `--checkup`.
 * When accepting a filename completion, fill in leading `./` if given.
+
 
 Internal
 --------

--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -45,8 +45,12 @@ def _is_where_or_having(token: Token | None) -> bool:
 
 def _find_doubled_backticks(text: str) -> list[int]:
     length = len(text)
-    doubled_backticks: list[int] = []
+    doubled_backtick_positions: list[int] = []
     backtick = '`'
+    two_backticks = backtick + backtick
+
+    if two_backticks not in text:
+        return doubled_backtick_positions
 
     for index in range(0, length):
         ch = text[index]
@@ -54,13 +58,13 @@ def _find_doubled_backticks(text: str) -> list[int]:
             index += 1
             continue
         if index + 1 < length and text[index + 1] == backtick:
-            doubled_backticks.append(index)
-            doubled_backticks.append(index + 1)
+            doubled_backtick_positions.append(index)
+            doubled_backtick_positions.append(index + 1)
             index += 2
             continue
         index += 1
 
-    return doubled_backticks
+    return doubled_backtick_positions
 
 
 @functools.lru_cache(maxsize=128)
@@ -76,8 +80,7 @@ def is_inside_quotes(text: str, pos: int) -> Literal[False, 'single', 'double', 
     backslash = '\\'
 
     # scanning the string twice seems to be needed to handle doubled backticks
-    if backtick in text:
-        doubled_backtick_positions = _find_doubled_backticks(text)
+    doubled_backtick_positions = _find_doubled_backticks(text)
 
     length = len(text)
     if pos < 0:

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -752,3 +752,209 @@ def test_string_no_completion_spaces_inner_2(completer, complete_event):
     position = len('select "json ')
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
     assert result == []
+
+
+def test_backticked_column_completion(completer, complete_event):
+    text = 'select `Tim'
+    position = len(text)
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == [
+        # todo it would be nicer if the column names sorted to the top
+        Completion(text='`time`', start_position=-4),
+        Completion(text='`timediff`', start_position=-4),
+        Completion(text='`timestamp`', start_position=-4),
+        Completion(text='`time_format`', start_position=-4),
+        Completion(text='`time_to_sec`', start_position=-4),
+        Completion(text='`Time_zone_id`', start_position=-4),
+        Completion(text='`timestampadd`', start_position=-4),
+        Completion(text='`timestampdiff`', start_position=-4),
+        Completion(text='`datetime`', start_position=-4),
+        Completion(text='`optimize`', start_position=-4),
+        Completion(text='`optimizer_costs`', start_position=-4),
+        Completion(text='`utc_time`', start_position=-4),
+        Completion(text='`utc_timestamp`', start_position=-4),
+        Completion(text='`current_time`', start_position=-4),
+        Completion(text='`current_timestamp`', start_position=-4),
+        Completion(text='`localtime`', start_position=-4),
+        Completion(text='`localtimestamp`', start_position=-4),
+        Completion(text='`password_lock_time`', start_position=-4),
+    ]
+
+
+def test_backticked_column_completion_component(completer, complete_event):
+    text = 'select `com'
+    position = len(text)
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == [
+        # todo it would be nicer if "comment" sorted to the top because it is a column name,
+        #      and because it is a reserved word
+        Completion(text='`commit`', start_position=-4),
+        Completion(text='`comment`', start_position=-4),
+        Completion(text='`compact`', start_position=-4),
+        Completion(text='`compress`', start_position=-4),
+        Completion(text='`committed`', start_position=-4),
+        Completion(text='`component`', start_position=-4),
+        Completion(text='`completion`', start_position=-4),
+        Completion(text='`compressed`', start_position=-4),
+        Completion(text='`compression`', start_position=-4),
+        Completion(text='`column`', start_position=-4),
+        Completion(text='`column_format`', start_position=-4),
+        Completion(text='`column_name`', start_position=-4),
+        Completion(text='`columns`', start_position=-4),
+        Completion(text='`second_microsecond`', start_position=-4),
+        Completion(text='`uncommitted`', start_position=-4),
+    ]
+
+
+def test_backticked_column_completion_two_character(completer, complete_event):
+    text = 'select `f'
+    position = len(text)
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == [
+        # todo it would be nicer if the column name "first_name" sorted to the top
+        Completion(text='`for`', start_position=-2),
+        Completion(text='`from`', start_position=-2),
+        Completion(text='`fast`', start_position=-2),
+        Completion(text='`file`', start_position=-2),
+        Completion(text='`full`', start_position=-2),
+        Completion(text='`field`', start_position=-2),
+        Completion(text='`floor`', start_position=-2),
+        Completion(text='`fixed`', start_position=-2),
+        Completion(text='`float`', start_position=-2),
+        Completion(text='`false`', start_position=-2),
+        Completion(text='`fetch`', start_position=-2),
+        Completion(text='`first`', start_position=-2),
+        Completion(text='`flush`', start_position=-2),
+        Completion(text='`force`', start_position=-2),
+        Completion(text='`found`', start_position=-2),
+        Completion(text='`float4`', start_position=-2),
+        Completion(text='`float8`', start_position=-2),
+        Completion(text='`factor`', start_position=-2),
+        Completion(text='`faults`', start_position=-2),
+        Completion(text='`fields`', start_position=-2),
+        Completion(text='`filter`', start_position=-2),
+        Completion(text='`finish`', start_position=-2),
+        Completion(text='`format`', start_position=-2),
+        Completion(text='`follows`', start_position=-2),
+        Completion(text='`foreign`', start_position=-2),
+        Completion(text='`fulltext`', start_position=-2),
+        Completion(text='`function`', start_position=-2),
+        Completion(text='`from_days`', start_position=-2),
+        Completion(text='`following`', start_position=-2),
+        Completion(text='`first_name`', start_position=-2),
+        Completion(text='`found_rows`', start_position=-2),
+        Completion(text='`find_in_set`', start_position=-2),
+        Completion(text='`from_base64`', start_position=-2),
+        Completion(text='`first_value`', start_position=-2),
+        Completion(text='`foreign key`', start_position=-2),
+        Completion(text='`format_bytes`', start_position=-2),
+        Completion(text='`from_unixtime`', start_position=-2),
+        Completion(text='`file_block_size`', start_position=-2),
+        Completion(text='`format_pico_time`', start_position=-2),
+        Completion(text='`failed_login_attempts`', start_position=-2),
+        Completion(text='`left join`', start_position=-2),
+        Completion(text='`after`', start_position=-2),
+        Completion(text='`before`', start_position=-2),
+        Completion(text='`default`', start_position=-2),
+        Completion(text='`default_auth`', start_position=-2),
+        Completion(text='`definer`', start_position=-2),
+        Completion(text='`definition`', start_position=-2),
+        Completion(text='`enforced`', start_position=-2),
+        Completion(text='`if`', start_position=-2),
+        Completion(text='`infile`', start_position=-2),
+        Completion(text='`left`', start_position=-2),
+        Completion(text='`logfile`', start_position=-2),
+        Completion(text='`of`', start_position=-2),
+        Completion(text='`off`', start_position=-2),
+        Completion(text='`offset`', start_position=-2),
+        Completion(text='`outfile`', start_position=-2),
+        Completion(text='`profile`', start_position=-2),
+        Completion(text='`profiles`', start_position=-2),
+        Completion(text='`reference`', start_position=-2),
+        Completion(text='`references`', start_position=-2),
+    ]
+
+
+def test_backticked_column_completion_three_character(completer, complete_event):
+    text = 'select `fi'
+    position = len(text)
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == [
+        # todo it would be nicer if the column name "first_name" sorted to the top
+        Completion(text='`file`', start_position=-3),
+        Completion(text='`field`', start_position=-3),
+        Completion(text='`fixed`', start_position=-3),
+        Completion(text='`first`', start_position=-3),
+        Completion(text='`fields`', start_position=-3),
+        Completion(text='`filter`', start_position=-3),
+        Completion(text='`finish`', start_position=-3),
+        Completion(text='`first_name`', start_position=-3),
+        Completion(text='`find_in_set`', start_position=-3),
+        Completion(text='`first_value`', start_position=-3),
+        Completion(text='`file_block_size`', start_position=-3),
+        Completion(text='`definer`', start_position=-3),
+        Completion(text='`definition`', start_position=-3),
+        Completion(text='`failed_login_attempts`', start_position=-3),
+        Completion(text='`foreign`', start_position=-3),
+        Completion(text='`infile`', start_position=-3),
+        Completion(text='`logfile`', start_position=-3),
+        Completion(text='`outfile`', start_position=-3),
+        Completion(text='`profile`', start_position=-3),
+        Completion(text='`profiles`', start_position=-3),
+        Completion(text='`foreign key`', start_position=-3),
+    ]
+
+
+def test_backticked_column_completion_four_character(completer, complete_event):
+    text = 'select `fir'
+    position = len(text)
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == [
+        # todo it would be nicer if the column name "first_name" sorted to the top
+        Completion(text='`first`', start_position=-4),
+        Completion(text='`first_name`', start_position=-4),
+        Completion(text='`first_value`', start_position=-4),
+        Completion(text='`definer`', start_position=-4),
+        Completion(text='`filter`', start_position=-4),
+    ]
+
+
+def test_backticked_table_completion_required(completer, complete_event):
+    text = 'select ABC from `rév'
+    position = len(text)
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == [
+        Completion(text='`réveillé`', start_position=-4),
+    ]
+
+
+def test_backticked_table_completion_not_required(completer, complete_event):
+    text = 'select * from `t'
+    position = len(text)
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == [
+        Completion(text='`test`', start_position=-2),
+        Completion(text='`test 2`', start_position=-2),
+        Completion(text='`time_zone`', start_position=-2),
+        Completion(text='`time_zone_name`', start_position=-2),
+        Completion(text='`time_zone_transition`', start_position=-2),
+        Completion(text='`time_zone_leap_second`', start_position=-2),
+        Completion(text='`time_zone_transition_type`', start_position=-2),
+    ]
+
+
+def test_string_no_completion_backtick(completer, complete_event):
+    text = 'select * from "`t'
+    position = len(text)
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == []
+
+
+# todo this shouldn't suggest anything but the space resets the logic
+# and it completes on "bar" alone
+@pytest.mark.xfail
+def test_backticked_no_completion_spaces(completer, complete_event):
+    text = 'select * from `nocomplete bar'
+    position = len(text)
+    result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == []


### PR DESCRIPTION
## Description
Previously the behavior was a little janky: on the first character after a backtick, only identifiers which might _require_ a backtick were offered as suggestions (because, for instance, they matched reserved words).  Sometimes, that list would be empty, and no suggestions were offered.  Then, after typing a few more characters, rapidfuzz matching kicked in, and more suggestions were offered, with backticks off for the additional rapidfuzz suggestions.

Now the behavior is more consistent: if a backtick is typed, _all_ suggestions which could work in that place are offered, with uniform backticks on the suggestions, even if backticks are not required for the given identifier.

Of course, how early the suggestions are offered is still dependent on the `min_completion_trigger` option in `~/.myclirc`, so precise behavior in the above paragraph is conditional on having the default settings.

This PR still struggles on the case of spaces within the backtick, which I'd like to leave for future work, and an `xfail` test is included to represent the todo.

Fixes #1564 .

Changes

 * Tuck optimization check inside `_find_doubled_backticks()`, and make the optimization test for double instead of single backticks.
 * Remove function `unescape_name()`, which is unused, and seems wrongly named since it oriented towards strings rather than identifiers.
 * Let `find_matches(`) add backticks to all suggestions if backtick quoting is detected at the cursor.
 * Recast a variable name in `_find_doubled_backticks()`.

Per some comments in the tests, it would be nicer if column names sorted more strongly to the top in the `SELECT` context, but that is not new to these changes.

Another idea could be sorting to the top only those suggestions which require a backtick, when in the backtick context -- something for the future.

We also seem to be needlessly suggesting some generic keywords in the `SELECT` context, but that is also not new to these changes.  And if they are going to appear, it seems to make more sense to have them in backticks like the other suggestions, for the sake of uniformity.

Example of the new behavior:
<img width="1116" height="298" alt="new_backtick" src="https://github.com/user-attachments/assets/0ca3e769-c6bd-4a26-8e99-371a60cc23b1" />

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
