### PR TITLE
Remove info counter from fzf history-search UI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ Features
 * Bind alternate terminal sequences for function keys F2 - F4.
 * Add `llm help` subcommand.
 * Rewrite `help` table.
+* Remove "info" counter from fzf history-search UI.
 
 
 Bug Fixes

--- a/mycli/packages/toolkit/fzf.py
+++ b/mycli/packages/toolkit/fzf.py
@@ -43,9 +43,18 @@ def search_history(event: KeyPressEvent, incremental: bool = False) -> None:
         formatted_history_items.append(f"{timestamp}  {formatted_item}")
         original_history_items.append(item)
 
+    options = [
+        '--info=hidden',
+        '--scheme=history',
+        '--tiebreak=index',
+        '--bind=ctrl-r:up,alt-r:up',
+        '--preview-window=down:wrap',
+        '--preview="printf \'%s\' {}"',
+    ]
+
     result = fzf.prompt(
         formatted_history_items,
-        fzf_options="--scheme=history --tiebreak=index --bind ctrl-r:up,alt-r:up --preview-window=down:wrap --preview=\"printf '%s' {}\"",
+        fzf_options=' '.join(options),
     )
 
     if result:


### PR DESCRIPTION
## Description

Remove this counter:

<img width="1052" height="310" alt="last image" src="https://github.com/user-attachments/assets/7e65605b-7ece-4aa3-8886-f1ccdaeac8e5" />

in favor of a cleaner interface.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
