### PR TITLE
Let interactive prompt changes respect dynamic format strings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,16 @@
+Upcoming (TBD)
+==============
+
+Features
+---------
+* Add extra error output on connection failure for possible SSL mismatch (#1584).
+
+
+Bug Fixes
+---------
+* Let interactive changes to the prompt format respect dynamically-computed values.
+
+
 1.56.0 (2026/02/23)
 ==============
 
@@ -6,7 +19,6 @@ Features
 * Let the `--dsn` argument accept literal DSNs as well as aliases.
 * Accept `--character-set` as an alias for `--charset` at the CLI.
 * Add SSL/TLS version to `status` output.
-* Add extra error output on connection failure for possible SSL mismatch (#1584)
 * Accept `socket` as a DSN query parameter.
 * Accept new-style `ssl_mode` in DSN URI query parameters, to match CLI argument.
 * Fully deprecate the built-in SSH functionality.

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -435,7 +435,7 @@ class MyCli:
             message = "Missing required argument, format."
             return [SQLResult(status=message)]
 
-        self.prompt_format = self.get_prompt(arg)
+        self.prompt_format = arg
         return [SQLResult(status=f"Changed prompt format to {arg}")]
 
     def initialize_logging(self) -> None:


### PR DESCRIPTION
## Description
The interactive `prompt` command was calling `get_prompt()` to set the prompt format.  But `get_prompt()` computes the substituted values of any format strings.

Therefore the interactive `prompt` command was "burning in" any dynamically-computed values such as the date or the database name as a static value.

This is a bug, and it differs from the behavior of setting the `prompt` option in `~/.myclirc`, which works correctly here.

The fix is to set the prompt format directly to the argument to` change_prompt_format()`, because the argument _is_ a format string.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
