### PR TITLE
fzf search: ensure fullscreen with preview on

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ Bug Fixes
 ---------
 * Force a prompt_toolkit refresh after fzf history search to avoid display glitches.
 * Include `status` footer in paged output.
+* Ensure fullscreen in fuzzy history search.
 
 
 1.57.0 (2026/02/25)

--- a/mycli/packages/toolkit/fzf.py
+++ b/mycli/packages/toolkit/fzf.py
@@ -49,7 +49,8 @@ def search_history(event: KeyPressEvent, incremental: bool = False) -> None:
         '--scheme=history',
         '--tiebreak=index',
         '--bind=ctrl-r:up,alt-r:up',
-        '--preview-window=down:wrap',
+        '--preview-window=down:wrap:nohidden',
+        '--no-height',
         '--preview="printf \'%s\' {}"',
     ]
 


### PR DESCRIPTION
## Description
fzf search: ensure fullscreen with preview on, overriding environment variable `FZF_DEFAULT_OPTS` in part.

The mycli documentation describes the fzf search as fullscreen with a preview; these options selectively override parts of `FZF_DEFAULT_OPTS` from the environment to make sure that is always true.

The user's fzf keybindings, colors, and most other options are still taken from `FZF_DEFAULT_OPTS` if present.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
