### PR TITLE
Syntax highlighting for fuzzy search previews

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ Features
 * Add documentation index URL to inline help.
 * Rewrite bottom toolbar, showing more statuses, but staying compact.
 * Let `help <keyword>` list similar keywords when not found.
+* Optionally highlight fuzzy search previews.
 
 
 Bug Fixes

--- a/mycli/TIPS
+++ b/mycli/TIPS
@@ -226,6 +226,8 @@ set up connection defaults using the "[connection]" section in ~/.myclirc!
 
 use "min_completion_trigger" in ~/.myclirc to defer completions!
 
+colorize search previews with "highlight_preview" in ~/.myclirc!
+
 ###
 ### redirection
 ###

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -238,13 +238,21 @@ def mycli_bindings(mycli) -> KeyBindings:
         if mode == 'reverse_isearch':
             search_history(event, incremental=True)
         else:
-            search_history(event)
+            search_history(
+                event,
+                highlight_preview=mycli.highlight_preview,
+                highlight_style=mycli.syntax_style,
+            )
 
     @kb.add("escape", "r", filter=control_is_searchable & emacs_mode)
     def _(event: KeyPressEvent) -> None:
         """Search history using fzf when available."""
         _logger.debug("Detected <alt-r> key.")
-        search_history(event)
+        search_history(
+            event,
+            highlight_preview=mycli.highlight_preview,
+            highlight_style=mycli.syntax_style,
+        )
 
     @kb.add('c-d', filter=ctrl_d_condition)
     def _(event: KeyPressEvent) -> None:

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -255,6 +255,8 @@ class MyCli:
 
         keyword_casing = c["main"].get("keyword_casing", "auto")
 
+        self.highlight_preview = c['search'].as_bool('highlight_preview')
+
         self.query_history: list[Query] = []
 
         # Initialize completer.
@@ -2481,6 +2483,7 @@ def do_config_checkup(mycli: MyCli) -> None:
     for executable in [
         'less',
         'fzf',
+        'pygmentize',
     ]:
         if shutil.which(executable):
             print(f'The "{executable}" executable was found — good!')

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -154,6 +154,15 @@ my_cnf_transition_done = False
 # A password can be reset with --use-keyring=reset at the CLI.
 use_keyring = False
 
+[search]
+
+# Whether to apply syntax highlighting to the preview window in fuzzy history
+# search.  There is a small performance penalty to enabling this.  The "pygmentize"
+# CLI tool must also be available.  The syntax style from the "syntax_style"
+# option will be respected, though additional customizations from [colors] will
+# not be applied.
+highlight_preview = False
+
 [connection]
 
 # character set for connections without --character-set being set

--- a/mycli/packages/toolkit/fzf.py
+++ b/mycli/packages/toolkit/fzf.py
@@ -1,4 +1,5 @@
 import re
+import shlex
 from shutil import which
 
 from prompt_toolkit import search
@@ -19,7 +20,12 @@ class Fzf(FzfPrompt):
         return self.executable is not None
 
 
-def search_history(event: KeyPressEvent, incremental: bool = False) -> None:
+def search_history(
+    event: KeyPressEvent,
+    highlight_preview: bool = False,
+    highlight_style: str = 'default',
+    incremental: bool = False,
+) -> None:
     buffer = event.current_buffer
     history = buffer.history
 
@@ -51,8 +57,12 @@ def search_history(event: KeyPressEvent, incremental: bool = False) -> None:
         '--bind=ctrl-r:up,alt-r:up',
         '--preview-window=down:wrap:nohidden',
         '--no-height',
-        '--preview="printf \'%s\' {}"',
     ]
+
+    if highlight_preview and which('pygmentize'):
+        options.append(f'--preview="printf \'%s\' {{}} | pygmentize -l mysql -P style={shlex.quote(highlight_style)}"')
+    else:
+        options.append('--preview="printf \'%s\' {}"')
 
     result = fzf.prompt(
         formatted_history_items,

--- a/test/myclirc
+++ b/test/myclirc
@@ -152,6 +152,15 @@ my_cnf_transition_done = False
 # A password can be reset with --use-keyring=reset at the CLI.
 use_keyring = False
 
+[search]
+
+# Whether to apply syntax highlighting to the preview window in fuzzy history
+# search.  There is a small performance penalty to enabling this.  The "pygmentize"
+# CLI tool must also be available.  The syntax style from the "syntax_style"
+# option will be respected, though additional customizations from [colors] will
+# not be applied.
+highlight_preview = False
+
 [connection]
 
 # character set for connections without --character-set being set


### PR DESCRIPTION
## Description
 * add a `[search]` section to myclirc with a `highlight_preview` option
 * leave the option off by default as it does introduce a small lag when traversing search candidates
 * optionally call `pygmentize` when creating the preview text
 * add `pygmentize` to external executables tested in `--checkup`
 * update TIPS

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
