### PR TITLE
Reference non-yanked version of `cli_helpers` in `pyproject.toml`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ Bug Fixes
 * Don't diagnose free-entry sections such as `[favorite_queries]` in `--checkup`.
 * When accepting a filename completion, fill in leading `./` if given.
 
+Internal
+--------
+* Bump `cli_helpers` to non-yanked version.
+
 
 1.54.1 (2026/02/17)
 ==============

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "sqlparse>=0.3.0,<0.6.0",
     "sqlglot[rs] == 27.*",
     "configobj ~= 5.0.9",
-    "cli_helpers[styles] ~= 2.10.0",
+    "cli_helpers[styles] ~= 2.10.1",
     "pyperclip ~= 1.11.0",
     "pycryptodomex ~= 3.23.0",
     "pyfzf ~= 0.3.1",


### PR DESCRIPTION
## Description
This changes little in practice since the `~=` operator is used, but it makes better sense not to point to a yanked version of a dependency.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
