### PR TITLE
Rewrite bottom toolbar, but keep it compact

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Features
 * Add `\bug` command.
 * Let the `F1` key open a browser to mycli.net/docs and emit help text.
 * Add documentation index URL to inline help.
+* Rewrite bottom toolbar, showing more statuses, but staying compact.
 
 
 Bug Fixes

--- a/mycli/clitoolbar.py
+++ b/mycli/clitoolbar.py
@@ -7,35 +7,60 @@ from prompt_toolkit.key_binding.vi_state import InputMode
 from mycli.packages import special
 
 
-def create_toolbar_tokens_func(mycli, show_fish_help: Callable) -> Callable:
+def create_toolbar_tokens_func(mycli, show_initial_toolbar_help: Callable) -> Callable:
     """Return a function that generates the toolbar tokens."""
 
     def get_toolbar_tokens() -> list[tuple[str, str]]:
-        result = [("class:bottom-toolbar", " ")]
+        divider = ('class:bottom-toolbar', ' │ ')
+
+        result = [("class:bottom-toolbar", "[Tab] Complete")]
+
+        result.append(divider)
+        result.append(("class:bottom-toolbar", "[F1] Help"))
+
+        if mycli.completer.smart_completion:
+            result.append(divider)
+            result.append(("class:bottom-toolbar", "[F2] Smart-complete:"))
+            result.append(("class:bottom-toolbar.on", "ON"))
+        else:
+            result.append(divider)
+            result.append(("class:bottom-toolbar", "[F2] Smart-complete:"))
+            result.append(("class:bottom-toolbar.off", "OFF"))
+
+        if mycli.multi_line:
+            result.append(divider)
+            result.append(("class:bottom-toolbar", "[F3] Multiline:"))
+            result.append(("class:bottom-toolbar.on", "ON"))
+        else:
+            result.append(divider)
+            result.append(("class:bottom-toolbar", "[F3] Multiline:"))
+            result.append(("class:bottom-toolbar.off", "OFF"))
+
+        if mycli.prompt_app.editing_mode == EditingMode.VI:
+            result.append(divider)
+            result.append(("class:bottom-toolbar", "Vi:"))
+            result.append(("class:bottom-toolbar.on", _get_vi_mode()))
+
+        if mycli.toolbar_error_message:
+            result.append(divider)
+            result.append(("class:bottom-toolbar", mycli.toolbar_error_message))
+            mycli.toolbar_error_message = None
 
         if mycli.multi_line:
             delimiter = special.get_current_delimiter()
-            result.append((
-                "class:bottom-toolbar",
-                f' ({"Semi-colon" if delimiter == ";" else "Delimiter"} [{delimiter}] will end the line) ',
-            ))
+            if delimiter != ';' or show_initial_toolbar_help():
+                result.append(divider)
+                result.append(('class:bottom-toolbar', '"'))
+                result.append(('class:bottom-toolbar.on', delimiter))
+                result.append(('class:bottom-toolbar', '" ends a statement'))
 
-        if mycli.multi_line:
-            result.append(("class:bottom-toolbar.on", "[F3] Multiline: ON  "))
-        else:
-            result.append(("class:bottom-toolbar.off", "[F3] Multiline: OFF  "))
-        if mycli.prompt_app.editing_mode == EditingMode.VI:
-            result.append(("class:bottom-toolbar.on", f"Vi-mode ({_get_vi_mode()})"))
-
-        if mycli.toolbar_error_message:
-            result.append(("class:bottom-toolbar", "  " + mycli.toolbar_error_message))
-            mycli.toolbar_error_message = None
-
-        if show_fish_help():
-            result.append(("class:bottom-toolbar", "  Right-arrow to complete suggestion"))
+        if show_initial_toolbar_help():
+            result.append(divider)
+            result.append(("class:bottom-toolbar", "right-arrow accepts full-line suggestion"))
 
         if mycli.completion_refresher.is_refreshing():
-            result.append(("class:bottom-toolbar", "     Refreshing completions..."))
+            result.append(divider)
+            result.append(("class:bottom-toolbar", "Refreshing completions…"))
 
         return result
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -922,7 +922,7 @@ class MyCli:
                 continuation = " "
             return [("class:continuation", continuation)]
 
-        def show_suggestion_tip() -> bool:
+        def show_initial_toolbar_help() -> bool:
             return iterations < 2
 
         # Keep track of whether or not the query is mutating. In case
@@ -1228,7 +1228,7 @@ class MyCli:
             query = Query(text, successful, mutating)
             self.query_history.append(query)
 
-        get_toolbar_tokens = create_toolbar_tokens_func(self, show_suggestion_tip)
+        get_toolbar_tokens = create_toolbar_tokens_func(self, show_initial_toolbar_help)
         if self.wider_completion_menu:
             complete_style = CompleteStyle.MULTI_COLUMN
         else:


### PR DESCRIPTION
 ## Description
* Recast `show_fish_help()` as `show_initial_toolbar_help()` since it is be used more generally.
 * Recast `show_suggestion_tip()` as `show_initial_toolbar_help()` so that the caller matches the callee.
 * Make a toolbar section divider with a vertical bar.
 * Add Tab to permanent list of suggested keys.
 * Add F1 to permanent list of suggested keys (assumes #1627).
 * Add F2 to permanent list of suggested keys and show smart-complete status.
 * Only highlight the "ON" part of multiline when on, and remove space. Constraining the total highlighted characters to a smaller number makes the line in general more readable, though the styling of the highlighted letters depends on the configuration..
 * Only highlight the vi modes when vi edit mode is on, and remove space.
 * Only show delimiter text if non-standard or initial, and make the text shorter.
 * Make right-arrow help text explain _which_ suggestions are referred to, avoiding the confusing word "complete".
 * Make "refreshing" message shorter with a Unicode ellipsis.

A key feature of the reorganization is that transient text only can appear on the right, so the keystroke help stays more aligned.

Toolbar in "initial" mode with extra notes to the right (specific colors/styles depend on user settings):

<img width="2214" height="60" alt="toolbar_initial" src="https://github.com/user-attachments/assets/137e6561-e7d8-4e13-bae9-a7f92bb1bd80" />

Toolbar after "initial" mode:

<img width="1178" height="54" alt="toolbar" src="https://github.com/user-attachments/assets/a7afb5bd-1e18-4f13-90ad-d8dcc81a647f" />


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
