### PR TITLE
Make the `--ssl-capath` CLI argument a directory

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Bug Fixes
+---------
+* Make `--ssl-capath` argument a directory.
+
+
 1.55.0 (2026/02/20)
 ==============
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1663,7 +1663,7 @@ class MyCli:
 )
 @click.option("--ssl/--no-ssl", "ssl_enable", default=None, help="Enable SSL for connection (automatically enabled with other flags).")
 @click.option("--ssl-ca", help="CA file in PEM format.", type=click.Path(exists=True))
-@click.option("--ssl-capath", help="CA directory.")
+@click.option("--ssl-capath", help="CA directory.", type=click.Path(exists=True, file_okay=False, dir_okay=True))
 @click.option("--ssl-cert", help="X509 cert in PEM format.", type=click.Path(exists=True))
 @click.option("--ssl-key", help="X509 key in PEM format.", type=click.Path(exists=True))
 @click.option("--ssl-cipher", help="SSL cipher to use.")


### PR DESCRIPTION
## Description

This influences the helpdoc, which now will show

    --ssl-capath DIRECTORY

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
