### PR TITLE
Strip trailing newlines with `\e <filename>`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ Bug Fixes
 * Let interactive changes to the prompt format respect dynamically-computed values.
 * Better handle arguments to `system cd`.
 * Fix missing keepalives in `\e` prompt loop.
+* Always strip trailing newlines with `\e`.
 
 
 1.56.0 (2026/02/23)

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -194,7 +194,7 @@ def open_external_editor(filename: str | None = None, sql: str | None = None) ->
                 query = f.read()
         except IOError:
             message = f'Error reading file: {filename}'
-        return (query, message)
+        return (query.rstrip('\n'), message)
 
     # Populate the editor buffer with the partial sql (if available) and a
     # placeholder comment.


### PR DESCRIPTION
## Description
Trailing newlines were stripped in other variations of `\e`, but not when reading from a file.  Stripping helps place the cursor in the expected place when returning to the prompt.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
