### PR TITLE
Accept `socket` as a DSN query parameter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Features
 * Let the `--dsn` argument accept literal DSNs as well as aliases.
 * Accept `--character-set` as an alias for `--charset` at the CLI.
 * Add SSL/TLS version to `status` output.
+* Accept `socket` as a DSN query parameter.
 
 
 Bug Fixes

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1993,6 +1993,8 @@ def cli(
         if params := dsn_params.get('ssl_verify_server_cert'):
             ssl_verify_server_cert = ssl_verify_server_cert or (params[0].lower() == 'true')
             ssl_enable = True
+        if params := dsn_params.get('socket'):
+            socket = socket or params[0]
 
     ssl_mode = ssl_mode or mycli.ssl_mode  # cli option or config option
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -929,6 +929,20 @@ def test_dsn(monkeypatch):
         and MockMyCli.connect_args['database'] == 'dsn_database'
     )
 
+    # accept socket as a query parameter
+    result = runner.invoke(
+        mycli.main.cli,
+        args=[
+            'mysql://dsn_user:dsn_passwd@localhost/dsn_database?socket=mysql.sock',
+        ],
+    )
+    assert result.exit_code == 0, result.output + ' ' + str(result.exception)
+    assert MockMyCli.connect_args['user'] == 'dsn_user'
+    assert MockMyCli.connect_args['passwd'] == 'dsn_passwd'
+    assert MockMyCli.connect_args['host'] == 'localhost'
+    assert MockMyCli.connect_args['database'] == 'dsn_database'
+    assert MockMyCli.connect_args['socket'] == 'mysql.sock'
+
 
 def test_ssh_config(monkeypatch):
     # Setup classes to mock mycli.main.MyCli


### PR DESCRIPTION
## Description

`socket` as a query parameter instead of `--socket` as a CLI flag allows it to be saved in a DSN alias.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
