### PR TITLE
Better cleanup of resources in the test suite

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@ Bug Fixes
 Internal
 ---------
 * Better tests for `null_string` configuration option.
+* Better cleanup of resources in the test suite.
 
 
 Documentation

--- a/test/features/steps/basic_commands.py
+++ b/test/features/steps/basic_commands.py
@@ -14,6 +14,8 @@ from textwrap import dedent
 from behave import then, when
 import wrappers
 
+from test.utils import TEMPFILE_PREFIX
+
 
 @when("we run dbcli")
 def step_run_cli(context):
@@ -55,7 +57,7 @@ def step_send_help(context):
 
 @when("we send source command")
 def step_send_source_command(context):
-    with tempfile.NamedTemporaryFile() as f:
+    with tempfile.NamedTemporaryFile(prefix=TEMPFILE_PREFIX) as f:
         f.write(b"\\?")
         f.flush()
         context.cli.sendline(f"\\. {f.name}")

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -89,17 +89,12 @@ def test_corrupted_pad():
     assert "user" not in contents
 
 
-def test_get_mylogin_cnf_path():
+def test_get_mylogin_cnf_path(monkeypatch):
     """Tests that the path for .mylogin.cnf is detected."""
-    original_env = None
-    if "MYSQL_TEST_LOGIN_FILE" in os.environ:
-        original_env = os.environ.pop("MYSQL_TEST_LOGIN_FILE")
+    monkeypatch.delenv('MYSQL_TEST_LOGIN_FILE', raising=False)
     is_windows = sys.platform == "win32"
 
     login_cnf_path = get_mylogin_cnf_path()
-
-    if original_env is not None:
-        os.environ["MYSQL_TEST_LOGIN_FILE"] = original_env
 
     if login_cnf_path is not None:
         assert login_cnf_path.endswith(".mylogin.cnf")
@@ -111,21 +106,21 @@ def test_get_mylogin_cnf_path():
             assert login_cnf_path.startswith(home_dir)
 
 
-def test_alternate_get_mylogin_cnf_path():
+def test_alternate_get_mylogin_cnf_path(monkeypatch):
     """Tests that the alternate path for .mylogin.cnf is detected."""
-    original_env = None
-    if "MYSQL_TEST_LOGIN_FILE" in os.environ:
-        original_env = os.environ.pop("MYSQL_TEST_LOGIN_FILE")
 
-    _, temp_path = tempfile.mkstemp()
-    os.environ["MYSQL_TEST_LOGIN_FILE"] = temp_path
+    fd, temp_path = tempfile.mkstemp()
+    monkeypatch.setenv('MYSQL_TEST_LOGIN_FILE', temp_path)
 
     login_cnf_path = get_mylogin_cnf_path()
 
-    if original_env is not None:
-        os.environ["MYSQL_TEST_LOGIN_FILE"] = original_env
-
     assert temp_path == login_cnf_path
+
+    try:
+        os.close(fd)
+        os.remove(temp_path)
+    except Exception:
+        pass
 
 
 def test_str_to_bool():

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -16,7 +16,7 @@ from mycli.packages.parseutils import is_valid_connection_scheme
 import mycli.packages.special
 from mycli.packages.special.main import COMMANDS as SPECIAL_COMMANDS
 from mycli.sqlexecute import ServerInfo, SQLExecute
-from test.utils import DATABASE, HOST, PASSWORD, PORT, USER, dbtest, run
+from test.utils import DATABASE, HOST, PASSWORD, PORT, TEMPFILE_PREFIX, USER, dbtest, run
 
 test_dir = os.path.abspath(os.path.dirname(__file__))
 project_dir = os.path.dirname(test_dir)
@@ -464,7 +464,7 @@ def test_execute_arg_with_checkpoint(executor):
     sql = "select * from test;"
     runner = CliRunner()
 
-    with NamedTemporaryFile(mode="w", delete=False) as checkpoint:
+    with NamedTemporaryFile(prefix=TEMPFILE_PREFIX, mode="w", delete=False) as checkpoint:
         checkpoint.close()
 
     result = runner.invoke(cli, args=CLI_ARGS + ["--execute", sql, f"--checkpoint={checkpoint.name}"])
@@ -687,10 +687,10 @@ def test_reserved_space_is_integer(monkeypatch):
 
 def test_list_dsn(monkeypatch):
     monkeypatch.setattr(MyCli, "system_config_files", [])
-    monkeypatch.setattr(MyCli, "pwd_config_file", os.path.join(test_dir, "does_not_exist.myclirc"))
+    monkeypatch.setattr(MyCli, "pwd_config_file", os.devnull)
     runner = CliRunner()
     # keep Windows from locking the file with delete=False
-    with NamedTemporaryFile(mode="w", delete=False) as myclirc:
+    with NamedTemporaryFile(prefix=TEMPFILE_PREFIX, mode="w", delete=False) as myclirc:
         myclirc.write(
             dedent("""\
             [alias_dsn]
@@ -729,7 +729,7 @@ def test_unprettify_statement():
 def test_list_ssh_config():
     runner = CliRunner()
     # keep Windows from locking the file with delete=False
-    with NamedTemporaryFile(mode="w", delete=False) as ssh_config:
+    with NamedTemporaryFile(prefix=TEMPFILE_PREFIX, mode="w", delete=False) as ssh_config:
         ssh_config.write(
             dedent("""\
             Host test
@@ -1058,7 +1058,7 @@ def test_ssh_config(monkeypatch):
 
     # Setup temporary configuration
     # keep Windows from locking the file with delete=False
-    with NamedTemporaryFile(mode="w", delete=False) as ssh_config:
+    with NamedTemporaryFile(prefix=TEMPFILE_PREFIX, mode="w", delete=False) as ssh_config:
         ssh_config.write(
             dedent("""\
             Host test
@@ -1161,7 +1161,7 @@ def test_execute_with_logfile(executor):
     sql = 'select 1'
     runner = CliRunner()
 
-    with NamedTemporaryFile(mode="w", delete=False) as logfile:
+    with NamedTemporaryFile(prefix=TEMPFILE_PREFIX, mode="w", delete=False) as logfile:
         result = runner.invoke(mycli.main.cli, args=CLI_ARGS + ["--logfile", logfile.name, "--execute", sql])
         assert result.exit_code == 0
 

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -10,10 +10,11 @@ from pymysql import ProgrammingError
 import pytest
 
 import mycli.packages.special
-from test.utils import db_connection, dbtest, send_ctrl_c
+from test.utils import TEMPFILE_PREFIX, db_connection, dbtest, send_ctrl_c
 
 
-def test_set_get_pager():
+def test_set_get_pager(monkeypatch):
+    monkeypatch.setenv('PAGER', '')
     mycli.packages.special.set_pager_enabled(True)
     assert mycli.packages.special.is_pager_enabled()
     mycli.packages.special.set_pager_enabled(False)
@@ -42,7 +43,10 @@ def test_set_get_expanded_output():
     assert not mycli.packages.special.is_expanded_output()
 
 
-def test_editor_command():
+def test_editor_command(monkeypatch):
+    monkeypatch.setenv('EDITOR', 'true')
+    monkeypatch.setenv('VISUAL', 'true')
+
     assert mycli.packages.special.editor_command(r"hello\e")
     assert mycli.packages.special.editor_command(r"hello\edit")
     assert mycli.packages.special.editor_command(r"\e hello")
@@ -54,8 +58,6 @@ def test_editor_command():
 
     assert mycli.packages.special.get_filename(r"\e filename") == "filename"
 
-    os.environ["EDITOR"] = "true"
-    os.environ["VISUAL"] = "true"
     if os.name != "nt":
         assert mycli.packages.special.open_external_editor(sql=r"select 1") == ('select 1', None)
     else:
@@ -65,7 +67,7 @@ def test_editor_command():
 def test_tee_command():
     mycli.packages.special.write_tee("hello world")  # write without file set
     # keep Windows from locking the file with delete=False
-    with tempfile.NamedTemporaryFile(delete=False) as f:
+    with tempfile.NamedTemporaryFile(prefix=TEMPFILE_PREFIX, delete=False) as f:
         mycli.packages.special.execute(None, "tee " + f.name)
         mycli.packages.special.write_tee("hello world")
         if os.name == "nt":
@@ -103,7 +105,7 @@ def test_tee_command_error():
         mycli.packages.special.execute(None, "tee")
 
     with pytest.raises(OSError):
-        with tempfile.NamedTemporaryFile() as f:
+        with tempfile.NamedTemporaryFile(prefix=TEMPFILE_PREFIX) as f:
             os.chmod(f.name, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
             mycli.packages.special.execute(None, f"tee {f.name}")
 
@@ -137,7 +139,7 @@ def test_once_command():
 
     mycli.packages.special.write_once("hello world")  # write without file set
     # keep Windows from locking the file with delete=False
-    with tempfile.NamedTemporaryFile(delete=False) as f:
+    with tempfile.NamedTemporaryFile(prefix=TEMPFILE_PREFIX, delete=False) as f:
         mycli.packages.special.execute(None, "\\once " + f.name)
         mycli.packages.special.write_once("hello world")
         if os.name == "nt":
@@ -175,7 +177,7 @@ def test_pipe_once_command():
         mycli.packages.special.write_once("hello world")
         mycli.packages.special.flush_pipe_once_if_written(None)
     else:
-        with tempfile.NamedTemporaryFile() as f:
+        with tempfile.NamedTemporaryFile(prefix=TEMPFILE_PREFIX) as f:
             mycli.packages.special.execute(None, "\\pipe_once tee " + f.name)
             mycli.packages.special.write_pipe_once("hello world")
             mycli.packages.special.flush_pipe_once_if_written(None)

--- a/test/test_tabular_output.py
+++ b/test/test_tabular_output.py
@@ -16,7 +16,8 @@ from test.utils import HOST, PASSWORD, PORT, USER, dbtest
 def mycli():
     cli = MyCli()
     cli.connect(None, USER, PASSWORD, HOST, PORT, None, init_command=None)
-    return cli
+    yield cli
+    cli.sqlexecute.conn.close()
 
 
 @dbtest

--- a/test/utils.py
+++ b/test/utils.py
@@ -20,6 +20,7 @@ CHARACTER_SET = os.getenv("PYTEST_CHARSET", "utf8mb4")
 SSH_USER = os.getenv("PYTEST_SSH_USER", None)
 SSH_HOST = os.getenv("PYTEST_SSH_HOST", None)
 SSH_PORT = int(os.getenv("PYTEST_SSH_PORT", "22"))
+TEMPFILE_PREFIX = 'mycli_test_suite_'
 
 
 def db_connection(dbname=None):


### PR DESCRIPTION
 ## Description
* name tempfiles with a prefix in case they get left behind
 * use monkeypatch methods to manipulate environment variables, ensuring that state doesn't persist for another test
 * avoid creating file `does_not_exist.myclirc`
 * explicitly tear down `sqlexecute` connection in fixture

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
