### PR TITLE
Use `transform_region()` for prettify/unprettify

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,17 +20,18 @@ Bug Fixes
 * Ensure fullscreen in fuzzy history search.
 
 
-Internal
----------
-* Better tests for `null_string` configuration option.
-* Better cleanup of resources in the test suite.
-
-
 Documentation
 ---------
 * Add `help <keyword>` to TIPS.
 * Refine inline help descriptions.
 * Add `$VISUAL` environment variable hint to TIPS.
+
+
+Internal
+---------
+* Better tests for `null_string` configuration option.
+* Better cleanup of resources in the test suite.
+* Simplify prettify/unprettify handlers.
 
 
 1.57.0 (2026/02/25)

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -166,14 +166,8 @@ def mycli_bindings(mycli) -> KeyBindings:
         _logger.debug("Detected <C-x p>/> key.")
 
         b = event.app.current_buffer
-        cursorpos_relative = b.cursor_position / max(1, len(b.text))
-        pretty_text = mycli.handle_prettify_binding(b.text)
-        if len(pretty_text) > 0:
-            b.text = pretty_text
-            cursorpos_abs = int(round(cursorpos_relative * len(b.text)))
-            while 0 < cursorpos_abs < len(b.text) and b.text[cursorpos_abs] in (" ", "\n"):
-                cursorpos_abs -= 1
-            b.cursor_position = min(cursorpos_abs, len(b.text))
+        if b.text:
+            b.transform_region(0, len(b.text), mycli.handle_prettify_binding)
 
     @kb.add("c-x", "u", filter=emacs_mode)
     def _(event: KeyPressEvent) -> None:
@@ -185,14 +179,8 @@ def mycli_bindings(mycli) -> KeyBindings:
         _logger.debug("Detected <C-x u>/< key.")
 
         b = event.app.current_buffer
-        cursorpos_relative = b.cursor_position / max(1, len(b.text))
-        unpretty_text = mycli.handle_unprettify_binding(b.text)
-        if len(unpretty_text) > 0:
-            b.text = unpretty_text
-            cursorpos_abs = int(round(cursorpos_relative * len(b.text)))
-            while 0 < cursorpos_abs < len(b.text) and b.text[cursorpos_abs] in (" ", "\n"):
-                cursorpos_abs -= 1
-            b.cursor_position = min(cursorpos_abs, len(b.text))
+        if b.text:
+            b.transform_region(0, len(b.text), mycli.handle_unprettify_binding)
 
     @kb.add("c-o", "d", filter=emacs_mode)
     def _(event: KeyPressEvent) -> None:


### PR DESCRIPTION
## Description
This method is built in to `prompt_toolkit`, and simpler.  The position of the cursor in the transformed text is still not precise, as expected. (It wasn't precise before.)

xref #1646 covers the bot's main issue.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
