### PR TITLE
Better tests for `null_string` config option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,11 @@ Bug Fixes
 * Ensure fullscreen in fuzzy history search.
 
 
+Internal
+---------
+* Better tests for `null_string` configuration option.
+
+
 Documentation
 ---------
 * Add `help <keyword>` to TIPS.

--- a/test/features/fixture_data/help_commands.txt
+++ b/test/features/fixture_data/help_commands.txt
@@ -1,25 +1,25 @@
 +----------------+----------+---------------------------------+-------------------------------------------------------------+
 | Command        | Shortcut | Usage                           | Description                                                 |
 +----------------+----------+---------------------------------+-------------------------------------------------------------+
-| \G             | <nope>   | <query>\G                       | Display query results vertically.                           |
-| \bug           | <nope>   | \bug                            | File a bug on GitHub.                                       |
-| \clip          | <nope>   | <query>\clip                    | Copy query to the system clipboard.                         |
-| \dt            | <nope>   | \dt[+] [table]                  | List or describe tables.                                    |
+| \G             | <null>   | <query>\G                       | Display query results vertically.                           |
+| \bug           | <null>   | \bug                            | File a bug on GitHub.                                       |
+| \clip          | <null>   | <query>\clip                    | Copy query to the system clipboard.                         |
+| \dt            | <null>   | \dt[+] [table]                  | List or describe tables.                                    |
 | \edit          | \e       | <query>\edit | \edit <filename> | Edit query with editor (uses $VISUAL or $EDITOR).           |
-| \f             | <nope>   | \f [name [args..]]              | List or execute favorite queries.                           |
-| \fd            | <nope>   | \fd <name>                      | Delete a favorite query.                                    |
-| \fs            | <nope>   | \fs <name> <query>              | Save a favorite query.                                      |
-| \l             | <nope>   | \l                              | List databases.                                             |
+| \f             | <null>   | \f [name [args..]]              | List or execute favorite queries.                           |
+| \fd            | <null>   | \fd <name>                      | Delete a favorite query.                                    |
+| \fs            | <null>   | \fs <name> <query>              | Save a favorite query.                                      |
+| \l             | <null>   | \l                              | List databases.                                             |
 | \llm           | \ai      | \llm [arguments]                | Interrogate an LLM.  See "\llm help".                       |
 | \once          | \o       | \once [-o] <filename>           | Append next result to an output file (overwrite using -o).  |
 | \pipe_once     | \|       | \pipe_once <command>            | Send next result to a subprocess.                           |
 | \timing        | \t       | \timing                         | Toggle timing of queries.                                   |
 | connect        | \r       | connect [database]              | Reconnect to the server, optionally switching databases.    |
-| delimiter      | <nope>   | delimiter <string>              | Change end-of-statement delimiter.                          |
+| delimiter      | <null>   | delimiter <string>              | Change end-of-statement delimiter.                          |
 | exit           | \q       | exit                            | Exit.                                                       |
 | help           | \?       | help [term]                     | Show this help, or search for a term on the server.         |
 | nopager        | \n       | nopager                         | Disable pager; print to stdout.                             |
-| notee          | <nope>   | notee                           | Stop writing results to an output file.                     |
+| notee          | <null>   | notee                           | Stop writing results to an output file.                     |
 | nowarnings     | \w       | nowarnings                      | Disable automatic warnings display.                         |
 | pager          | \P       | pager [command]                 | Set pager to [command]. Print query results via pager.      |
 | prompt         | \R       | prompt <string>                 | Change prompt format.                                       |
@@ -28,10 +28,10 @@
 | rehash         | \#       | rehash                          | Refresh auto-completions.                                   |
 | source         | \.       | source <filename>               | Execute queries from a file.                                |
 | status         | \s       | status                          | Get status information from the server.                     |
-| system         | <nope>   | system <command>                | Execute a system shell commmand.                            |
+| system         | <null>   | system <command>                | Execute a system shell commmand.                            |
 | tableformat    | \T       | tableformat <format>            | Change the table format used to output interactive results. |
-| tee            | <nope>   | tee [-o] <filename>             | Append all results to an output file (overwrite using -o).  |
+| tee            | <null>   | tee [-o] <filename>             | Append all results to an output file (overwrite using -o).  |
 | use            | \u       | use <database>                  | Change to a new database.                                   |
 | warnings       | \W       | warnings                        | Enable automatic warnings display.                          |
-| watch          | <nope>   | watch [seconds] [-c] <query>    | Execute query every [seconds] seconds (5 by default).       |
+| watch          | <null>   | watch [seconds] [-c] <query>    | Execute query every [seconds] seconds (5 by default).       |
 +----------------+----------+---------------------------------+-------------------------------------------------------------+

--- a/test/features/steps/crud_table.py
+++ b/test/features/steps/crud_table.py
@@ -118,7 +118,7 @@ def step_see_null_selected(context):
             +--------+\r
             | NULL   |\r
             +--------+\r
-            | <nope> |\r
+            | <null> |\r
             +--------+
             """
         ).strip()

--- a/test/myclirc
+++ b/test/myclirc
@@ -66,7 +66,7 @@ redirect_format = csv
 # How to display the missing value (ie NULL).  Only certain table formats
 # support configuring the missing value.  CSV for example always uses the
 # empty string, and JSON formats use native nulls.
-null_string = <nope>
+null_string = <null>
 
 # How to align numeric data in tabular output: right or left.
 numeric_alignment = right

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -70,7 +70,7 @@ def test_binary_display_hex(executor, capsys):
         sqlresult.postamble,
         False,
         False,
-        "<nope>",
+        "<null>",
         "right",
         "hex",
         None,
@@ -110,7 +110,7 @@ def test_binary_display_utf8(executor, capsys):
         sqlresult.postamble,
         False,
         False,
-        "<nope>",
+        "<null>",
         "right",
         "utf8",
         None,
@@ -1172,3 +1172,29 @@ def test_execute_with_logfile(executor):
             os.remove(logfile.name)
     except Exception as e:
         print(f"An error occurred while attempting to delete the file: {e}")
+
+
+def test_null_string_config(monkeypatch):
+    monkeypatch.setattr(MyCli, 'system_config_files', [])
+    monkeypatch.setattr(MyCli, 'pwd_config_file', os.devnull)
+    runner = CliRunner()
+    # keep Windows from locking the file with delete=False
+    with NamedTemporaryFile(mode='w', delete=False) as myclirc:
+        myclirc.write(
+            dedent("""\
+            [main]
+            null_string = <nope>
+            """)
+        )
+        myclirc.flush()
+        args = CLI_ARGS + ['--myclirc', myclirc.name, '--format=table', '--execute', 'SELECT NULL']
+        result = runner.invoke(mycli.main.cli, args=args)
+        assert '<nope>' in result.output
+        assert '<null>' not in result.output
+
+    # delete=False means we should try to clean up
+    try:
+        if os.path.exists(myclirc.name):
+            os.remove(myclirc.name)
+    except Exception as e:
+        print(f'An error occurred while attempting to delete the file: {e}')


### PR DESCRIPTION
## Description
Instead of setting `null_string` for all tests in `test/myclirc`, let `test/myclirc` be closer to the default, and set `null_string` to a special value for a single test.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
