### PR TITLE
Fix `\llm` usage document, adding a `help` subcommand

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features
 ---------
 * Add extra error output on connection failure for possible SSL mismatch (#1584).
 * Bind alternate terminal sequences for function keys F2 - F4.
+* Add `llm help` subcommand.
 
 
 Bug Fixes
@@ -13,6 +14,7 @@ Bug Fixes
 * Better handle arguments to `system cd`.
 * Fix missing keepalives in `\e` prompt loop.
 * Always strip trailing newlines with `\e`.
+* Fix `\llm` without arguments, and remove debug output.
 
 
 Documentation

--- a/mycli/packages/special/llm.py
+++ b/mycli/packages/special/llm.py
@@ -33,6 +33,7 @@ except ImportError:
 from pymysql.cursors import Cursor
 
 from mycli.packages.special.main import Verbosity, parse_special_command
+from mycli.packages.sqlresult import SQLResult
 
 log = logging.getLogger(__name__)
 
@@ -225,11 +226,9 @@ def handle_llm(
 ) -> tuple[str, str | None, float]:
     _, verbosity, arg = parse_special_command(text)
     if not LLM_IMPORTED:
-        output = [(None, None, None, NEED_DEPENDENCIES)]
-        raise FinishIteration(output)
-    if not arg.strip():
-        output = [(None, None, None, USAGE)]
-        raise FinishIteration(output)
+        raise FinishIteration(results=[SQLResult(title=NEED_DEPENDENCIES, results=[])])
+    if arg.strip().lower() in ['', 'help', '?', r'\?']:
+        raise FinishIteration(results=[SQLResult(title=USAGE, results=[])])
     parts = shlex.split(arg)
     restart = False
     if "-c" in parts:
@@ -262,12 +261,11 @@ def handle_llm(
             if match:
                 sql = match.group(1).strip()
             else:
-                output = [(None, None, None, result)]
-                raise FinishIteration(output)
+                raise FinishIteration(results=[SQLResult(title=result, results=[])])
             return (result if verbosity == Verbosity.SUCCINCT else "", sql, end - start)
         else:
             run_external_cmd("llm", *args, restart_cli=restart)
-            raise FinishIteration(None)
+            raise FinishIteration(results=None)
     try:
         ensure_mycli_template()
         start = time()
@@ -392,8 +390,6 @@ def sql_using_llm(
         question,
         " ",
     ]
-    click.echo(args[4])
-    click.echo(args[7])
     click.echo("Invoking llm command with schema information and sample data")
     _, result = run_external_cmd("llm", *args, capture_output=True)
     click.echo("Received response from the llm command")

--- a/test/test_llm_special.py
+++ b/test/test_llm_special.py
@@ -9,6 +9,7 @@ from mycli.packages.special.llm import (
     is_llm_command,
     sql_using_llm,
 )
+from mycli.packages.sqlresult import SQLResult
 
 
 # Override executor fixture to avoid real DB connections during llm tests
@@ -28,19 +29,33 @@ def test_llm_command_without_args(mock_llm, executor):
     with pytest.raises(FinishIteration) as exc_info:
         handle_llm(test_text, executor, 'mysql', 0, 0)
     # Should return usage message when no args provided
-    assert exc_info.value.args[0] == [(None, None, None, USAGE)]
+    assert exc_info.value.results == [SQLResult(title=USAGE, results=[])]
+
+
+@patch("mycli.packages.special.llm.llm")
+def test_llm_command_with_help_subcommand(mock_llm, executor):
+    r"""
+    Invoking \llm with "help" should print the usage and raise FinishIteration.
+    """
+    assert mock_llm is not None
+    test_text = r"\llm help"
+    with pytest.raises(FinishIteration) as exc_info:
+        handle_llm(test_text, executor, 'mysql', 0, 0)
+    # Should return usage message when "help" subcommand or variant is provided
+    assert exc_info.value.results == [SQLResult(title=USAGE, results=[])]
 
 
 @patch("mycli.packages.special.llm.llm")
 @patch("mycli.packages.special.llm.run_external_cmd")
 def test_llm_command_with_c_flag(mock_run_cmd, mock_llm, executor):
+    string = "Hello, no SQL today."
     # Suppose the LLM returns some text without fenced SQL
-    mock_run_cmd.return_value = (0, "Hello, no SQL today.")
+    mock_run_cmd.return_value = (0, string)
     test_text = r"\llm -c 'Something?'"
     with pytest.raises(FinishIteration) as exc_info:
         handle_llm(test_text, executor, 'mysql', 0, 0)
     # Expect raw output when no SQL fence found
-    assert exc_info.value.args[0] == [(None, None, None, "Hello, no SQL today.")]
+    assert exc_info.value.results == [SQLResult(title=string, results=[])]
 
 
 @patch("mycli.packages.special.llm.llm")
@@ -66,7 +81,7 @@ def test_llm_command_known_subcommand(mock_run_cmd, mock_llm, executor):
     with pytest.raises(FinishIteration) as exc_info:
         handle_llm(test_text, executor, 'mysql', 0, 0)
     mock_run_cmd.assert_called_once_with("llm", "models", restart_cli=False)
-    assert exc_info.value.args[0] is None
+    assert exc_info.value.results is None
 
 
 @patch("mycli.packages.special.llm.llm")
@@ -76,7 +91,7 @@ def test_llm_command_with_help_flag(mock_run_cmd, mock_llm, executor):
     with pytest.raises(FinishIteration) as exc_info:
         handle_llm(test_text, executor, 'mysql', 0, 0)
     mock_run_cmd.assert_called_once_with("llm", "--help", restart_cli=False)
-    assert exc_info.value.args[0] is None
+    assert exc_info.value.results is None
 
 
 @patch("mycli.packages.special.llm.llm")
@@ -86,7 +101,7 @@ def test_llm_command_with_install_flag(mock_run_cmd, mock_llm, executor):
     with pytest.raises(FinishIteration) as exc_info:
         handle_llm(test_text, executor, 'mysql', 0, 0)
     mock_run_cmd.assert_called_once_with("llm", "install", "openai", restart_cli=True)
-    assert exc_info.value.args[0] is None
+    assert exc_info.value.results is None
 
 
 @patch("mycli.packages.special.llm.llm")
@@ -195,4 +210,4 @@ def test_handle_llm_aliases_without_args(prefix, executor, monkeypatch):
     monkeypatch.setattr(llm_module, "llm", object())
     with pytest.raises(FinishIteration) as exc_info:
         handle_llm(prefix, executor, 'mysql', 0, 0)
-    assert exc_info.value.args[0] == [(None, None, None, USAGE)]
+    assert exc_info.value.results == [SQLResult(title=USAGE, results=[])]


### PR DESCRIPTION
## Description
`\llm` without arguments was broken, as well as other special cases such as dependency warnings.  There was also some (embarrassing) inappropriate debug output.

 * Return a `SQLResult` for each `FinishIteration()`, using the `title` property to get unformatted output.
 * Remove debug output.
 * Return the usage document for other arguments to `\llm` such as "help".

Maybe the `title` property to `SQLResult` should be renamed `preamble`, since I think it is used for unformatted frontmatter more than it is used for single-line titles.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
