### PR TITLE
Invalidate display after fzf history search, forcing a refresh

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ Features
 * Add `\bug` command.
 
 
+Bug Fixes
+---------
+* Force a prompt_toolkit refresh after fzf history search to avoid display glitches.
+
+
 1.57.0 (2026/02/25)
 ==============
 

--- a/mycli/packages/toolkit/fzf.py
+++ b/mycli/packages/toolkit/fzf.py
@@ -6,6 +6,7 @@ from prompt_toolkit.key_binding.key_processor import KeyPressEvent
 from pyfzf import FzfPrompt
 
 from mycli.packages.toolkit.history import FileHistoryWithTimestamp
+from mycli.packages.toolkit.utils import safe_invalidate_display
 
 
 class Fzf(FzfPrompt):
@@ -56,6 +57,7 @@ def search_history(event: KeyPressEvent, incremental: bool = False) -> None:
         formatted_history_items,
         fzf_options=' '.join(options),
     )
+    safe_invalidate_display(event.app)
 
     if result:
         selected_index = formatted_history_items.index(result[0])

--- a/mycli/packages/toolkit/utils.py
+++ b/mycli/packages/toolkit/utils.py
@@ -1,0 +1,20 @@
+from prompt_toolkit.application import Application, run_in_terminal
+
+
+def safe_invalidate_display(app: Application) -> None:
+    """
+    fzf can confuse the terminal/app when certain values are set in
+    environment variable FZF_DEFAULT_OPTS.
+
+    The same could happen after running other external programs.
+
+    This function invalidates the prompt_toolkit display, causing a
+    refresh of the prompt message and pending user input, without
+    leading to exceptions at exit time, as the built-in
+    app.invalidate() does.
+    """
+
+    def print_empty_string():
+        app.print_text('')
+
+    run_in_terminal(print_empty_string)


### PR DESCRIPTION
## Description

Depending upon settings, the prompt message might be invisible after returning from an fzf search.  One cause could be

    export FZF_DEFAULT_OPTS='--height=15%'

Leaving aside the question of the interaction between the environment variable and the search interface expected by the mycli documentation, we can solve the issue of the lost prompt message by manually invalidating the display.

As the docstring notes, `app.invalidate()` did not have the desired effect, and caused warnings at exit time:

    Task was destroyed but it is pending!

While this is more general, it is related to #1630 , which ensures that the above specific `--height=15%` issue is resolved in a specific way.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
