### PR TITLE
Make toolbar widths consistent on toggle actions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 Upcoming (TBD)
 ==============
 
+Bug Fixes
+---------
+* Make toolbar widths consistent on toggle actions.
+
+
 Internal
 ---------
 * Use prompt_toolkit's `bell()`.

--- a/mycli/clitoolbar.py
+++ b/mycli/clitoolbar.py
@@ -21,7 +21,7 @@ def create_toolbar_tokens_func(mycli, show_initial_toolbar_help: Callable) -> Ca
         if mycli.completer.smart_completion:
             result.append(divider)
             result.append(("class:bottom-toolbar", "[F2] Smart-complete:"))
-            result.append(("class:bottom-toolbar.on", "ON"))
+            result.append(("class:bottom-toolbar.on", "ON "))
         else:
             result.append(divider)
             result.append(("class:bottom-toolbar", "[F2] Smart-complete:"))
@@ -30,7 +30,7 @@ def create_toolbar_tokens_func(mycli, show_initial_toolbar_help: Callable) -> Ca
         if mycli.multi_line:
             result.append(divider)
             result.append(("class:bottom-toolbar", "[F3] Multiline:"))
-            result.append(("class:bottom-toolbar.on", "ON"))
+            result.append(("class:bottom-toolbar.on", "ON "))
         else:
             result.append(divider)
             result.append(("class:bottom-toolbar", "[F3] Multiline:"))


### PR DESCRIPTION
## Description
Assuming a non-proportional font, if the ON and OFF texts have the same number of characters, then the letters to the right will not shift around when a setting is toggled via the function key.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
