### PR TITLE
Allow multiline input in batch mode on the standard input

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@ Bug Fixes
 * Make `--ssl-capath` argument a directory.
 * Allow users to use empty passwords without prompting or any configuration (#1584).
 * Check the existence of a socket more directly in `status`.
+* Allow multi-line SQL statements in batch mode on the standard input.
 
 
 1.55.0 (2026/02/20)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -88,6 +88,7 @@ SUPPORT_INFO = "Home: http://mycli.net\nBug tracker: https://github.com/dbcli/my
 DEFAULT_WIDTH = 80
 DEFAULT_HEIGHT = 25
 MIN_COMPLETION_TRIGGER = 1
+MAX_MULTILINE_BATCH_STATEMENT = 5000
 
 
 @Condition
@@ -2253,49 +2254,77 @@ def cli(
             click.secho(str(e), err=True, fg="red")
             sys.exit(1)
 
+    def dispatch_batch_statements(statements: str, batch_counter: int) -> None:
+        if batch_counter:
+            # this is imperfect if the first line of input has multiple statements
+            if batch_format == 'csv':
+                mycli.main_formatter.format_name = 'csv-noheader'
+            elif batch_format == 'tsv':
+                mycli.main_formatter.format_name = 'tsv_noheader'
+            elif batch_format == 'table':
+                mycli.main_formatter.format_name = 'ascii'
+            else:
+                mycli.main_formatter.format_name = 'tsv'
+        else:
+            if batch_format == 'csv':
+                mycli.main_formatter.format_name = 'csv'
+            elif batch_format == 'tsv':
+                mycli.main_formatter.format_name = 'tsv'
+            elif batch_format == 'table':
+                mycli.main_formatter.format_name = 'ascii'
+            else:
+                mycli.main_formatter.format_name = 'tsv'
+
+        warn_confirmed: bool | None = True
+        if not noninteractive and mycli.destructive_warning and is_destructive(mycli.destructive_keywords, statements):
+            try:
+                # this seems to work, even though we are reading from stdin above
+                sys.stdin = open("/dev/tty")
+                # bug: the prompt will not be visible if stdout is redirected
+                warn_confirmed = confirm_destructive_query(mycli.destructive_keywords, statements)
+            except (IOError, OSError):
+                mycli.logger.warning("Unable to open TTY as stdin.")
+                sys.exit(1)
+        try:
+            if warn_confirmed:
+                if throttle and batch_counter >= 1:
+                    sleep(throttle)
+                mycli.run_query(statements, checkpoint=checkpoint, new_line=True)
+        except Exception as e:
+            click.secho(str(e), err=True, fg="red")
+            sys.exit(1)
+
     if sys.stdin.isatty():
         mycli.run_cli()
     else:
         stdin = click.get_text_stream("stdin")
-        counter = 0
+        statements = ''
+        line_counter = 0
+        batch_counter = 0
         for stdin_text in stdin:
-            if counter:
-                if batch_format == 'csv':
-                    mycli.main_formatter.format_name = 'csv-noheader'
-                elif batch_format == 'tsv':
-                    mycli.main_formatter.format_name = 'tsv_noheader'
-                elif batch_format == 'table':
-                    mycli.main_formatter.format_name = 'ascii'
-                else:
-                    mycli.main_formatter.format_name = 'tsv'
-            else:
-                if batch_format == 'csv':
-                    mycli.main_formatter.format_name = 'csv'
-                elif batch_format == 'tsv':
-                    mycli.main_formatter.format_name = 'tsv'
-                elif batch_format == 'table':
-                    mycli.main_formatter.format_name = 'ascii'
-                else:
-                    mycli.main_formatter.format_name = 'tsv'
-            counter += 1
-            warn_confirmed: bool | None = True
-            if not noninteractive and mycli.destructive_warning and is_destructive(mycli.destructive_keywords, stdin_text):
-                try:
-                    # this seems to work, even though we are reading from stdin above
-                    sys.stdin = open("/dev/tty")
-                    # bug: the prompt will not be visible if stdout is redirected
-                    warn_confirmed = confirm_destructive_query(mycli.destructive_keywords, stdin_text)
-                except (IOError, OSError):
-                    mycli.logger.warning("Unable to open TTY as stdin.")
-                    sys.exit(1)
-            try:
-                if warn_confirmed:
-                    if throttle and counter > 1:
-                        sleep(throttle)
-                    mycli.run_query(stdin_text, checkpoint=checkpoint, new_line=True)
-            except Exception as e:
-                click.secho(str(e), err=True, fg="red")
+            line_counter += 1
+            if line_counter > MAX_MULTILINE_BATCH_STATEMENT:
+                click.secho(
+                    f'Saw single input statement greater than {MAX_MULTILINE_BATCH_STATEMENT} lines; assuming a parsing error.',
+                    err=True,
+                    fg="red",
+                )
                 sys.exit(1)
+            statements += stdin_text
+            try:
+                tokens = sqlglot.tokenize(statements, read='mysql')
+                if not tokens:
+                    continue
+                # we don't handle changing the delimiter within the batch input
+                if tokens[-1].text == ';':
+                    dispatch_batch_statements(statements, batch_counter)
+                    batch_counter += 1
+                    statements = ''
+                    line_counter = 0
+            except sqlglot.errors.TokenError:
+                continue
+        if statements:
+            dispatch_batch_statements(statements, batch_counter)
         sys.exit(0)
     mycli.close()
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -533,6 +533,20 @@ def test_batch_mode(executor):
 
 
 @dbtest
+def test_batch_mode_multiline_statement(executor):
+    run(executor, """create table test(a text)""")
+    run(executor, """insert into test values('abc'), ('def'), ('ghi')""")
+
+    sql = "select count(*)\nfrom test;\nselect * from test limit 1;"
+
+    runner = CliRunner()
+    result = runner.invoke(cli, args=CLI_ARGS, input=sql)
+
+    assert result.exit_code == 0
+    assert "count(*)\n3\na\nabc\n" in "".join(result.output)
+
+
+@dbtest
 def test_batch_mode_table(executor):
     run(executor, """create table test(a text)""")
     run(executor, """insert into test values('abc'), ('def'), ('ghi')""")


### PR DESCRIPTION
## Description
Tokenize each line of input with sqlglot, and dispatch the (possibly multi-statement) query if the last token is a semicolon.  If the last token is _not_ a semicolon, accumulate the line towards the next dispatch.

We don't handle the case where the input script itself changes the delimiter.

A limit of 5000 lines is set, after which, if we can't find a line ending in semicolon, we assume that something is wrong with the input and exit.

Caused (intentionally) by #1450, but we still can improve on it.

Fixes #1593 .

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
