### PR TITLE
Make `--character-set` an alias for `--charset` at the CLI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming (TBD)
 Features
 ---------
 * Let the `--dsn` argument accept literal DSNs as well as aliases.
+* Accept `--character-set` as an alias for `--charset` at the CLI.
 
 
 Bug Fixes

--- a/mycli/TIPS
+++ b/mycli/TIPS
@@ -16,7 +16,7 @@ the --throttle option helps slow down queries in batch mode!
 
 the --password-file option can be used with a FIFO to avoid saving creds to a file!
 
-the --charset option sets the character set for a single session!
+the --character-set option sets the character set for a single session!
 
 the --unbuffered flag can save memory when in batch mode!
 

--- a/mycli/completion_refresher.py
+++ b/mycli/completion_refresher.py
@@ -65,7 +65,7 @@ class CompletionRefresher:
             e.host,
             e.port,
             e.socket,
-            e.charset,
+            e.character_set,
             e.local_infile,
             e.ssl,
             e.ssh_user,

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -532,7 +532,7 @@ class MyCli:
         host: str | None = "",
         port: str | int | None = "",
         socket: str | None = "",
-        charset: str | None = "",
+        character_set: str | None = "",
         local_infile: bool = False,
         ssl: dict[str, Any] | None = None,
         ssh_user: str | None = "",
@@ -590,17 +590,17 @@ class MyCli:
         # default_character_set doesn't check in self.config_without_package_defaults, because the
         # option already existed before the my.cnf deprecation.  For the same reason,
         # default_character_set can be in [connection] or [main].
-        if not charset:
+        if not character_set:
             if 'default_character_set' in self.config['connection']:
-                charset = self.config['connection']['default_character_set']
+                character_set = self.config['connection']['default_character_set']
             elif 'default_character_set' in self.config['main']:
-                charset = self.config['main']['default_character_set']
+                character_set = self.config['main']['default_character_set']
             elif 'default_character_set' in cnf:
-                charset = cnf['default_character_set']
+                character_set = cnf['default_character_set']
             elif 'default-character-set' in cnf:
-                charset = cnf['default-character-set']
-        if not charset:
-            charset = 'utf8mb4'
+                character_set = cnf['default-character-set']
+        if not character_set:
+            character_set = 'utf8mb4'
 
         # Favor whichever local_infile option is set.
         use_local_infile = False
@@ -683,7 +683,7 @@ class MyCli:
                     host,
                     int_port,
                     socket,
-                    charset,
+                    character_set,
                     use_local_infile,
                     ssl_config_or_none,
                     ssh_user,
@@ -704,7 +704,7 @@ class MyCli:
                             host,
                             int_port,
                             socket,
-                            charset,
+                            character_set,
                             use_local_infile,
                             None,
                             ssh_user,
@@ -1712,7 +1712,7 @@ class MyCli:
 @click.option(
     "--unbuffered", is_flag=True, help="Instead of copying every row of data into a buffer, fetch rows as needed, to save memory."
 )
-@click.option("--charset", type=str, help="Character set for MySQL session.")
+@click.option("--character-set", "--charset", type=str, help="Character set for MySQL session.")
 @click.option(
     "--password-file", type=click.Path(), help="File or FIFO path containing the password to connect to the db if not specified otherwise."
 )
@@ -1777,7 +1777,7 @@ def cli(
     ssh_warning_off: bool | None,
     init_command: str | None,
     unbuffered: bool | None,
-    charset: str | None,
+    character_set: str | None,
     password_file: str | None,
     noninteractive: bool,
     batch_format: str | None,
@@ -2165,7 +2165,7 @@ def cli(
         ssh_key_filename=ssh_key_filename,
         init_command=combined_init_cmd,
         unbuffered=unbuffered,
-        charset=charset,
+        character_set=character_set,
         use_keyring=use_keyring,
         reset_keyring=reset_keyring,
     )

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -153,7 +153,7 @@ use_keyring = False
 
 [connection]
 
-# character set for connections without --charset being set
+# character set for connections without --character-set being set
 default_character_set = utf8mb4
 
 # whether to enable LOAD DATA LOCAL INFILE for connections without --local-infile being set

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -156,7 +156,7 @@ class SQLExecute:
         host: str | None,
         port: int | None,
         socket: str | None,
-        charset: str | None,
+        character_set: str | None,
         local_infile: bool | None,
         ssl: dict[str, Any] | None,
         ssh_user: str | None,
@@ -173,7 +173,7 @@ class SQLExecute:
         self.host = host
         self.port = port
         self.socket = socket
-        self.charset = charset
+        self.character_set = character_set
         self.local_infile = local_infile
         self.ssl = ssl
         self.server_info: ServerInfo | None = None
@@ -196,7 +196,7 @@ class SQLExecute:
         host: str | None = None,
         port: int | None = None,
         socket: str | None = None,
-        charset: str | None = None,
+        character_set: str | None = None,
         local_infile: bool | None = None,
         ssl: dict[str, Any] | None = None,
         ssh_host: str | None = None,
@@ -213,7 +213,7 @@ class SQLExecute:
         host = host if host is not None else self.host
         port = port if port is not None else self.port
         socket = socket if socket is not None else self.socket
-        charset = charset if charset is not None else self.charset
+        character_set = character_set if character_set is not None else self.character_set
         local_infile = local_infile if local_infile is not None else self.local_infile
         ssl = ssl if ssl is not None else self.ssl
         ssh_user = ssh_user if ssh_user is not None else self.ssh_user
@@ -230,7 +230,7 @@ class SQLExecute:
             "\thost: %r"
             "\tport: %r"
             "\tsocket: %r"
-            "\tcharset: %r"
+            "\tcharacter_set: %r"
             "\tlocal_infile: %r"
             "\tssl: %r"
             "\tssh_user: %r"
@@ -245,7 +245,7 @@ class SQLExecute:
             host,
             port,
             socket,
-            charset,
+            character_set,
             local_infile,
             ssl,
             ssh_user,
@@ -285,7 +285,7 @@ class SQLExecute:
             port=port or 0,
             unix_socket=socket,
             use_unicode=True,
-            charset=charset or '',
+            charset=character_set or '',
             autocommit=True,
             client_flag=client_flag,
             local_infile=local_infile or False,
@@ -331,7 +331,7 @@ class SQLExecute:
         self.host = host
         self.port = port
         self.socket = socket
-        self.charset = charset
+        self.character_set = character_set
         self.ssl = ssl
         self.init_command = init_command
         self.unbuffered = unbuffered

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,7 +3,7 @@
 import pytest
 
 import mycli.sqlexecute
-from test.utils import CHARSET, DATABASE, HOST, PASSWORD, PORT, SSH_HOST, SSH_PORT, SSH_USER, USER, create_db, db_connection
+from test.utils import CHARACTER_SET, DATABASE, HOST, PASSWORD, PORT, SSH_HOST, SSH_PORT, SSH_USER, USER, create_db, db_connection
 
 
 @pytest.fixture(scope="function")
@@ -30,7 +30,7 @@ def executor(connection):
         password=PASSWORD,
         port=PORT,
         socket=None,
-        charset=CHARSET,
+        character_set=CHARACTER_SET,
         local_infile=False,
         ssl=None,
         ssh_user=SSH_USER,

--- a/test/myclirc
+++ b/test/myclirc
@@ -151,7 +151,7 @@ use_keyring = False
 
 [connection]
 
-# character set for connections without --charset being set
+# character set for connections without --character-set being set
 default_character_set = utf8mb4
 
 # whether to enable LOAD DATA LOCAL INFILE for connections without --local-infile being set

--- a/test/utils.py
+++ b/test/utils.py
@@ -16,14 +16,14 @@ PASSWORD = os.getenv("PYTEST_PASSWORD")
 USER = os.getenv("PYTEST_USER", "root")
 HOST = os.getenv("PYTEST_HOST", "localhost")
 PORT = int(os.getenv("PYTEST_PORT", "3306"))
-CHARSET = os.getenv("PYTEST_CHARSET", "utf8mb4")
+CHARACTER_SET = os.getenv("PYTEST_CHARSET", "utf8mb4")
 SSH_USER = os.getenv("PYTEST_SSH_USER", None)
 SSH_HOST = os.getenv("PYTEST_SSH_HOST", None)
 SSH_PORT = int(os.getenv("PYTEST_SSH_PORT", "22"))
 
 
 def db_connection(dbname=None):
-    conn = pymysql.connect(user=USER, host=HOST, port=PORT, database=dbname, password=PASSWORD, charset=CHARSET, local_infile=False)
+    conn = pymysql.connect(user=USER, host=HOST, port=PORT, database=dbname, password=PASSWORD, charset=CHARACTER_SET, local_infile=False)
     conn.autocommit = True
     return conn
 


### PR DESCRIPTION
## Description
Make `--character-set` an alias for `--charset` at the CLI, for alignment with the spelling of the equivalent option in `~/.myclirc`.

Internally, refactor to use `character_set` instead of `charset` wherever possible.  The form `charset` is limited to the invocation of `pymysql's connect()`.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
