### PR TITLE
Accept on/off values for `--use-keyring`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Features
 * Let `help <keyword>` list similar keywords when not found.
 * Optionally highlight fuzzy search previews.
 * Make `\edit` synonymous with the `\e` command.
+* More liberally accept `on`/`off` values for `true`/`false`, and vice versa.
 
 
 Bug Fixes

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1786,9 +1786,9 @@ class MyCli:
 @click.option(
     '--use-keyring',
     'use_keyring_cli_opt',
-    type=click.Choice(['true', 'false', 'reset']),
+    type=str,
     default=None,
-    help='Store and retrieve passwords from the system keyring: true/false/reset.',
+    help='Store and retrieve passwords from the system keyring: on/off/reset.',
 )
 @click.option(
     '--keepalive-ticks',
@@ -2158,7 +2158,11 @@ def cli(
         use_keyring = str_to_bool(mycli.config['main'].get('use_keyring', 'False'))
         reset_keyring = False
     else:
-        use_keyring = str_to_bool(use_keyring_cli_opt)
+        try:
+            use_keyring = str_to_bool(use_keyring_cli_opt)
+        except ValueError:
+            click.secho('Unknown value for --use_keyring', err=True, fg='red')
+            sys.exit(1)
         reset_keyring = False
 
     # todo: removeme after a period of transition

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1015,6 +1015,65 @@ def test_dsn(monkeypatch):
     assert MockMyCli.connect_args['character_set'] == 'utf8mb3'
 
 
+def test_keyring_arg(monkeypatch):
+    # Setup classes to mock mycli.main.MyCli
+    class Formatter:
+        format_name = None
+
+    class Logger:
+        def debug(self, *args, **args_dict):
+            pass
+
+        def warning(self, *args, **args_dict):
+            pass
+
+    class MockMyCli:
+        config = {
+            'main': {},
+            'alias_dsn': {},
+            "connection": {
+                "default_keepalive_ticks": 0,
+            },
+        }
+
+        def __init__(self, **args):
+            self.logger = Logger()
+            self.destructive_warning = False
+            self.main_formatter = Formatter()
+            self.redirect_formatter = Formatter()
+            self.ssl_mode = 'auto'
+            self.my_cnf = {'client': {}, 'mysqld': {}}
+            self.default_keepalive_ticks = 0
+
+        def connect(self, **args):
+            MockMyCli.connect_args = args
+
+        def run_query(self, query, new_line=True):
+            pass
+
+    import mycli.main
+
+    monkeypatch.setattr(mycli.main, 'MyCli', MockMyCli)
+    runner = CliRunner()
+
+    result = runner.invoke(mycli.main.cli, args=['--use-keyring', 'True'])
+    assert result.exit_code == 0, result.output + ' ' + str(result.exception)
+    assert MockMyCli.connect_args['use_keyring'] is True
+
+    result = runner.invoke(mycli.main.cli, args=['--use-keyring', 'on'])
+    assert result.exit_code == 0, result.output + ' ' + str(result.exception)
+    assert MockMyCli.connect_args['use_keyring'] is True
+
+    result = runner.invoke(mycli.main.cli, args=['--use-keyring', 'off'])
+    assert result.exit_code == 0, result.output + ' ' + str(result.exception)
+    assert MockMyCli.connect_args['use_keyring'] is False
+
+    result = runner.invoke(mycli.main.cli, args=['--use-keyring', 'Reset'])
+    assert result.exit_code == 0, result.output + ' ' + str(result.exception)
+    assert MockMyCli.connect_args['use_keyring'] is True
+    assert MockMyCli.connect_args['reset_keyring'] is True
+
+
 def test_ssh_config(monkeypatch):
     # Setup classes to mock mycli.main.MyCli
     class Formatter:


### PR DESCRIPTION
## Description
Accept on/off values for `--use-keyring`, keeping true/false, as well as treating "reset" as special.

The motivation is uniformity in the interface.

The only loss is that click does not display the value choices in the helpdoc, but they are already listed in the description.

Here we also change the description to suggest on/off, while continuing to silently accept true/false.  The reason for the change is that `--ssl-mode` came first, and `--ssl-mode` takes on/off.

See #1606  for more on the motivation.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
