### PR TITLE
`--keepalive-ticks` CLI option and DSN parameter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Features
 * Accept `socket` as a DSN query parameter.
 * Accept new-style `ssl_mode` in DSN URI query parameters, to match CLI argument.
 * Fully deprecate the built-in SSH functionality.
+* Let `--keepalive-ticks` be set per-connection, as a CLI option or DSN parameter.
 
 
 Bug Fixes

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -163,6 +163,7 @@ class MyCli:
         self.toolbar_error_message: str | None = None
         self.prompt_app: PromptSession | None = None
         self._keepalive_counter = 0
+        self.keepalive_ticks: int | None = 0
 
         # self.cnf_files is a class variable that stores the list of mysql
         # config files to read in at launch.
@@ -544,6 +545,7 @@ class MyCli:
         unbuffered: bool | None = None,
         use_keyring: bool | None = None,
         reset_keyring: bool | None = None,
+        keepalive_ticks: int | None = None,
     ) -> None:
         cnf = {
             "database": None,
@@ -572,6 +574,7 @@ class MyCli:
         port = port or cnf["port"]
         ssl_config: dict[str, Any] = ssl or {}
         user_connection_config = self.config_without_package_defaults.get('connection', {})
+        self.keepalive_ticks = keepalive_ticks
 
         int_port = port and int(port)
         if not int_port:
@@ -1004,10 +1007,12 @@ class MyCli:
 
             Example at https://github.com/prompt-toolkit/python-prompt-toolkit/blob/main/examples/prompts/inputhook.py
             """
-            if self.default_keepalive_ticks < 1:
+            if self.keepalive_ticks is None:
+                return
+            if self.keepalive_ticks < 1:
                 return
             self._keepalive_counter += 1
-            if self._keepalive_counter > self.default_keepalive_ticks:
+            if self._keepalive_counter > self.keepalive_ticks:
                 self._keepalive_counter = 0
                 self.logger.debug('keepalive ping')
                 try:
@@ -1018,7 +1023,7 @@ class MyCli:
                     self.logger.debug('keepalive ping error %r', e)
 
         def one_iteration(text: str | None = None) -> None:
-            inputhook = keepalive_hook if self.default_keepalive_ticks >= 1 else None
+            inputhook = keepalive_hook if self.keepalive_ticks and self.keepalive_ticks >= 1 else None
             if text is None:
                 try:
                     assert self.prompt_app is not None
@@ -1729,6 +1734,11 @@ class MyCli:
     default=None,
     help='Store and retrieve passwords from the system keyring: true/false/reset.',
 )
+@click.option(
+    '--keepalive-ticks',
+    type=int,
+    help='Send regular keepalive pings to the connection, roughly every <int> seconds.',
+)
 @click.option("--checkup", is_flag=True, help="Run a checkup on your config file.")
 @click.pass_context
 def cli(
@@ -1784,6 +1794,7 @@ def cli(
     throttle: float,
     use_keyring_cli_opt: str | None,
     checkup: bool,
+    keepalive_ticks: int | None,
 ) -> None:
     """A MySQL terminal client with auto-completion and syntax highlighting.
 
@@ -2005,7 +2016,11 @@ def cli(
             ssl_mode = ssl_mode or 'on'
         if params := dsn_params.get('socket'):
             socket = socket or params[0]
+        if params := dsn_params.get('keepalive_ticks'):
+            if keepalive_ticks is None:
+                keepalive_ticks = int(params[0])
 
+    keepalive_ticks = keepalive_ticks if keepalive_ticks is not None else mycli.default_keepalive_ticks
     ssl_mode = ssl_mode or mycli.ssl_mode  # cli option or config option
 
     # if there is a mismatch between the ssl_mode value and other sources of ssl config, show a warning
@@ -2180,6 +2195,7 @@ def cli(
         character_set=character_set,
         use_keyring=use_keyring,
         reset_keyring=reset_keyring,
+        keepalive_ticks=keepalive_ticks,
     )
 
     if combined_init_cmd:

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -754,6 +754,9 @@ def test_dsn(monkeypatch):
         config = {
             "main": {},
             "alias_dsn": {},
+            "connection": {
+                "default_keepalive_ticks": 0,
+            },
         }
 
         def __init__(self, **args):
@@ -763,6 +766,7 @@ def test_dsn(monkeypatch):
             self.redirect_formatter = Formatter()
             self.ssl_mode = "auto"
             self.my_cnf = {"client": {}, "mysqld": {}}
+            self.default_keepalive_ticks = 0
 
         def connect(self, **args):
             MockMyCli.connect_args = args
@@ -820,6 +824,9 @@ def test_dsn(monkeypatch):
     MockMyCli.config = {
         "main": {},
         "alias_dsn": {"test": "mysql://alias_dsn_user:alias_dsn_passwd@alias_dsn_host:4/alias_dsn_database"},
+        "connection": {
+            "default_keepalive_ticks": 0,
+        },
     }
     MockMyCli.connect_args = None
 
@@ -838,6 +845,9 @@ def test_dsn(monkeypatch):
     MockMyCli.config = {
         "main": {},
         "alias_dsn": {"test": "mysql://alias_dsn_user:alias_dsn_passwd@alias_dsn_host:4/alias_dsn_database"},
+        "connection": {
+            "default_keepalive_ticks": 0,
+        },
     }
     MockMyCli.connect_args = None
 
@@ -895,6 +905,24 @@ def test_dsn(monkeypatch):
 
     # When a user uses a DSN with query parameters, and also used command line
     # arguments, prefer the command line arguments.
+    MockMyCli.connect_args = None
+    MockMyCli.config = {
+        "main": {},
+        "alias_dsn": {},
+        "connection": {
+            "default_keepalive_ticks": 0,
+        },
+    }
+
+    # keepalive_ticks as a query parameter
+    result = runner.invoke(mycli.main.cli, args=["mysql://dsn_user:dsn_passwd@dsn_host:6/dsn_database?keepalive_ticks=30"])
+    assert result.exit_code == 0, result.output + " " + str(result.exception)
+    assert MockMyCli.connect_args["keepalive_ticks"] == 30
+
+    MockMyCli.connect_args = None
+
+    # When a user uses a DSN with query parameters, and also used command line
+    # arguments, use the command line arguments.
     result = runner.invoke(
         mycli.main.cli,
         args=[
@@ -958,6 +986,9 @@ def test_ssh_config(monkeypatch):
         config = {
             "main": {},
             "alias_dsn": {},
+            "connection": {
+                "default_keepalive_ticks": 0,
+            },
         }
 
         def __init__(self, **args):
@@ -967,6 +998,7 @@ def test_ssh_config(monkeypatch):
             self.redirect_formatter = Formatter()
             self.ssl_mode = "auto"
             self.my_cnf = {"client": {}, "mysqld": {}}
+            self.default_keepalive_ticks = 0
 
         def connect(self, **args):
             MockMyCli.connect_args = args


### PR DESCRIPTION
## Description

This allows the user to set keepalives on a per-connection basis.  The motivation is a persisted DSN, but it seems inconsistent not to include the CLI flag.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
