### PR TITLE
Add help on F1 keystroke

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming (TBD)
 Features
 ---------
 * Add `\bug` command.
+* Let the `F1` key open a browser to mycli.net/docs and emit help text.
 
 
 Bug Fixes

--- a/doc/key_bindings.rst
+++ b/doc/key_bindings.rst
@@ -7,6 +7,12 @@ Most key bindings are simply inherited from `prompt-toolkit <https://python-prom
 The following key bindings are special to mycli:
 
 ###
+F1
+###
+
+Open documentation index in a browser tab.
+
+###
 F2
 ###
 

--- a/mycli/TIPS
+++ b/mycli/TIPS
@@ -118,6 +118,8 @@ run SQL scripts in batch mode using the standard input!
 
 edit a query in an external editor using keystrokes control-x + control-e!
 
+open a documentation browser using keystroke F1!
+
 toggle smart completion using keystroke F2!
 
 toggle multi-line mode using keystroke F3!

--- a/mycli/constants.py
+++ b/mycli/constants.py
@@ -1,1 +1,2 @@
+DOCS_URL = 'https://mycli.net/docs'
 ISSUES_URL = 'https://github.com/dbcli/mycli/issues'

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -1,5 +1,7 @@
 import logging
+import webbrowser
 
+import prompt_toolkit
 from prompt_toolkit.application.current import get_app
 from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.filters import (
@@ -11,8 +13,10 @@ from prompt_toolkit.filters import (
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.key_processor import KeyPressEvent
 
+from mycli.constants import DOCS_URL
 from mycli.packages import shortcuts
 from mycli.packages.toolkit.fzf import search_history
+from mycli.packages.toolkit.utils import safe_invalidate_display
 
 _logger = logging.getLogger(__name__)
 
@@ -30,9 +34,43 @@ def in_completion() -> bool:
     return bool(app.current_buffer.complete_state)
 
 
+def print_f1_help():
+    app = get_app()
+    app.print_text('\n')
+    app.print_text([
+        ('', 'Inline help — type "'),
+        ('bold', 'help'),
+        ('', '" or "'),
+        ('bold', r'\?'),
+        ('', '"\n'),
+    ])
+    app.print_text([
+        ('', 'Docs index — '),
+        ('bold', DOCS_URL),
+        ('', '\n'),
+    ])
+    app.print_text('\n')
+
+
 def mycli_bindings(mycli) -> KeyBindings:
     """Custom key bindings for mycli."""
     kb = KeyBindings()
+
+    @kb.add('f1')
+    def _(event: KeyPressEvent) -> None:
+        """Open browser to documentation index."""
+        _logger.debug('Detected F1 key.')
+        webbrowser.open_new_tab(DOCS_URL)
+        prompt_toolkit.application.run_in_terminal(print_f1_help)
+        safe_invalidate_display(event.app)
+
+    @kb.add('escape', '[', 'P')
+    def _(event: KeyPressEvent) -> None:
+        """Open browser to documentation index."""
+        _logger.debug("Detected alternate F1 key sequence.")
+        webbrowser.open_new_tab(DOCS_URL)
+        prompt_toolkit.application.run_in_terminal(print_f1_help)
+        safe_invalidate_display(event.app)
 
     @kb.add("f2")
     def _(_event: KeyPressEvent) -> None:


### PR DESCRIPTION
## Description
 * open documentation index in web browser on F1
 * emit output using `prompt_toolkit` methods such that the prompt is restored including pending input
 * include the docs URL in the output in case the browser did not open
 * include alternate F1 key sequence that `prompt_toolkit` doesn't handle
 * update `TIPS` and `key_bindings.rst`

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
