### PR TITLE
Let `--ssl_mode=auto` prefer SSL only for TCP/IP

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ Features
 * Fully deprecate the built-in SSH functionality.
 * Let `--keepalive-ticks` be set per-connection, as a CLI option or DSN parameter.
 * Accept `character_set` as a DSN query parameter.
+* Don't attempt SSL for local socket connections when in "auto" SSL mode.
 
 
 Bug Fixes

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1663,7 +1663,7 @@ class MyCli:
 @click.option(
     "--ssl-mode",
     "ssl_mode",
-    help="Set desired SSL behavior. auto=preferred, on=required, off=off.",
+    help="Set desired SSL behavior. auto=preferred if TCP/IP, on=required, off=off.",
     type=click.Choice(["auto", "on", "off"]),
 )
 @click.option("--ssl/--no-ssl", "ssl_enable", default=None, help="Enable SSL for connection (automatically enabled with other flags).")
@@ -2038,19 +2038,22 @@ def cli(
     # configure SSL if ssl_mode is auto/on or if
     # ssl_enable = True (from --ssl or a DSN URI) and ssl_mode is None
     if ssl_mode in ("auto", "on") or (ssl_enable and ssl_mode is None):
-        ssl = {
-            "mode": ssl_mode,
-            "enable": ssl_enable,
-            "ca": ssl_ca and os.path.expanduser(ssl_ca),
-            "cert": ssl_cert and os.path.expanduser(ssl_cert),
-            "key": ssl_key and os.path.expanduser(ssl_key),
-            "capath": ssl_capath,
-            "cipher": ssl_cipher,
-            "tls_version": tls_version,
-            "check_hostname": ssl_verify_server_cert,
-        }
-        # remove empty ssl options
-        ssl = {k: v for k, v in ssl.items() if v is not None}
+        if socket and ssl_mode == 'auto':
+            ssl = None
+        else:
+            ssl = {
+                "mode": ssl_mode,
+                "enable": ssl_enable,
+                "ca": ssl_ca and os.path.expanduser(ssl_ca),
+                "cert": ssl_cert and os.path.expanduser(ssl_cert),
+                "key": ssl_key and os.path.expanduser(ssl_key),
+                "capath": ssl_capath,
+                "cipher": ssl_cipher,
+                "tls_version": tls_version,
+                "check_hostname": ssl_verify_server_cert,
+            }
+            # remove empty ssl options
+            ssl = {k: v for k, v in ssl.items() if v is not None}
     else:
         ssl = None
 

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -165,9 +165,11 @@ default_keepalive_ticks = 0
 
 # Sets the desired behavior for handling secure connections to the database server.
 # Possible values:
-# auto = SSL is preferred. Will attempt to connect via SSL, but will fallback to cleartext as needed.
-# on = SSL is required. Will attempt to connect via SSL and will fail if a secure connection is not established.
-# off = do not use SSL. Will fail if the server requires a secure connection.
+# auto = SSL is preferred for TCP/IP connections. Will attempt to connect via SSL, but will fall
+#        back to cleartext as needed.  Will not attempt to connect with SSL over local sockets.
+# on   = SSL is required. Will attempt to connect via SSL even on a local socket, and will fail if
+#        a secure connection is not established.
+# off  = do not use SSL. Will fail if the server requires a secure connection.
 default_ssl_mode = auto
 
 # SSL CA file for connections without --ssl-ca being set

--- a/test/myclirc
+++ b/test/myclirc
@@ -163,9 +163,11 @@ default_keepalive_ticks = 0
 
 # Sets the desired behavior for handling secure connections to the database server.
 # Possible values:
-# auto = SSL is preferred. Will attempt to connect via SSL, but will fallback to cleartext as needed.
-# on = SSL is required. Will attempt to connect via SSL and will fail if a secure connection is not established.
-# off = do not use SSL. Will fail if the server requires a secure connection.
+# auto = SSL is preferred for TCP/IP connections. Will attempt to connect via SSL, but will fall
+#        back to cleartext as needed.  Will not attempt to connect with SSL over local sockets.
+# on   = SSL is required. Will attempt to connect via SSL even on a local socket, and will fail if
+#        a secure connection is not established.
+# off  = do not use SSL. Will fail if the server requires a secure connection.
 default_ssl_mode = auto
 
 # SSL CA file for connections without --ssl-ca being set


### PR DESCRIPTION
## Description
While it is _possible_ to negotiate an SSL connection to MySQL over a local socket, it shouldn't be needed (should it?).

Nothing is transmitted over a network in that scenario.

If the user still does need SSL/TLS, `--ssl-mode=on` is available to force it.

@scottnemes does this PR make sense?  I'm open to being convinced otherwise.  It just made sense to me.   (There could even be a fourth ssl_mode but that seemed like needless complexity.)

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
