### PR TITLE
Let `--checkup` test for external executables

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 Upcoming (TBD)
 ==============
 
+Features
+---------
+* `--checkup` now checks for external executables.
+
+
 Bug Fixes
 ---------
 * Watch command now returns correct time when ran as part of a multi-part query (#1565)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -2356,6 +2356,16 @@ def do_config_checkup(mycli: MyCli) -> None:
     did_output_unsupported = False
     did_output_deprecated = False
 
+    print('\n### External executables:\n')
+    for executable in [
+        'less',
+        'fzf',
+    ]:
+        if shutil.which(executable):
+            print(f'The "{executable}" executable was found — good!')
+        else:
+            print(f'The recommended "{executable}" executable was not found — some functionality will suffer.')
+
     indent = '    '
     transitions = {
         f'{indent}[main]\n{indent}default_character_set': f'{indent}[connection]\n{indent}default_character_set',
@@ -2364,7 +2374,8 @@ def do_config_checkup(mycli: MyCli) -> None:
     reverse_transitions = {v: k for k, v in transitions.items()}
 
     if not list(mycli.config.keys()):
-        print('\nThe local ~/,myclirc is missing or empty.\n')
+        print('\n### Missing file:\n')
+        print('The local ~/,myclirc is missing or empty.\n')
         did_output_missing = True
     else:
         for section_name in mycli.config:
@@ -2432,7 +2443,8 @@ def do_config_checkup(mycli: MyCli) -> None:
             'For more info on supported features, see the commentary and defaults at:\n\n    * https://github.com/dbcli/mycli/blob/main/mycli/myclirc\n'
         )
     else:
-        print('User configuration all up to date!')
+        print('\n### Configuration:\n')
+        print('User configuration all up to date!\n')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Let `--checkup` test for external executables:

 * less
 * fzf

and rework some formatting of the `--checkup` output.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
