### PR TITLE
Fully deprecate the built-in SSH functionality

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ Features
 * Add SSL/TLS version to `status` output.
 * Accept `socket` as a DSN query parameter.
 * Accept new-style `ssl_mode` in DSN URI query parameters, to match CLI argument.
+* Fully deprecate the built-in SSH functionality.
 
 
 Bug Fixes

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1883,8 +1883,8 @@ def cli(
     # ssh_port and ssh_config_path have truthy defaults and are not included
     if any([ssh_user, ssh_host, ssh_password, ssh_key_filename, list_ssh_config, ssh_config_host]) and not ssh_warning_off:
         click.secho(
-            "Warning: The built-in SSH functionality is soft deprecated and may be removed in a future release. "
-            "Please discuss or vote on this at https://github.com/dbcli/mycli/issues/1464",
+            "Warning: The built-in SSH functionality is deprecated and will be removed in a future release. "
+            "See Issue https://github.com/dbcli/mycli/issues/1464",
             err=True,
             fg="red",
         )


### PR DESCRIPTION
## Description
A month after the soft deprecation notice was released, there has been no discussion on the linked GitHub Issue #1464.

For this and other reasons, it very much seems that nobody is using these features.

Transition here from a "soft" to a "hard" deprecation, changing the notice to say that this featureset will be removed.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
