### PR TITLE
Add environment variable section to `--checkup`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Features
 * Let `help <keyword>` list similar keywords when not found.
 * Optionally highlight fuzzy search previews.
 * Make `\edit` synonymous with the `\e` command.
+* Add environment variable section to `--checkup`.
 
 
 Bug Fixes
@@ -29,6 +30,7 @@ Documentation
 ---------
 * Add `help <keyword>` to TIPS.
 * Refine inline help descriptions.
+* Add `$VISUAL` environment variable hint to TIPS.
 
 
 1.57.0 (2026/02/25)

--- a/mycli/TIPS
+++ b/mycli/TIPS
@@ -54,6 +54,8 @@ edit a query in an external editor using <query>\edit!
 
 edit a query in an external editor using \edit <filename>!
 
+set "export VISUAL='code --wait'" in your shell to `\edit` queries using VS Code!
+
 \f lists favorite queries; \f <name> executes a favorite!
 
 \fs <name> <query> saves a favorite query!

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -2490,6 +2490,16 @@ def do_config_checkup(mycli: MyCli) -> None:
         else:
             print(f'The recommended "{executable}" executable was not found — some functionality will suffer.')
 
+    print('\n### Environment variables:\n')
+    for variable in [
+        'EDITOR',
+        'VISUAL',
+    ]:
+        if value := os.environ.get(variable):
+            print(f'The ${variable} environment variable was set to "{value}" — good!')
+        else:
+            print(f'The ${variable} environment variable was not set — some functionality will suffer.')
+
     indent = '    '
     transitions = {
         f'{indent}[main]\n{indent}default_character_set': f'{indent}[connection]\n{indent}default_character_set',


### PR DESCRIPTION
## Description
Add environment variable section to `--checkup`, covering editor setup, and add `$VISUAL` example to `TIPS`.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
