### PR TITLE
Don't attempt to diagnose free-entry sections in `--checkup`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming (TBD)
 Bug Fixes
 ---------
 * Watch command now returns correct time when ran as part of a multi-part query (#1565)
+* Don't diagnose free-entry sections such as `[favorite_queries]` in `--checkup`.
 
 
 1.54.1 (2026/02/17)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -2395,6 +2395,14 @@ def do_config_checkup(mycli: MyCli) -> None:
                 if section_name == 'colors' and item_name.startswith('sql.'):
                     # these are commented out in the package myclirc
                     continue
+                if section_name in [
+                    'favorite_queries',
+                    'init-commands',
+                    'alias_dsn',
+                    'alias_dsn.init-commands',
+                ]:
+                    # these are free-entry sections, so a comparison per item is not meaningful
+                    continue
                 transition_key = f'{indent}[{section_name}]\n{indent}{item_name}'
                 if transition_key in transitions:
                     continue


### PR DESCRIPTION
## Description
Sections such as `[favorite_queries]` are free-entry by the user, so a comparison to the distribution configuration per-item in those sections is not meaningful, and produces unhelpful output.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
