### PR TITLE
Rewrite help table, adding a Usage column

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Features
 * Add extra error output on connection failure for possible SSL mismatch (#1584).
 * Bind alternate terminal sequences for function keys F2 - F4.
 * Add `llm help` subcommand.
+* Rewrite `help` table.
 
 
 Bug Fixes

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -300,30 +300,30 @@ class MyCli:
             self.sqlexecute.close()
 
     def register_special_commands(self) -> None:
-        special.register_special_command(self.change_db, "use", "\\u", "Change to a new database.", aliases=["\\u"])
+        special.register_special_command(self.change_db, "use", "use <database>", "Change to a new database.", aliases=["\\u"])
         special.register_special_command(
             self.manual_reconnect,
             "connect",
-            "\\r",
-            "Reconnect to the database. Optional database argument.",
+            "connect [database]",
+            "Reconnect to the server, optionally switching databases.",
             aliases=["\\r"],
             case_sensitive=True,
         )
         special.register_special_command(
-            self.refresh_completions, "rehash", "\\#", "Refresh auto-completions.", arg_type=ArgType.NO_QUERY, aliases=["\\#"]
+            self.refresh_completions, "rehash", "rehash", "Refresh auto-completions.", arg_type=ArgType.NO_QUERY, aliases=["\\#"]
         )
         special.register_special_command(
             self.change_table_format,
             "tableformat",
-            "\\T",
-            "Change the table format used to output results.",
+            "tableformat <format>",
+            "Change the table format used to output interactive results.",
             aliases=["\\T"],
             case_sensitive=True,
         )
         special.register_special_command(
             self.change_redirect_format,
             "redirectformat",
-            "\\Tr",
+            "redirectformat <format>",
             "Change the table format used to output redirected results.",
             aliases=["\\Tr"],
             case_sensitive=True,
@@ -331,7 +331,7 @@ class MyCli:
         special.register_special_command(
             self.disable_show_warnings,
             "nowarnings",
-            "\\w",
+            "nowarnings",
             "Disable automatic warnings display.",
             aliases=["\\w"],
             case_sensitive=True,
@@ -339,14 +339,16 @@ class MyCli:
         special.register_special_command(
             self.enable_show_warnings,
             "warnings",
-            "\\W",
+            "warnings",
             "Enable automatic warnings display.",
             aliases=["\\W"],
             case_sensitive=True,
         )
-        special.register_special_command(self.execute_from_file, "source", "\\. filename", "Execute commands from file.", aliases=["\\."])
         special.register_special_command(
-            self.change_prompt_format, "prompt", "\\R", "Change prompt format.", aliases=["\\R"], case_sensitive=True
+            self.execute_from_file, "source", "source <filename>", "Execute commands from file.", aliases=["\\."]
+        )
+        special.register_special_command(
+            self.change_prompt_format, "prompt", "prompt <string>", "Change prompt format.", aliases=["\\R"], case_sensitive=True
         )
 
     def manual_reconnect(self, arg: str = "", **_) -> Generator[SQLResult, None, None]:

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -61,7 +61,7 @@ def list_databases(cur: Cursor, **_) -> list[SQLResult]:
 
 
 @special_command(
-    "status", "\\s", "Get status information from the server.", arg_type=ArgType.RAW_QUERY, aliases=["\\s"], case_sensitive=True
+    "status", "status", "Get status information from the server.", arg_type=ArgType.RAW_QUERY, aliases=["\\s"], case_sensitive=True
 )
 def status(cur: Cursor, **_) -> list[SQLResult]:
     query = "SHOW GLOBAL STATUS;"

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -82,8 +82,8 @@ def set_destructive_keywords(val: list[str]) -> None:
 
 @special_command(
     "pager",
-    "\\P [command]",
-    "Set PAGER. Print the query results via PAGER.",
+    "pager [command]",
+    "Set pager to [command]. Print query results via pager.",
     arg_type=ArgType.PARSED_QUERY,
     aliases=["\\P"],
     case_sensitive=True,
@@ -104,13 +104,13 @@ def set_pager(arg: str, **_) -> list[SQLResult]:
     return [SQLResult(status=msg)]
 
 
-@special_command("nopager", "\\n", "Disable pager, print to stdout.", arg_type=ArgType.NO_QUERY, aliases=["\\n"], case_sensitive=True)
+@special_command("nopager", "nopager", "Disable pager, print to stdout.", arg_type=ArgType.NO_QUERY, aliases=["\\n"], case_sensitive=True)
 def disable_pager() -> list[SQLResult]:
     set_pager_enabled(False)
     return [SQLResult(status="Pager disabled.")]
 
 
-@special_command("\\timing", "\\t", "Toggle timing of commands.", arg_type=ArgType.NO_QUERY, aliases=["\\t"], case_sensitive=True)
+@special_command("\\timing", "\\timing", "Toggle timing of commands.", arg_type=ArgType.NO_QUERY, aliases=["\\t"], case_sensitive=True)
 def toggle_timing() -> list[SQLResult]:
     global TIMING_ENABLED
     TIMING_ENABLED = not TIMING_ENABLED
@@ -331,7 +331,7 @@ def subst_favorite_query_args(query: str, args: list[str]) -> list[str | None]:
     return [query, None]
 
 
-@special_command("\\fs", "\\fs name query", "Save a favorite query.")
+@special_command("\\fs", "\\fs <name> <query>", "Save a favorite query.")
 def save_favorite_query(arg: str, **_) -> list[SQLResult]:
     """Save a new favorite query.
     Returns (title, rows, headers, status)"""
@@ -350,7 +350,7 @@ def save_favorite_query(arg: str, **_) -> list[SQLResult]:
     return [SQLResult(status="Saved.")]
 
 
-@special_command("\\fd", "\\fd [name]", "Delete a favorite query.")
+@special_command("\\fd", "\\fd <name>", "Delete a favorite query.")
 def delete_favorite_query(arg: str, **_) -> list[SQLResult]:
     """Delete an existing favorite query."""
     usage = "Syntax: \\fd name.\n\n" + FavoriteQueries.instance.usage
@@ -362,7 +362,7 @@ def delete_favorite_query(arg: str, **_) -> list[SQLResult]:
     return [SQLResult(status=status)]
 
 
-@special_command("system", "system [command]", "Execute a system shell commmand.")
+@special_command("system", "system <command>", "Execute a system shell commmand.")
 def execute_system_command(arg: str, **_) -> list[SQLResult]:
     """Execute a system shell command."""
     usage = "Syntax: system [command].\n"
@@ -405,7 +405,7 @@ def parseargfile(arg: str) -> tuple[str, str]:
     return (os.path.expanduser(filename), mode)
 
 
-@special_command("tee", "tee [-o] filename", "Append all results to an output file (overwrite using -o).")
+@special_command("tee", "tee [-o] <filename>", "Append all results to an output file (overwrite using -o).")
 def set_tee(arg: str, **_) -> list[SQLResult]:
     global tee_file
 
@@ -438,7 +438,7 @@ def write_tee(output: str) -> None:
         tee_file.flush()
 
 
-@special_command("\\once", "\\o [-o] filename", "Append next result to an output file (overwrite using -o).", aliases=["\\o"])
+@special_command("\\once", "\\once [-o] <filename>", "Append next result to an output file (overwrite using -o).", aliases=["\\o"])
 def set_once(arg: str, **_) -> list[SQLResult]:
     global once_file, written_to_once_file
 
@@ -491,7 +491,7 @@ def _run_post_redirect_hook(post_redirect_command: str, filename: str) -> None:
         raise OSError(f"Redirect post hook failed: {e}") from e
 
 
-@special_command("\\pipe_once", "\\| command", "Send next result to a subprocess.", aliases=["\\|"])
+@special_command("\\pipe_once", "\\pipe_once <command>", "Send next result to a subprocess.", aliases=["\\|"])
 def set_pipe_once(arg: str, **_) -> list[SQLResult]:
     if not arg:
         raise OSError("pipe_once requires a command")
@@ -550,7 +550,7 @@ def flush_pipe_once_if_written(post_redirect_command: str) -> None:
     PIPE_ONCE['stdout_mode'] = None
 
 
-@special_command("watch", "watch [seconds] [-c] query", "Executes the query every [seconds] seconds (by default 5).")
+@special_command("watch", "watch [seconds] [-c] <query>", "Executes the query every [seconds] seconds (by default 5).")
 def watch_query(arg: str, **kwargs) -> Generator[SQLResult, None, None]:
     usage = """Syntax: watch [seconds] [-c] query.
     * seconds: The interval at the query will be repeated, in seconds.
@@ -617,7 +617,7 @@ def watch_query(arg: str, **kwargs) -> Generator[SQLResult, None, None]:
             set_pager_enabled(old_pager_enabled)
 
 
-@special_command("delimiter", None, "Change SQL delimiter.")
+@special_command("delimiter", "delimiter <string>", "Change end-of-statement delimiter.")
 def set_delimiter(arg: str, **_) -> list[SQLResult]:
     return delimiter_command.set(arg)
 

--- a/mycli/packages/special/main.py
+++ b/mycli/packages/special/main.py
@@ -26,11 +26,12 @@ SpecialCommand = namedtuple(
     [
         "handler",
         "command",
-        "shortcut",
+        "usage",
         "description",
         "arg_type",
         "hidden",
         "case_sensitive",
+        "shortcut",
     ],
 )
 
@@ -64,7 +65,7 @@ def parse_special_command(sql: str) -> tuple[str, Verbosity, str]:
 
 def special_command(
     command: str,
-    shortcut: str | None,
+    usage: str | None,
     description: str,
     arg_type: ArgType = ArgType.PARSED_QUERY,
     hidden: bool = False,
@@ -75,7 +76,7 @@ def special_command(
         register_special_command(
             wrapped,
             command,
-            shortcut,
+            usage,
             description,
             arg_type=arg_type,
             hidden=hidden,
@@ -90,7 +91,7 @@ def special_command(
 def register_special_command(
     handler: Callable,
     command: str,
-    shortcut: str | None,
+    usage: str | None,
     description: str,
     arg_type: ArgType = ArgType.PARSED_QUERY,
     hidden: bool = False,
@@ -101,11 +102,12 @@ def register_special_command(
     COMMANDS[cmd] = SpecialCommand(
         handler,
         command,
-        shortcut,
+        usage,
         description,
         arg_type=arg_type,
         hidden=hidden,
         case_sensitive=case_sensitive,
+        shortcut=aliases[0] if aliases else None,
     )
     aliases = [] if aliases is None else aliases
     for alias in aliases:
@@ -113,11 +115,12 @@ def register_special_command(
         COMMANDS[cmd] = SpecialCommand(
             handler,
             command,
-            shortcut,
+            usage,
             description,
             arg_type=arg_type,
             case_sensitive=case_sensitive,
             hidden=True,
+            shortcut=None,
         )
 
 
@@ -152,14 +155,16 @@ def execute(cur: Cursor, sql: str) -> list[SQLResult]:
     raise CommandNotFound(f"Command type not found: {command}")
 
 
-@special_command("help", "\\?", "Show this help.", arg_type=ArgType.NO_QUERY, aliases=["\\?", "?"])
+@special_command(
+    "help", "help [term]", "Show this help, or search for a term on the server.", arg_type=ArgType.NO_QUERY, aliases=["\\?", "?"]
+)
 def show_help(*_args) -> list[SQLResult]:
-    headers = ["Command", "Shortcut", "Description"]
+    headers = ["Command", "Shortcut", "Usage", "Description"]
     result = []
 
     for _, value in sorted(COMMANDS.items()):
         if not value.hidden:
-            result.append((value.command, value.shortcut, value.description))
+            result.append((value.command, value.shortcut, value.usage, value.description))
     return [SQLResult(results=result, headers=headers)]
 
 
@@ -181,21 +186,23 @@ def show_keyword_help(cur: Cursor, arg: str) -> list[SQLResult]:
         return [SQLResult(status=f'No help found for {keyword}.')]
 
 
-@special_command("exit", "\\q", "Exit.", arg_type=ArgType.NO_QUERY, aliases=["\\q"])
-@special_command("quit", "\\q", "Quit.", arg_type=ArgType.NO_QUERY)
+@special_command("exit", "exit", "Exit.", arg_type=ArgType.NO_QUERY, aliases=["\\q"])
+@special_command("quit", "quit", "Quit.", arg_type=ArgType.NO_QUERY, aliases=["\\q"])
 def quit_(*_args):
     raise EOFError
 
 
-@special_command("\\e", "\\e", "Edit command with editor (uses $EDITOR).", arg_type=ArgType.NO_QUERY, case_sensitive=True)
-@special_command("\\clip", "\\clip", "Copy query to the system clipboard.", arg_type=ArgType.NO_QUERY, case_sensitive=True)
-@special_command("\\G", "\\G", "Display current query results vertically.", arg_type=ArgType.NO_QUERY, case_sensitive=True)
+@special_command(
+    "\\e", "<query>\\e | \\e <filename>", "Edit query with editor (uses $EDITOR).", arg_type=ArgType.NO_QUERY, case_sensitive=True
+)
+@special_command("\\clip", "<query>\\clip", "Copy query to the system clipboard.", arg_type=ArgType.NO_QUERY, case_sensitive=True)
+@special_command("\\G", "<query>\\G", "Display query results vertically.", arg_type=ArgType.NO_QUERY, case_sensitive=True)
 def stub():
     raise NotImplementedError
 
 
 if LLM_IMPORTED:
 
-    @special_command("\\llm", "\\ai", "Interrogate an LLM.", arg_type=ArgType.RAW_QUERY, case_sensitive=True)
+    @special_command("\\llm", "\\llm [arguments]", "Interrogate an LLM.", arg_type=ArgType.RAW_QUERY, case_sensitive=True, aliases=["\\ai"])
     def llm_stub():
         raise NotImplementedError

--- a/test/features/fixture_data/help_commands.txt
+++ b/test/features/fixture_data/help_commands.txt
@@ -1,36 +1,36 @@
-+----------------+----------------------------+------------------------------------------------------------+
-| Command        | Shortcut                   | Description                                                |
-+----------------+----------------------------+------------------------------------------------------------+
-| \G             | \G                         | Display current query results vertically.                  |
-| \clip          | \clip                      | Copy query to the system clipboard.                        |
-| \dt            | \dt[+] [table]             | List or describe tables.                                   |
-| \e             | \e                         | Edit command with editor (uses $EDITOR).                   |
-| \f             | \f [name [args..]]         | List or execute favorite queries.                          |
-| \fd            | \fd [name]                 | Delete a favorite query.                                   |
-| \fs            | \fs name query             | Save a favorite query.                                     |
-| \l             | \l                         | List databases.                                            |
-| \llm           | \ai                        | Interrogate an LLM.                                        |
-| \once          | \o [-o] filename           | Append next result to an output file (overwrite using -o). |
-| \pipe_once     | \| command                 | Send next result to a subprocess.                          |
-| \timing        | \t                         | Toggle timing of commands.                                 |
-| connect        | \r                         | Reconnect to the database. Optional database argument.     |
-| delimiter      | <nope>                     | Change SQL delimiter.                                      |
-| exit           | \q                         | Exit.                                                      |
-| help           | \?                         | Show this help.                                            |
-| nopager        | \n                         | Disable pager, print to stdout.                            |
-| notee          | notee                      | Stop writing results to an output file.                    |
-| nowarnings     | \w                         | Disable automatic warnings display.                        |
-| pager          | \P [command]               | Set PAGER. Print the query results via PAGER.              |
-| prompt         | \R                         | Change prompt format.                                      |
-| quit           | \q                         | Quit.                                                      |
-| redirectformat | \Tr                        | Change the table format used to output redirected results. |
-| rehash         | \#                         | Refresh auto-completions.                                  |
-| source         | \. filename                | Execute commands from file.                                |
-| status         | \s                         | Get status information from the server.                    |
-| system         | system [command]           | Execute a system shell commmand.                           |
-| tableformat    | \T                         | Change the table format used to output results.            |
-| tee            | tee [-o] filename          | Append all results to an output file (overwrite using -o). |
-| use            | \u                         | Change to a new database.                                  |
-| warnings       | \W                         | Enable automatic warnings display.                         |
-| watch          | watch [seconds] [-c] query | Executes the query every [seconds] seconds (by default 5). |
-+----------------+----------------------------+------------------------------------------------------------+
++----------------+----------+------------------------------+-------------------------------------------------------------+
+| Command        | Shortcut | Usage                        | Description                                                 |
++----------------+----------+------------------------------+-------------------------------------------------------------+
+| \G             | <nope>   | <query>\G                    | Display query results vertically.                           |
+| \clip          | <nope>   | <query>\clip                 | Copy query to the system clipboard.                         |
+| \dt            | <nope>   | \dt[+] [table]               | List or describe tables.                                    |
+| \e             | <nope>   | <query>\e | \e <filename>    | Edit query with editor (uses $EDITOR).                      |
+| \f             | <nope>   | \f [name [args..]]           | List or execute favorite queries.                           |
+| \fd            | <nope>   | \fd <name>                   | Delete a favorite query.                                    |
+| \fs            | <nope>   | \fs <name> <query>           | Save a favorite query.                                      |
+| \l             | <nope>   | \l                           | List databases.                                             |
+| \llm           | \ai      | \llm [arguments]             | Interrogate an LLM.                                         |
+| \once          | \o       | \once [-o] <filename>        | Append next result to an output file (overwrite using -o).  |
+| \pipe_once     | \|       | \pipe_once <command>         | Send next result to a subprocess.                           |
+| \timing        | \t       | \timing                      | Toggle timing of commands.                                  |
+| connect        | \r       | connect [database]           | Reconnect to the server, optionally switching databases.    |
+| delimiter      | <nope>   | delimiter <string>           | Change end-of-statement delimiter.                          |
+| exit           | \q       | exit                         | Exit.                                                       |
+| help           | \?       | help [term]                  | Show this help, or search for a term on the server.         |
+| nopager        | \n       | nopager                      | Disable pager, print to stdout.                             |
+| notee          | <nope>   | notee                        | Stop writing results to an output file.                     |
+| nowarnings     | \w       | nowarnings                   | Disable automatic warnings display.                         |
+| pager          | \P       | pager [command]              | Set pager to [command]. Print query results via pager.      |
+| prompt         | \R       | prompt <string>              | Change prompt format.                                       |
+| quit           | \q       | quit                         | Quit.                                                       |
+| redirectformat | \Tr      | redirectformat <format>      | Change the table format used to output redirected results.  |
+| rehash         | \#       | rehash                       | Refresh auto-completions.                                   |
+| source         | \.       | source <filename>            | Execute commands from file.                                 |
+| status         | \s       | status                       | Get status information from the server.                     |
+| system         | <nope>   | system <command>             | Execute a system shell commmand.                            |
+| tableformat    | \T       | tableformat <format>         | Change the table format used to output interactive results. |
+| tee            | <nope>   | tee [-o] <filename>          | Append all results to an output file (overwrite using -o).  |
+| use            | \u       | use <database>               | Change to a new database.                                   |
+| warnings       | \W       | warnings                     | Enable automatic warnings display.                          |
+| watch          | <nope>   | watch [seconds] [-c] <query> | Executes the query every [seconds] seconds (by default 5).  |
++----------------+----------+------------------------------+-------------------------------------------------------------+

--- a/test/test_completion_engine.py
+++ b/test/test_completion_engine.py
@@ -606,7 +606,7 @@ def test_after_as(expression):
 )
 def test_source_is_file(expression):
     # "source" has to be registered by hand because that usually happens inside MyCLI in mycli/main.py
-    special.register_special_command(..., 'source', '\\. filename', 'Execute commands from file.', aliases=['\\.'])
+    special.register_special_command(..., 'source', '\\. <filename>', 'Execute commands from file.', aliases=['\\.'])
     suggestions = suggest_type(expression, expression)
     assert suggestions == [{"type": "file_name"}]
 

--- a/test/test_smart_completion_public_schema_only.py
+++ b/test/test_smart_completion_public_schema_only.py
@@ -80,7 +80,7 @@ def complete_event():
 def test_use_database_completion(completer, complete_event):
     text = "USE "
     position = len(text)
-    special.register_special_command(..., 'use', '\\u', 'Change to a new database.', aliases=['\\u'])
+    special.register_special_command(..., 'use', '\\u [database]', 'Change to a new database.', aliases=['\\u'])
     result = completer.get_completions(Document(text=text, cursor_position=position), complete_event)
     assert list(result) == [
         Completion(text="test", start_position=0),
@@ -640,7 +640,7 @@ def dummy_list_path(dir_name):
 )
 def test_file_name_completion(completer, complete_event, text, expected):
     position = len(text)
-    special.register_special_command(..., 'source', '\\. filename', 'Execute commands from file.', aliases=['\\.'])
+    special.register_special_command(..., 'source', '\\. <filename>', 'Execute commands from file.', aliases=['\\.'])
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
     expected = [Completion(txt, pos) for txt, pos in expected]
     assert result == expected
@@ -677,7 +677,7 @@ def test_source_eager_completion(completer, complete_event):
     script_filename = 'script_for_test_suite.sql'
     f = open(script_filename, 'w')
     f.close()
-    special.register_special_command(..., 'source', '\\. filename', 'Execute commands from file.', aliases=['\\.'])
+    special.register_special_command(..., 'source', '\\. <filename>', 'Execute commands from file.', aliases=['\\.'])
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
     success = True
     error = 'unknown'
@@ -701,7 +701,7 @@ def test_source_leading_dot_suggestions_completion(completer, complete_event):
     script_filename = 'script_for_test_suite.sql'
     f = open(script_filename, 'w')
     f.close()
-    special.register_special_command(..., 'source', '\\. filename', 'Execute commands from file.', aliases=['\\.'])
+    special.register_special_command(..., 'source', '\\. <filename>', 'Execute commands from file.', aliases=['\\.'])
     result = list(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
     success = True
     error = 'unknown'

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -118,7 +118,7 @@ def test_special_favorite_query():
     with db_connection().cursor() as cur:
         query = r'\?'
         mycli.packages.special.execute(cur, rf"\fs special {query}")
-        assert (r'\G', r'\G', 'Display current query results vertically.') in next(
+        assert (r'\G', None, r'<query>\G', 'Display query results vertically.') in next(
             mycli.packages.special.execute(cur, r'\f special')
         ).results
 

--- a/test/test_sqlexecute.py
+++ b/test/test_sqlexecute.py
@@ -216,7 +216,7 @@ def test_collapsed_output_special_command(executor):
 @dbtest
 def test_special_command(executor):
     results = run(executor, "\\?")
-    assert_result_equal(results, rows=("quit", "\\q", "Quit."), headers="Command", assert_contains=True, auto_status=False)
+    assert_result_equal(results, rows=("quit", "\\q", "quit", "Quit."), headers="Command", assert_contains=True, auto_status=False)
 
 
 @dbtest


### PR DESCRIPTION
## Description
Completely rewrite help table (via calls to `register_special_command()`).

Previously, usage notes were mixed with shortcuts, and notation was not consistent.

Split "Shortcut" and "Usage" into separate columns, and make notation in the "Usage" section consistent.

Changes
 * Let the third argument to `register_special_command()` be the usage note.
 * Deduce the shortcut from the list of aliases.
 * Don't repeat the shortcut in the output when it is equal to the main command.
 * In usage notes, use angle brackets for required arguments, and square brackets for optional arguments.
 * Lightly improve some Description text as well, such as specifying that `tableformat` applies to interactive results.
 * Use "query" consistently instead of "command".
 * Update tests.

<img width="1980" height="1488" alt="last image" src="https://github.com/user-attachments/assets/9183c033-4b78-4c56-adce-f345bb3a7912" />


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
