### PR TITLE
Add prompt format strings for server uptime

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ Features
 * Accept `character_set` as a DSN query parameter.
 * Don't attempt SSL for local socket connections when in "auto" SSL mode.
 * Add prompt format string for SSL/TLS version of the connection.
+* Add prompt format strings for displaying uptime.
 
 
 Bug Fixes

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -66,7 +66,7 @@ from mycli.packages.parseutils import is_destructive, is_dropping_database, is_v
 from mycli.packages.prompt_utils import confirm, confirm_destructive_query
 from mycli.packages.special.favoritequeries import FavoriteQueries
 from mycli.packages.special.main import ArgType
-from mycli.packages.special.utils import get_ssl_version
+from mycli.packages.special.utils import format_uptime, get_ssl_version, get_uptime
 from mycli.packages.sqlresult import SQLResult
 from mycli.packages.tabular_output import sql_format
 from mycli.packages.toolkit.history import FileHistoryWithTimestamp
@@ -1454,6 +1454,7 @@ class MyCli:
         with self._completer_lock:
             return self.completer.get_completions(Document(text=text, cursor_position=cursor_position), None)
 
+    # todo: time/uptime update on every character typed, instead of after every return
     def get_prompt(self, string: str) -> str:
         sqlexecute = self.sqlexecute
         assert sqlexecute is not None
@@ -1483,6 +1484,18 @@ class MyCli:
         string = string.replace("\\k", os.path.basename(sqlexecute.socket or str(sqlexecute.port)))
         string = string.replace("\\K", sqlexecute.socket or str(sqlexecute.port))
         string = string.replace("\\A", self.dsn_alias or "(none)")
+        # jump through hoops for the test environment, and for efficiency
+        if hasattr(sqlexecute, 'conn') and sqlexecute.conn is not None:
+            if '\\y' in string:
+                with sqlexecute.conn.cursor() as cur:
+                    string = string.replace('\\y', str(get_uptime(cur)) or '(none)')
+            if '\\Y' in string:
+                with sqlexecute.conn.cursor() as cur:
+                    string = string.replace('\\Y', format_uptime(str(get_uptime(cur))) or '(none)')
+        else:
+            string = string.replace('\\y', '(none)')
+            string = string.replace('\\Y', '(none)')
+
         string = string.replace("\\_", " ")
         # jump through hoops for the test environment and for efficiency
         if hasattr(sqlexecute, 'conn') and sqlexecute.conn is not None:

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -116,6 +116,8 @@ wider_completion_menu = False
 # * \T - connection SSL/TLS version
 # * \t - database vendor (Percona, MySQL, MariaDB, TiDB)
 # * \u - username
+# * \y - uptime in seconds (requires frequent trips to the server)
+# * \Y - uptime in words (requires frequent trips to the server)
 # * \A - DSN alias
 # * \n - a newline
 # * \_ - a space

--- a/mycli/packages/special/utils.py
+++ b/mycli/packages/special/utils.py
@@ -56,6 +56,22 @@ def format_uptime(uptime_in_seconds: str) -> str:
     return uptime
 
 
+def get_uptime(cur: Cursor) -> int:
+    query = 'SHOW STATUS LIKE "Uptime"'
+    logger.debug(query)
+
+    uptime = 0
+
+    try:
+        cur.execute(query)
+        if one := cur.fetchone():
+            uptime = int(one[1] or 0)
+    except pymysql.err.OperationalError:
+        pass
+
+    return uptime
+
+
 def get_ssl_version(cur: Cursor) -> str | None:
     cache_key = (id(cur.connection), cur.connection.thread_id())
 

--- a/test/myclirc
+++ b/test/myclirc
@@ -113,6 +113,8 @@ wider_completion_menu = False
 # * \K - full connection socket path OR the port
 # * \T - connection SSL/TLS version
 # * \t - database vendor (Percona, MySQL, MariaDB, TiDB)
+# * \y - uptime in seconds (requires frequent trips to the server)
+# * \Y - uptime in words (requires frequent trips to the server)
 # * \u - username
 # * \A - DSN alias
 # * \n - a newline


### PR DESCRIPTION
 ## Description
* `\y` shows uptime in seconds
 * `\Y` shows uptime in words

This requires a trip to the server for every update, which is noted in the commentary.

There is also a bug, not new to this commit, that the prompt is updated on every keypress rather than on every return.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
