### PR TITLE
Add documentation index URL to inline help

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features
 ---------
 * Add `\bug` command.
 * Let the `F1` key open a browser to mycli.net/docs and emit help text.
+* Add documentation index URL to inline help.
 
 
 Bug Fixes

--- a/mycli/packages/special/main.py
+++ b/mycli/packages/special/main.py
@@ -5,7 +5,7 @@ import os
 from typing import Callable
 import webbrowser
 
-from mycli.constants import ISSUES_URL
+from mycli.constants import DOCS_URL, ISSUES_URL
 from mycli.packages.sqlresult import SQLResult
 
 try:
@@ -167,7 +167,7 @@ def show_help(*_args) -> list[SQLResult]:
     for _, value in sorted(COMMANDS.items()):
         if not value.hidden:
             result.append((value.command, value.shortcut, value.usage, value.description))
-    return [SQLResult(results=result, headers=headers)]
+    return [SQLResult(results=result, headers=headers, postamble=f'Docs index — {DOCS_URL}')]
 
 
 def show_keyword_help(cur: Cursor, arg: str) -> list[SQLResult]:


### PR DESCRIPTION
## Description

Show docs URL in footer after inline help.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
