### PR TITLE
Show toolbar error messages in an error style

### DIFF
--- a/mycli/clitoolbar.py
+++ b/mycli/clitoolbar.py
@@ -43,7 +43,7 @@ def create_toolbar_tokens_func(mycli, show_initial_toolbar_help: Callable) -> Ca
 
         if mycli.toolbar_error_message:
             result.append(divider)
-            result.append(("class:bottom-toolbar", mycli.toolbar_error_message))
+            result.append(("class:bottom-toolbar.transaction.failed", mycli.toolbar_error_message))
             mycli.toolbar_error_message = None
 
         if mycli.multi_line:


### PR DESCRIPTION
## Description
Trivial followup to #1629, covered in the existing changelog entry.

<img width="1764" height="92" alt="last image" src="https://github.com/user-attachments/assets/11924a1a-a140-4e63-b10f-97142a605b5f" />


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
