### PR TITLE
Better handle arguments to `system cd`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Features
 Bug Fixes
 ---------
 * Let interactive changes to the prompt format respect dynamically-computed values.
+* Better handle arguments to `system cd`.
 
 
 1.56.0 (2026/02/23)

--- a/mycli/packages/special/utils.py
+++ b/mycli/packages/special/utils.py
@@ -1,9 +1,12 @@
 import logging
 import os
-import subprocess
+import shlex
 
+import click
 import pymysql
 from pymysql.cursors import Cursor
+
+from mycli.compat import WIN
 
 logger = logging.getLogger(__name__)
 
@@ -13,13 +16,21 @@ CACHED_SSL_VERSION: dict[tuple, str | None] = {}
 def handle_cd_command(arg: str) -> tuple[bool, str | None]:
     """Handles a `cd` shell command by calling python's os.chdir."""
     CD_CMD = "cd"
-    tokens = arg.split(CD_CMD + " ")
-    directory = tokens[-1] if len(tokens) > 1 else None
-    if not directory:
-        return False, "No folder name was provided."
+    tokens: list[str] = []
+    try:
+        tokens = shlex.split(arg, posix=not WIN)
+    except ValueError:
+        return False, 'Cannot parse cd command.'
+    if not tokens:
+        return False, 'Not a cd command.'
+    if not tokens[0].lower() == CD_CMD:
+        return False, 'Not a cd command.'
+    if len(tokens) != 2:
+        return False, 'Exactly one directory name must be provided.'
+    directory = tokens[1]
     try:
         os.chdir(directory)
-        subprocess.call(["pwd"])
+        click.echo(os.getcwd(), err=True)
         return True, None
     except OSError as e:
         return False, e.strerror

--- a/test/test_sqlexecute.py
+++ b/test/test_sqlexecute.py
@@ -222,7 +222,32 @@ def test_special_command(executor):
 @dbtest
 def test_cd_command_without_a_folder_name(executor):
     results = run(executor, "system cd")
-    assert_result_equal(results, status="No folder name was provided.")
+    assert_result_equal(results, status="Exactly one directory name must be provided.")
+
+
+@dbtest
+def test_cd_command_with_one_nonexistent_folder_name(executor):
+    results = run(executor, 'system cd nonexistent_folder_name')
+    assert_result_equal(results, status='No such file or directory')
+
+
+@dbtest
+def test_cd_command_with_one_real_folder_name(executor):
+    results = run(executor, 'system cd screenshots')
+    # todo would be better to capture stderr but there was a problem with capsys
+    assert results[0]['status'] == ''
+
+
+@dbtest
+def test_cd_command_with_two_folder_names(executor):
+    results = run(executor, "system cd one two")
+    assert_result_equal(results, status='Exactly one directory name must be provided.')
+
+
+@dbtest
+def test_cd_command_unbalanced(executor):
+    results = run(executor, "system cd 'one")
+    assert_result_equal(results, status='Cannot parse cd command.')
 
 
 @dbtest


### PR DESCRIPTION
## Description
 * Use `shlex.split` to handle quoted or backslash-escaped arguments correctly.  Previously the directory argument had to be a single word.
 * Use `os.getcwd()` instead of executing external `pwd`.
 * Improve error messages.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
