### PR TITLE
Accept `character_set` as a DSN query parameter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Features
 * Accept new-style `ssl_mode` in DSN URI query parameters, to match CLI argument.
 * Fully deprecate the built-in SSH functionality.
 * Let `--keepalive-ticks` be set per-connection, as a CLI option or DSN parameter.
+* Accept `character_set` as a DSN query parameter.
 
 
 Bug Fixes

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -2019,6 +2019,8 @@ def cli(
         if params := dsn_params.get('keepalive_ticks'):
             if keepalive_ticks is None:
                 keepalive_ticks = int(params[0])
+        if params := dsn_params.get('character_set'):
+            character_set = character_set or params[0]
 
     keepalive_ticks = keepalive_ticks if keepalive_ticks is not None else mycli.default_keepalive_ticks
     ssl_mode = ssl_mode or mycli.ssl_mode  # cli option or config option

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -969,6 +969,35 @@ def test_dsn(monkeypatch):
     assert MockMyCli.connect_args['database'] == 'dsn_database'
     assert MockMyCli.connect_args['socket'] == 'mysql.sock'
 
+    # accept character_set as a query parameter
+    result = runner.invoke(
+        mycli.main.cli,
+        args=[
+            'mysql://dsn_user:dsn_passwd@localhost/dsn_database?character_set=latin1',
+        ],
+    )
+    assert result.exit_code == 0, result.output + ' ' + str(result.exception)
+    assert MockMyCli.connect_args['user'] == 'dsn_user'
+    assert MockMyCli.connect_args['passwd'] == 'dsn_passwd'
+    assert MockMyCli.connect_args['host'] == 'localhost'
+    assert MockMyCli.connect_args['database'] == 'dsn_database'
+    assert MockMyCli.connect_args['character_set'] == 'latin1'
+
+    # --character_set overrides character_set as a query parameter
+    result = runner.invoke(
+        mycli.main.cli,
+        args=[
+            'mysql://dsn_user:dsn_passwd@localhost/dsn_database?character_set=latin1',
+            '--character-set=utf8mb3',
+        ],
+    )
+    assert result.exit_code == 0, result.output + ' ' + str(result.exception)
+    assert MockMyCli.connect_args['user'] == 'dsn_user'
+    assert MockMyCli.connect_args['passwd'] == 'dsn_passwd'
+    assert MockMyCli.connect_args['host'] == 'localhost'
+    assert MockMyCli.connect_args['database'] == 'dsn_database'
+    assert MockMyCli.connect_args['character_set'] == 'utf8mb3'
+
 
 def test_ssh_config(monkeypatch):
     # Setup classes to mock mycli.main.MyCli


### PR DESCRIPTION
## Description

Accept `character_set` as a DSN query parameter, which still can be overridden by the CLI argument `--character-set`.

The motivation is persisting DSNs with all connection parameters.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
