### PR TITLE
Liberally accept literal DSN arguments to `--dsn`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 Upcoming (TBD)
 ==============
 
+Features
+---------
+* Let the `--dsn` argument accept literal DSNs as well as aliases.
+
+
 Bug Fixes
 ---------
 * Make `--ssl-capath` argument a directory.

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -912,6 +912,23 @@ def test_dsn(monkeypatch):
         and MockMyCli.connect_args["ssl"]["enable"] is True
     )
 
+    # Accept a literal DSN with the --dsn flag (not only an alias)
+    result = runner.invoke(
+        mycli.main.cli,
+        args=[
+            '--dsn',
+            'mysql://dsn_user:dsn_passwd@dsn_host:6/dsn_database',
+        ],
+    )
+    assert result.exit_code == 0, result.output + ' ' + str(result.exception)
+    assert (
+        MockMyCli.connect_args['user'] == 'dsn_user'
+        and MockMyCli.connect_args['passwd'] == 'dsn_passwd'
+        and MockMyCli.connect_args['host'] == 'dsn_host'
+        and MockMyCli.connect_args['port'] == 6
+        and MockMyCli.connect_args['database'] == 'dsn_database'
+    )
+
 
 def test_ssh_config(monkeypatch):
     # Setup classes to mock mycli.main.MyCli


### PR DESCRIPTION
## Description
Forgive the user for thinking that `--dsn` can accept a literal DSN in addition to an alias.

Internally, recast the confusing variable name `dsn` to `dsn_alias`.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
