### PR TITLE
Let "help <term>" fall back to list similar terms

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ Features
 * Let the `F1` key open a browser to mycli.net/docs and emit help text.
 * Add documentation index URL to inline help.
 * Rewrite bottom toolbar, showing more statuses, but staying compact.
+* Let `help <keyword>` list similar keywords when not found.
 
 
 Bug Fixes

--- a/mycli/packages/special/main.py
+++ b/mycli/packages/special/main.py
@@ -172,20 +172,25 @@ def show_help(*_args) -> list[SQLResult]:
 
 def show_keyword_help(cur: Cursor, arg: str) -> list[SQLResult]:
     """
-    Call the built-in "show <command>", to display help for an SQL keyword.
+    Call the built-in "show <keyword>", to display help for an SQL keyword.
     :param cur: cursor
     :param arg: string
     :return: list
     """
-    keyword = arg.strip('"').strip("'")
-    query = f"help '{keyword}'"
+    keyword = arg.strip().strip('"\'')
+    query = 'help %s'
     logger.debug(query)
-    cur.execute(query)
+    cur.execute(query, keyword)
     if cur.description and cur.rowcount > 0:
         headers = [x[0] for x in cur.description]
-        return [SQLResult(results=cur, headers=headers, status="")]
+        return [SQLResult(results=cur, headers=headers)]
+    logger.debug(query)
+    cur.execute(query, (f'%{keyword}%',))
+    if cur.description and cur.rowcount > 0:
+        headers = [x[0] for x in cur.description]
+        return [SQLResult(title='Similar terms:', results=cur, headers=headers)]
     else:
-        return [SQLResult(status=f'No help found for {keyword}.')]
+        return [SQLResult(status=f'No help found for "{keyword}".')]
 
 
 @special_command('\\bug', '\\bug', 'File a bug on GitHub.', arg_type=ArgType.NO_QUERY)


### PR DESCRIPTION
## Description
Let `help <term>` fall back to list similar terms when the term is not found.

 * parameterize the help query
 * no need to pass empty status property
 * search for `%keyword%` if exact search fails, and report those results as a table of similar terms
 * quote "keyword" in failure message

Example:

<img width="658" height="344" alt="last image" src="https://github.com/user-attachments/assets/7135423f-d63f-45e8-9ed2-3917fdf859b7" />

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
