### PR TITLE
Add prompt format string for SSL/TLS version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ Features
 * Let `--keepalive-ticks` be set per-connection, as a CLI option or DSN parameter.
 * Accept `character_set` as a DSN query parameter.
 * Don't attempt SSL for local socket connections when in "auto" SSL mode.
+* Add prompt format string for SSL/TLS version of the connection.
 
 
 Bug Fixes

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -66,6 +66,7 @@ from mycli.packages.parseutils import is_destructive, is_dropping_database, is_v
 from mycli.packages.prompt_utils import confirm, confirm_destructive_query
 from mycli.packages.special.favoritequeries import FavoriteQueries
 from mycli.packages.special.main import ArgType
+from mycli.packages.special.utils import get_ssl_version
 from mycli.packages.sqlresult import SQLResult
 from mycli.packages.tabular_output import sql_format
 from mycli.packages.toolkit.history import FileHistoryWithTimestamp
@@ -1483,6 +1484,13 @@ class MyCli:
         string = string.replace("\\K", sqlexecute.socket or str(sqlexecute.port))
         string = string.replace("\\A", self.dsn_alias or "(none)")
         string = string.replace("\\_", " ")
+        # jump through hoops for the test environment and for efficiency
+        if hasattr(sqlexecute, 'conn') and sqlexecute.conn is not None:
+            if '\\T' in string:
+                with sqlexecute.conn.cursor() as cur:
+                    string = string.replace('\\T', get_ssl_version(cur) or '(none)')
+        else:
+            string = string.replace('\\T', '(none)')
         return string
 
     def run_query(

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -113,6 +113,7 @@ wider_completion_menu = False
 # * \J - full connection socket path
 # * \k - connection socket basename OR the port
 # * \K - full connection socket path OR the port
+# * \T - connection SSL/TLS version
 # * \t - database vendor (Percona, MySQL, MariaDB, TiDB)
 # * \u - username
 # * \A - DSN alias

--- a/test/myclirc
+++ b/test/myclirc
@@ -111,6 +111,7 @@ wider_completion_menu = False
 # * \J - full connection socket path
 # * \k - connection socket basename OR the port
 # * \K - full connection socket path OR the port
+# * \T - connection SSL/TLS version
 # * \t - database vendor (Percona, MySQL, MariaDB, TiDB)
 # * \u - username
 # * \A - DSN alias


### PR DESCRIPTION
## Description
`\T` will show the TLS version for the connection, or `(none)` when appropriate.

The negotiated version seems to require a trip to the server, but `get_ssl_version()` has been cached per `thread_id` so that we don't need to make that trip for every prompt refresh.

xref #1592 

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
