### PR TITLE
Check the socket property more directly in `status`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ Bug Fixes
 ---------
 * Make `--ssl-capath` argument a directory.
 * Allow users to use empty passwords without prompting or any configuration (#1584).
+* Check the existence of a socket more directly in `status`.
 
 
 1.55.0 (2026/02/20)

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -128,7 +128,7 @@ def status(cur: Cursor, **_) -> list[SQLResult]:
     output.append(("Protocol version:", variables["protocol_version"]))
     output.append(('SSL/TLS version:', get_ssl_version(cur)))
 
-    if "unix" in cur.connection.host_info.lower():
+    if getattr(cur.connection, 'unix_socket', None) is not None:
         host_info = cur.connection.host_info
     else:
         host_info = f'{cur.connection.host} via TCP/IP'


### PR DESCRIPTION
## Description
Instead of a string search, check that the connection has a `unix_socket` property.  Surely this is more robust.

Isn't it?

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
