### PR TITLE
Fix regression accepting pathname completion

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Bug Fixes
 ---------
 * Watch command now returns correct time when ran as part of a multi-part query (#1565)
 * Don't diagnose free-entry sections such as `[favorite_queries]` in `--checkup`.
+* When accepting a filename completion, fill in leading `./` if given.
 
 
 1.54.1 (2026/02/17)

--- a/mycli/packages/parseutils.py
+++ b/mycli/packages/parseutils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Generator
+from typing import Any, Generator, Literal
 
 import sqlglot
 import sqlparse
@@ -34,7 +34,15 @@ def is_valid_connection_scheme(text: str) -> tuple[bool, str | None]:
         return True, None
 
 
-def last_word(text: str, include: str = "alphanum_underscore") -> str:
+def last_word(
+    text: str,
+    include: Literal[
+        'alphanum_underscore',
+        'many_punctuations',
+        'most_punctuations',
+        'all_punctuations',
+    ] = 'alphanum_underscore',
+) -> str:
     r"""
     Find the last word in a sentence.
 


### PR DESCRIPTION
## Description
Ensure that when accepting a pathname completion, the path as typed is accepted and not modified into an invalid path.  See #1557 for an image.  The regression is most evident when typing a path with a leading `./`.

Changes
 * Use a `Literal` for the `include` argument to `last_word()`
 * Create a separate length-measurement string for pathname completions, based on a different last-word cleanup regex.
 * Remove some todo comments from tests which are now resolved.

The logic of `length_based_on_path` assumes that if _any_ of the suggestions are pathnames, then _all_ of the suggestions are pathnames, which is currently true, and likely to remain true.

It would be nice to have a test which simulated accepting the first suggestion, to check that the filled-in completion does not get mangled, as happened before.

Let's say this fixes #1557, because it fixes the actual regression.  There are some other behaviors listed there which may not be desirable but were not caused by #1500 .  Let's open separate issues if we want to do further work on pathname completion.  For example, there is no pathname completion for `\edit <pathname>` at all.  And completion on `~/` does not seem to provide candidates.

I'm also not 100% clear on the subtleties of `last_word()`, and why the `alphanum_underscore` cleanup regex is the best one for this case, but it does work exactly right per @scottnemes 's diagnosis, and the relevant change was indeed introduced in #1500.  Maybe there should be a cleanup regex named `pathnames`, for clarity.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
