### PR TITLE
Make `\edit` synonymous with the `\e` command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Features
 * Rewrite bottom toolbar, showing more statuses, but staying compact.
 * Let `help <keyword>` list similar keywords when not found.
 * Optionally highlight fuzzy search previews.
+* Make `\edit` synonymous with the `\e` command.
 
 
 Bug Fixes

--- a/mycli/TIPS
+++ b/mycli/TIPS
@@ -50,7 +50,9 @@ copy a query to the clipboard using \clip at the end of the query!
 
 \dt lists tables; \dt <table> describes <table>!
 
-edit a query in an external editor using \e!
+edit a query in an external editor using <query>\edit!
+
+edit a query in an external editor using \edit <filename>!
 
 \f lists favorite queries; \f <name> executes a favorite!
 

--- a/mycli/clibuffer.py
+++ b/mycli/clibuffer.py
@@ -40,6 +40,7 @@ def _multiline_exception(text: str) -> bool:
             "\\g",
             "\\G",
             r"\e",
+            r"\edit",
             r"\clip",
         ))
         or

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -151,11 +151,16 @@ def editor_command(command: str) -> bool:
     """
     # It is possible to have `\e filename` or `SELECT * FROM \e`. So we check
     # for both conditions.
-    return command.strip().endswith("\\e") or command.strip().startswith("\\e")
+    return (
+        command.strip().endswith("\\e")
+        or command.strip().startswith("\\e ")
+        or command.strip().endswith("\\edit")
+        or command.strip().startswith("\\edit ")
+    )
 
 
 def get_filename(sql: str) -> str | None:
-    if sql.strip().startswith("\\e"):
+    if sql.strip().startswith("\\e ") or sql.strip().startswith("\\edit "):
         command, _, filename = sql.partition(" ")
         return filename.strip() or None
     else:
@@ -169,7 +174,7 @@ def get_editor_query(sql: str) -> str:
     # The reason we can't simply do .strip('\e') is that it strips characters,
     # not a substring. So it'll strip "e" in the end of the sql also!
     # Ex: "select * from style\e" -> "select * from styl".
-    pattern = re.compile(r"(^\\e|\\e$)")
+    pattern = re.compile(r"(\\e$|\\edit$)")
     while pattern.search(sql):
         sql = pattern.sub("", sql)
 

--- a/mycli/packages/special/main.py
+++ b/mycli/packages/special/main.py
@@ -206,7 +206,12 @@ def quit_(*_args):
 
 
 @special_command(
-    "\\e", "<query>\\e | \\e <filename>", "Edit query with editor (uses $EDITOR).", arg_type=ArgType.NO_QUERY, case_sensitive=True
+    "\\edit",
+    "<query>\\edit | \\edit <filename>",
+    "Edit query with editor (uses $EDITOR).",
+    arg_type=ArgType.NO_QUERY,
+    case_sensitive=True,
+    aliases=['\\e'],
 )
 @special_command("\\clip", "<query>\\clip", "Copy query to the system clipboard.", arg_type=ArgType.NO_QUERY, case_sensitive=True)
 @special_command("\\G", "<query>\\G", "Display query results vertically.", arg_type=ArgType.NO_QUERY, case_sensitive=True)

--- a/test/features/fixture_data/help_commands.txt
+++ b/test/features/fixture_data/help_commands.txt
@@ -1,37 +1,37 @@
-+----------------+----------+------------------------------+-------------------------------------------------------------+
-| Command        | Shortcut | Usage                        | Description                                                 |
-+----------------+----------+------------------------------+-------------------------------------------------------------+
-| \G             | <nope>   | <query>\G                    | Display query results vertically.                           |
-| \bug           | <nope>   | \bug                         | File a bug on GitHub.                                       |
-| \clip          | <nope>   | <query>\clip                 | Copy query to the system clipboard.                         |
-| \dt            | <nope>   | \dt[+] [table]               | List or describe tables.                                    |
-| \e             | <nope>   | <query>\e | \e <filename>    | Edit query with editor (uses $EDITOR).                      |
-| \f             | <nope>   | \f [name [args..]]           | List or execute favorite queries.                           |
-| \fd            | <nope>   | \fd <name>                   | Delete a favorite query.                                    |
-| \fs            | <nope>   | \fs <name> <query>           | Save a favorite query.                                      |
-| \l             | <nope>   | \l                           | List databases.                                             |
-| \llm           | \ai      | \llm [arguments]             | Interrogate an LLM.                                         |
-| \once          | \o       | \once [-o] <filename>        | Append next result to an output file (overwrite using -o).  |
-| \pipe_once     | \|       | \pipe_once <command>         | Send next result to a subprocess.                           |
-| \timing        | \t       | \timing                      | Toggle timing of commands.                                  |
-| connect        | \r       | connect [database]           | Reconnect to the server, optionally switching databases.    |
-| delimiter      | <nope>   | delimiter <string>           | Change end-of-statement delimiter.                          |
-| exit           | \q       | exit                         | Exit.                                                       |
-| help           | \?       | help [term]                  | Show this help, or search for a term on the server.         |
-| nopager        | \n       | nopager                      | Disable pager, print to stdout.                             |
-| notee          | <nope>   | notee                        | Stop writing results to an output file.                     |
-| nowarnings     | \w       | nowarnings                   | Disable automatic warnings display.                         |
-| pager          | \P       | pager [command]              | Set pager to [command]. Print query results via pager.      |
-| prompt         | \R       | prompt <string>              | Change prompt format.                                       |
-| quit           | \q       | quit                         | Quit.                                                       |
-| redirectformat | \Tr      | redirectformat <format>      | Change the table format used to output redirected results.  |
-| rehash         | \#       | rehash                       | Refresh auto-completions.                                   |
-| source         | \.       | source <filename>            | Execute commands from file.                                 |
-| status         | \s       | status                       | Get status information from the server.                     |
-| system         | <nope>   | system <command>             | Execute a system shell commmand.                            |
-| tableformat    | \T       | tableformat <format>         | Change the table format used to output interactive results. |
-| tee            | <nope>   | tee [-o] <filename>          | Append all results to an output file (overwrite using -o).  |
-| use            | \u       | use <database>               | Change to a new database.                                   |
-| warnings       | \W       | warnings                     | Enable automatic warnings display.                          |
-| watch          | <nope>   | watch [seconds] [-c] <query> | Executes the query every [seconds] seconds (by default 5).  |
-+----------------+----------+------------------------------+-------------------------------------------------------------+
++----------------+----------+---------------------------------+-------------------------------------------------------------+
+| Command        | Shortcut | Usage                           | Description                                                 |
++----------------+----------+---------------------------------+-------------------------------------------------------------+
+| \G             | <nope>   | <query>\G                       | Display query results vertically.                           |
+| \bug           | <nope>   | \bug                            | File a bug on GitHub.                                       |
+| \clip          | <nope>   | <query>\clip                    | Copy query to the system clipboard.                         |
+| \dt            | <nope>   | \dt[+] [table]                  | List or describe tables.                                    |
+| \edit          | \e       | <query>\edit | \edit <filename> | Edit query with editor (uses $EDITOR).                      |
+| \f             | <nope>   | \f [name [args..]]              | List or execute favorite queries.                           |
+| \fd            | <nope>   | \fd <name>                      | Delete a favorite query.                                    |
+| \fs            | <nope>   | \fs <name> <query>              | Save a favorite query.                                      |
+| \l             | <nope>   | \l                              | List databases.                                             |
+| \llm           | \ai      | \llm [arguments]                | Interrogate an LLM.                                         |
+| \once          | \o       | \once [-o] <filename>           | Append next result to an output file (overwrite using -o).  |
+| \pipe_once     | \|       | \pipe_once <command>            | Send next result to a subprocess.                           |
+| \timing        | \t       | \timing                         | Toggle timing of commands.                                  |
+| connect        | \r       | connect [database]              | Reconnect to the server, optionally switching databases.    |
+| delimiter      | <nope>   | delimiter <string>              | Change end-of-statement delimiter.                          |
+| exit           | \q       | exit                            | Exit.                                                       |
+| help           | \?       | help [term]                     | Show this help, or search for a term on the server.         |
+| nopager        | \n       | nopager                         | Disable pager, print to stdout.                             |
+| notee          | <nope>   | notee                           | Stop writing results to an output file.                     |
+| nowarnings     | \w       | nowarnings                      | Disable automatic warnings display.                         |
+| pager          | \P       | pager [command]                 | Set pager to [command]. Print query results via pager.      |
+| prompt         | \R       | prompt <string>                 | Change prompt format.                                       |
+| quit           | \q       | quit                            | Quit.                                                       |
+| redirectformat | \Tr      | redirectformat <format>         | Change the table format used to output redirected results.  |
+| rehash         | \#       | rehash                          | Refresh auto-completions.                                   |
+| source         | \.       | source <filename>               | Execute commands from file.                                 |
+| status         | \s       | status                          | Get status information from the server.                     |
+| system         | <nope>   | system <command>                | Execute a system shell commmand.                            |
+| tableformat    | \T       | tableformat <format>            | Change the table format used to output interactive results. |
+| tee            | <nope>   | tee [-o] <filename>             | Append all results to an output file (overwrite using -o).  |
+| use            | \u       | use <database>                  | Change to a new database.                                   |
+| warnings       | \W       | warnings                        | Enable automatic warnings display.                          |
+| watch          | <nope>   | watch [seconds] [-c] <query>    | Executes the query every [seconds] seconds (by default 5).  |
++----------------+----------+---------------------------------+-------------------------------------------------------------+

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -44,8 +44,13 @@ def test_set_get_expanded_output():
 
 def test_editor_command():
     assert mycli.packages.special.editor_command(r"hello\e")
-    assert mycli.packages.special.editor_command(r"\ehello")
+    assert mycli.packages.special.editor_command(r"hello\edit")
+    assert mycli.packages.special.editor_command(r"\e hello")
+    assert mycli.packages.special.editor_command(r"\edit hello")
+
     assert not mycli.packages.special.editor_command(r"hello")
+    assert not mycli.packages.special.editor_command(r"\ehello")
+    assert not mycli.packages.special.editor_command(r"\edithello")
 
     assert mycli.packages.special.get_filename(r"\e filename") == "filename"
 


### PR DESCRIPTION
## Description
Make `\edit` synonymous with the `\e` command, and preferred in the documentation.  Technically, `\e` becomes an alias for `\edit`.

At first glance there appears to be an ambiguity, due to the fact that `\e` is a leading substring of `\edit`, but there is not one, because we require a space between the command and filename in the _leading_ form, and because there is no ambiguity in the _trailing_ form.

Adding the space separator requirement here is reasonable because
 * that is how it works for other commands such as `\o`/`\once` (which also happens to share the same potential ambiguity)
 * the leading `\e` form is currently broken without a space: a command such as `\escript.sql` attempts to edit a literal query `script.sql` rather than opening a file, contrary to the documentation

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
