### PR TITLE
Accept `ssl_mode` in DSN URI query parameters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ Features
 * Accept `--character-set` as an alias for `--charset` at the CLI.
 * Add SSL/TLS version to `status` output.
 * Accept `socket` as a DSN query parameter.
+* Accept new-style `ssl_mode` in DSN URI query parameters, to match CLI argument.
 
 
 Bug Fixes

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1874,7 +1874,7 @@ def cli(
     if ssl_enable is not None:
         click.secho(
             "Warning: The --ssl/--no-ssl CLI options are deprecated and will be removed in a future release. "
-            "Please use the ssl_mode config or --ssl-mode CLI options instead. "
+            "Please use the \"default_ssl_mode\" config option or --ssl-mode CLI flag instead. "
             "See issue https://github.com/dbcli/mycli/issues/1507",
             err=True,
             fg="yellow",
@@ -1971,28 +1971,38 @@ def cli(
             dsn_params = {}
 
         if params := dsn_params.get('ssl'):
-            ssl_enable = ssl_enable or (params[0].lower() == 'true')
+            click.secho(
+                'Warning: The "ssl" DSN URI parameter is deprecated and will be removed in a future release. '
+                'Please use the "ssl_mode" parameter instead. '
+                'See issue https://github.com/dbcli/mycli/issues/1507',
+                err=True,
+                fg='yellow',
+            )
+            if params[0].lower() == 'true':
+                ssl_mode = 'on'
+        if params := dsn_params.get('ssl_mode'):
+            ssl_mode = ssl_mode or params[0]
         if params := dsn_params.get('ssl_ca'):
             ssl_ca = ssl_ca or params[0]
-            ssl_enable = True
+            ssl_mode = ssl_mode or 'on'
         if params := dsn_params.get('ssl_capath'):
             ssl_capath = ssl_capath or params[0]
-            ssl_enable = True
+            ssl_mode = ssl_mode or 'on'
         if params := dsn_params.get('ssl_cert'):
             ssl_cert = ssl_cert or params[0]
-            ssl_enable = True
+            ssl_mode = ssl_mode or 'on'
         if params := dsn_params.get('ssl_key'):
             ssl_key = ssl_key or params[0]
-            ssl_enable = True
+            ssl_mode = ssl_mode or 'on'
         if params := dsn_params.get('ssl_cipher'):
             ssl_cipher = ssl_cipher or params[0]
-            ssl_enable = True
+            ssl_mode = ssl_mode or 'on'
         if params := dsn_params.get('tls_version'):
             tls_version = tls_version or params[0]
-            ssl_enable = True
+            ssl_mode = ssl_mode or 'on'
         if params := dsn_params.get('ssl_verify_server_cert'):
             ssl_verify_server_cert = ssl_verify_server_cert or (params[0].lower() == 'true')
-            ssl_enable = True
+            ssl_mode = ssl_mode or 'on'
         if params := dsn_params.get('socket'):
             socket = socket or params[0]
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -882,7 +882,7 @@ def test_dsn(monkeypatch):
     )
 
     # Use a DSN with query parameters
-    result = runner.invoke(mycli.main.cli, args=["mysql://dsn_user:dsn_passwd@dsn_host:6/dsn_database?ssl=True"])
+    result = runner.invoke(mycli.main.cli, args=["mysql://dsn_user:dsn_passwd@dsn_host:6/dsn_database?ssl_mode=off"])
     assert result.exit_code == 0, result.output + " " + str(result.exception)
     assert (
         MockMyCli.connect_args["user"] == "dsn_user"
@@ -890,27 +890,25 @@ def test_dsn(monkeypatch):
         and MockMyCli.connect_args["host"] == "dsn_host"
         and MockMyCli.connect_args["port"] == 6
         and MockMyCli.connect_args["database"] == "dsn_database"
-        and MockMyCli.connect_args["ssl"]["enable"] is True
+        and MockMyCli.connect_args["ssl"] is None
     )
 
-    # When a user uses a DSN with query parameters, and used command line
-    # arguments, use the command line arguments.
+    # When a user uses a DSN with query parameters, and also used command line
+    # arguments, prefer the command line arguments.
     result = runner.invoke(
         mycli.main.cli,
         args=[
-            "mysql://dsn_user:dsn_passwd@dsn_host:6/dsn_database?ssl=False",
-            "--ssl",
+            'mysql://dsn_user:dsn_passwd@dsn_host:6/dsn_database?ssl_mode=off',
+            '--ssl-mode=on',
         ],
     )
-    assert result.exit_code == 0, result.output + " " + str(result.exception)
-    assert (
-        MockMyCli.connect_args["user"] == "dsn_user"
-        and MockMyCli.connect_args["passwd"] == "dsn_passwd"
-        and MockMyCli.connect_args["host"] == "dsn_host"
-        and MockMyCli.connect_args["port"] == 6
-        and MockMyCli.connect_args["database"] == "dsn_database"
-        and MockMyCli.connect_args["ssl"]["enable"] is True
-    )
+    assert result.exit_code == 0, result.output + ' ' + str(result.exception)
+    assert MockMyCli.connect_args['user'] == 'dsn_user'
+    assert MockMyCli.connect_args['passwd'] == 'dsn_passwd'
+    assert MockMyCli.connect_args['host'] == 'dsn_host'
+    assert MockMyCli.connect_args['port'] == 6
+    assert MockMyCli.connect_args['database'] == 'dsn_database'
+    assert MockMyCli.connect_args['ssl']['mode'] == 'on'
 
     # Accept a literal DSN with the --dsn flag (not only an alias)
     result = runner.invoke(


### PR DESCRIPTION
## Description
 * deprecate `ssl` in DSN query parameters (as in CLI options)
 * accept `ssl_mode` in DSN query parameters
 * refactor implicit SSL-enable logic to use `ssl_mode`
 
Incidentally

 * fix CLI option deprecation warning to refer to `default_ssl_mode` (adding prefix "default_")
 * update tests which did not account for SSL becoming on by default

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
