### PR TITLE
Prefer `https` over `http` in docs and commentary

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 A command line client for MySQL that can do auto-completion and syntax highlighting.
 
-Homepage: [http://mycli.net](http://mycli.net)
-Documentation: [http://mycli.net/docs](http://mycli.net/docs)
+Homepage: [https://mycli.net](https://mycli.net)
+Documentation: [https://mycli.net/docs](https://mycli.net/docs)
 
 ![Completion](screenshots/tables.png)
 ![CompletionGif](screenshots/main.gif)
 
-Postgres Equivalent: [http://pgcli.com](http://pgcli.com)
+Postgres Equivalent: [https://pgcli.com](https://pgcli.com)
 
 Quick Start
 -----------
@@ -115,7 +115,7 @@ sudo dnf install mycli
 
 Install the `less` pager, for example by `scoop install less`.
 
-Follow the instructions on this blogpost: http://web.archive.org/web/20221006045208/https://www.codewall.co.uk/installing-using-mycli-on-windows/
+Follow the instructions on this blogpost: https://web.archive.org/web/20221006045208/https://www.codewall.co.uk/installing-using-mycli-on-windows/
 
 **Mycli is not tested on Windows**, but the libraries used in the app are Windows-compatible.
 This means it should work without any modifications, but isn't supported.
@@ -130,15 +130,15 @@ Mycli on Windows.
 
 ### Thanks:
 
-This project was funded through kickstarter. My thanks to the [backers](http://mycli.net/sponsors) who supported the project.
+This project was funded through kickstarter. My thanks to the [backers](https://mycli.net/sponsors) who supported the project.
 
 A special thanks to [Jonathan Slenders](https://twitter.com/jonathan_s) for
-creating [Python Prompt Toolkit](http://github.com/jonathanslenders/python-prompt-toolkit),
+creating [Python Prompt Toolkit](https://github.com/jonathanslenders/python-prompt-toolkit),
 which is quite literally the backbone library, that made this app possible.
 Jonathan has also provided valuable feedback and support during the development
 of this app.
 
-[Click](http://click.pocoo.org/) is used for command line option parsing
+[Click](https://palletsprojects.com/projects/click) is used for command line option parsing
 and printing error messages.
 
 Thanks to [PyMysql](https://github.com/PyMySQL/PyMySQL) for a pure python adapter to MySQL database.
@@ -159,9 +159,9 @@ or set `--charset=utf8` when invoking MyCLI.
 
 ### Configuration and Usage
 
-For more information on using and configuring mycli, [check out our documentation](http://mycli.net/docs).
+For more information on using and configuring mycli, [check out our documentation](https://mycli.net/docs).
 
 Common topics include:
-- [Configuring mycli](http://mycli.net/config)
-- [Using/Disabling the pager](http://mycli.net/pager)
-- [Syntax colors](http://mycli.net/syntax)
+- [Configuring mycli](https://mycli.net/config)
+- [Using/Disabling the pager](https://mycli.net/pager)
+- [Syntax colors](https://mycli.net/syntax)

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,6 @@ Upcoming (TBD)
 Features
 ---------
 * Add extra error output on connection failure for possible SSL mismatch (#1584).
-* Startup tips: add right-arrow key binding.
 
 
 Bug Fixes
@@ -13,6 +12,12 @@ Bug Fixes
 * Better handle arguments to `system cd`.
 * Fix missing keepalives in `\e` prompt loop.
 * Always strip trailing newlines with `\e`.
+
+
+Documentation
+---------
+* Startup tips: add right-arrow key binding.
+* Prefer `https` protocol over `http` in documentation.
 
 
 Internal
@@ -1636,7 +1641,7 @@ Features
   ```
 
 * Add `--defaults-group-suffix` to the command line. This lets the user specify
-  a group to use in the my.cnf files. (Thanks: [Irina Truong](http://github.com/j-bennet))
+  a group to use in the my.cnf files. (Thanks: [Irina Truong](https://github.com/j-bennet))
 
   In the my.cnf file a user can specify credentials for different databases and
   invoke mycli with the group name to use the appropriate credentials.
@@ -1701,7 +1706,7 @@ Features
 
 * Fuzzy completion is now case-insensitive. (Thanks: [bjarnagin](https://github.com/bjarnagin))
 * Added new-line (`\n`) to the list of special characters to use in prompt. (Thanks: [brewneaux](https://github.com/brewneaux))
-* Honor the `pager` setting in my.cnf files. (Thanks: [Irina Truong](http://github.com/j-bennet))
+* Honor the `pager` setting in my.cnf files. (Thanks: [Irina Truong](https://github.com/j-bennet))
 
 Bug Fixes
 ----------
@@ -1771,7 +1776,7 @@ Bug Fixes
 [Amjith Ramanujam]: https://blog.amjith.com
 [Artem Bezsmertnyi]: https://github.com/mrdeathless
 [BuonOmo]: https://github.com/BuonOmo
-[Daniel West]: http://github.com/danieljwest
+[Daniel West]: https://github.com/danieljwest
 [Dick Marinus]: https://github.com/meeuw
 [François Pietka]: https://github.com/fpietka
 [Frederic Aoustin]: https://github.com/fraoustin

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -86,7 +86,7 @@ sqlparse.engine.grouping.MAX_GROUPING_TOKENS = None  # type: ignore[assignment]
 # Query tuples are used for maintaining history
 Query = namedtuple("Query", ["query", "successful", "mutating"])
 
-SUPPORT_INFO = "Home: http://mycli.net\nBug tracker: https://github.com/dbcli/mycli/issues"
+SUPPORT_INFO = "Home: https://mycli.net\nBug tracker: https://github.com/dbcli/mycli/issues"
 DEFAULT_WIDTH = 80
 DEFAULT_HEIGHT = 25
 MIN_COMPLETION_TRIGGER = 1

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -87,7 +87,7 @@ post_redirect_command =
 # manni, igor, xcode, vim, autumn, vs, rrt, native, perldoc, borland, tango, emacs,
 # friendly, monokai, paraiso, colorful, murphy, bw, pastie, paraiso, trac, default,
 # fruity.
-# Screenshots at http://mycli.net/syntax
+# Screenshots at https://mycli.net/syntax
 # Can be further modified in [colors]
 syntax_style = default
 

--- a/test/myclirc
+++ b/test/myclirc
@@ -85,7 +85,7 @@ post_redirect_command = ""
 # manni, igor, xcode, vim, autumn, vs, rrt, native, perldoc, borland, tango, emacs,
 # friendly, monokai, paraiso, colorful, murphy, bw, pastie, paraiso, trac, default,
 # fruity.
-# Screenshots at http://mycli.net/syntax
+# Screenshots at https://mycli.net/syntax
 # Can be further modified in [colors]
 syntax_style = default
 


### PR DESCRIPTION
## Description
Prefer `http` over `https` in docs and commentary, also updating the "click" link to a new domain which supports HTTPS.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
