### PR TITLE
Fix missing keepalives in `\e` prompt loop

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Bug Fixes
 ---------
 * Let interactive changes to the prompt format respect dynamically-computed values.
 * Better handle arguments to `system cd`.
+* Fix missing keepalives in `\e` prompt loop.
 
 
 1.56.0 (2026/02/23)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -785,6 +785,7 @@ class MyCli:
     def handle_editor_command(
         self,
         text: str,
+        inputhook: Callable | None,
         loaded_message_fn: Callable,
     ) -> str:
         r"""Editor command is any query that is prefixed or suffixed by a '\e'.
@@ -809,9 +810,9 @@ class MyCli:
             while True:
                 try:
                     assert isinstance(self.prompt_app, PromptSession)
-                    # buglet: this prompt() invocation doesn't have an inputhook for keepalive pings
                     text = self.prompt_app.prompt(
                         default=sql,
+                        inputhook=inputhook,
                         message=loaded_message_fn,
                     )
                     break
@@ -1066,6 +1067,7 @@ class MyCli:
                 try:
                     text = self.handle_editor_command(
                         text,
+                        inputhook,
                         loaded_message_fn,
                     )
                 except RuntimeError as e:


### PR DESCRIPTION
## Description
Fix missing keepalives in `\e` prompt loop by passing the `inputhook` value to `handle_editor_command()`.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
