### PR TITLE
Refactor `SQLResult` dataclass, `format_sqlresult()`, and callers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Bug Fixes
 Internal
 ---------
 * Use prompt_toolkit's `bell()`.
+* Refactor `SQLResult` dataclass.
 
 
 1.58.0 (2026/02/28)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -944,9 +944,9 @@ class MyCli:
             nonlocal mutating
             result_count = watch_count = 0
             for result in results:
-                logger.debug("title: %r", result.title)
-                logger.debug("headers: %r", result.headers)
-                logger.debug("rows: %r", result.results)
+                logger.debug("preamble: %r", result.preamble)
+                logger.debug("header: %r", result.header)
+                logger.debug("rows: %r", result.rows)
                 logger.debug("status: %r", result.status)
                 logger.debug("command: %r", result.command)
                 threshold = 1000
@@ -962,7 +962,7 @@ class MyCli:
                             sys.exit(1)
                     else:
                         watch_count += 1
-                if is_select(result.status) and isinstance(result.results, Cursor) and result.results.rowcount > threshold:
+                if is_select(result.status) and isinstance(result.rows, Cursor) and result.rows.rowcount > threshold:
                     self.echo(
                         f"The result set has more than {threshold} rows.",
                         fg="red",
@@ -979,17 +979,14 @@ class MyCli:
                 else:
                     max_width = None
 
-                formatted = self.format_output(
-                    result.title,
-                    result.results,
-                    result.headers,
-                    result.postamble,
-                    special.is_expanded_output(),
-                    special.is_redirected(),
-                    self.null_string,
-                    self.numeric_alignment,
-                    self.binary_display,
-                    max_width,
+                formatted = self.format_sqlresult(
+                    result,
+                    is_expanded=special.is_expanded_output(),
+                    is_redirected=special.is_redirected(),
+                    null_string=self.null_string,
+                    numeric_alignment=self.numeric_alignment,
+                    binary_display=self.binary_display,
+                    max_width=max_width,
                 )
 
                 t = time() - start
@@ -1013,20 +1010,17 @@ class MyCli:
                 mutating = mutating or is_mutating(result.status)
 
                 # get and display warnings if enabled
-                if self.show_warnings and isinstance(result.results, Cursor) and result.results.warning_count > 0:
+                if self.show_warnings and isinstance(result.rows, Cursor) and result.rows.warning_count > 0:
                     warnings = sqlexecute.run("SHOW WARNINGS")
                     for warning in warnings:
-                        formatted = self.format_output(
-                            warning.title,
-                            warning.results,
-                            warning.headers,
-                            warning.postamble,
-                            special.is_expanded_output(),
-                            special.is_redirected(),
-                            self.null_string,
-                            self.numeric_alignment,
-                            self.binary_display,
-                            max_width,
+                        formatted = self.format_sqlresult(
+                            warning,
+                            is_expanded=special.is_expanded_output(),
+                            is_redirected=special.is_redirected(),
+                            null_string=self.null_string,
+                            numeric_alignment=self.numeric_alignment,
+                            binary_display=self.binary_display,
+                            max_width=max_width,
                         )
                         self.echo("")
                         self.output(formatted, warning.status)
@@ -1190,7 +1184,7 @@ class MyCli:
                     # Restart connection to the database
                     sqlexecute.connect()
                     try:
-                        for _title, _cur, _headers, status in sqlexecute.run(f"kill {connection_id_to_kill}"):
+                        for _preamble, _cur, _headers, status in sqlexecute.run(f"kill {connection_id_to_kill}"):
                             status_str = str(status).lower()
                             if status_str.find("ok") > -1:
                                 logger.debug("cancelled query, connection id: %r, sql: %r", connection_id_to_kill, text)
@@ -1559,35 +1553,29 @@ class MyCli:
         for result in results:
             self.main_formatter.query = query
             self.redirect_formatter.query = query
-            output = self.format_output(
-                result.title,
-                result.results,
-                result.headers,
-                result.postamble,
-                special.is_expanded_output(),
-                special.is_redirected(),
-                self.null_string,
-                self.numeric_alignment,
-                self.binary_display,
+            output = self.format_sqlresult(
+                result,
+                is_expanded=special.is_expanded_output(),
+                is_redirected=special.is_redirected(),
+                null_string=self.null_string,
+                numeric_alignment=self.numeric_alignment,
+                binary_display=self.binary_display,
             )
             for line in output:
                 self.log_output(line)
                 click.echo(line, nl=new_line)
 
             # get and display warnings if enabled
-            if self.show_warnings and isinstance(result.results, Cursor) and result.results.warning_count > 0:
+            if self.show_warnings and isinstance(result.rows, Cursor) and result.rows.warning_count > 0:
                 warnings = self.sqlexecute.run("SHOW WARNINGS")
                 for warning in warnings:
-                    output = self.format_output(
-                        warning.title,
-                        warning.results,
-                        warning.headers,
-                        warning.postamble,
-                        special.is_expanded_output(),
-                        special.is_redirected(),
-                        self.null_string,
-                        self.numeric_alignment,
-                        self.binary_display,
+                    output = self.format_sqlresult(
+                        warning,
+                        is_expanded=special.is_expanded_output(),
+                        is_redirected=special.is_redirected(),
+                        null_string=self.null_string,
+                        numeric_alignment=self.numeric_alignment,
+                        binary_display=self.binary_display,
                     )
                     for line in output:
                         click.echo(line, nl=new_line)
@@ -1595,13 +1583,10 @@ class MyCli:
             checkpoint.write(query.rstrip('\n') + '\n')
             checkpoint.flush()
 
-    def format_output(
+    def format_sqlresult(
         self,
-        title: str | None,
-        cur: Cursor | list[tuple] | None,
-        headers: list[str] | str | None,
-        postamble: str | None,
-        expanded: bool = False,
+        result,
+        is_expanded: bool = False,
         is_redirected: bool = False,
         null_string: str | None = None,
         numeric_alignment: str = 'right',
@@ -1613,7 +1598,7 @@ class MyCli:
         else:
             use_formatter = self.main_formatter
 
-        expanded = expanded or use_formatter.format_name == "vertical"
+        is_expanded = is_expanded or use_formatter.format_name == "vertical"
         output: itertools.chain[str] = itertools.chain()
 
         output_kwargs = {
@@ -1631,31 +1616,33 @@ class MyCli:
             # will run before preprocessors defined as part of the format in cli_helpers
             output_kwargs["preprocessors"] = (preprocessors.convert_to_undecoded_string,)
 
-        if title:
-            output = itertools.chain(output, [title])
+        if result.preamble:
+            output = itertools.chain(output, [result.preamble])
 
-        if headers or (cur and title):
+        if result.header or (result.rows and result.preamble):
             column_types = None
             colalign = None
-            if isinstance(cur, Cursor):
+            if isinstance(result.rows, Cursor):
 
                 def get_col_type(col) -> type:
                     col_type = FIELD_TYPES.get(col[1], str)
                     return col_type if type(col_type) is type else str
 
-                if cur.rowcount > 0:
-                    column_types = [get_col_type(tup) for tup in cur.description]
+                if result.rows.rowcount > 0:
+                    column_types = [get_col_type(tup) for tup in result.rows.description]
                     colalign = [numeric_alignment if x in (int, float, Decimal) else 'left' for x in column_types]
                 else:
                     column_types, colalign = [], []
 
-            if max_width is not None and isinstance(cur, Cursor):
-                cur = list(cur)
+            if max_width is not None and isinstance(result.rows, Cursor):
+                result_rows = list(result.rows)
+            else:
+                result_rows = result.rows
 
             formatted = use_formatter.format_output(
-                cur,
-                headers,
-                format_name="vertical" if expanded else None,
+                result_rows,
+                result.header or [],
+                format_name="vertical" if is_expanded else None,
                 column_types=column_types,
                 colalign=colalign,
                 **output_kwargs,
@@ -1665,12 +1652,12 @@ class MyCli:
                 formatted = formatted.splitlines()
             formatted = iter(formatted)
 
-            if not expanded and max_width and headers and cur:
+            if not is_expanded and max_width and result.header and result_rows:
                 first_line = next(formatted)
                 if len(strip_ansi(first_line)) > max_width:
                     formatted = use_formatter.format_output(
-                        cur,
-                        headers,
+                        result_rows,
+                        result.header,
                         format_name="vertical",
                         column_types=column_types,
                         **output_kwargs,
@@ -1682,8 +1669,8 @@ class MyCli:
 
             output = itertools.chain(output, formatted)
 
-        if postamble:
-            output = itertools.chain(output, [postamble])
+        if result.postamble:
+            output = itertools.chain(output, [result.postamble])
 
         return output
 

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -27,25 +27,24 @@ def list_tables(
         query = "SHOW TABLES"
     logger.debug(query)
     cur.execute(query)
-    status = ""
     if cur.description:
-        headers = [x[0] for x in cur.description]
+        header = [x[0] for x in cur.description]
     else:
-        return [SQLResult(status="")]
+        return [SQLResult()]
 
     # Fetch results before potentially executing another query
     results = list(cur.fetchall()) if verbose and arg else cur
 
+    postamble = ''
     if verbose and arg:
         query = f'SHOW CREATE TABLE {arg}'
         logger.debug(query)
         cur.execute(query)
         if one := cur.fetchone():
-            # Returning the SHOW CREATE TABLE as a "status" keeps it unformatted,
-            # which is a hack.  There should be an unformmatted_results argument.
-            status = one[1]
+            postamble = one[1]
 
-    return [SQLResult(results=results, headers=headers, status=status)]
+    # todo missing a status line because sqlexecute.get_result was not used
+    return [SQLResult(header=header, rows=results, postamble=postamble)]
 
 
 @special_command("\\l", "\\l", "List databases.", arg_type=ArgType.RAW_QUERY, case_sensitive=True)
@@ -54,10 +53,11 @@ def list_databases(cur: Cursor, **_) -> list[SQLResult]:
     logger.debug(query)
     cur.execute(query)
     if cur.description:
-        headers = [x[0] for x in cur.description]
-        return [SQLResult(results=cur, headers=headers, status="")]
+        header = [x[0] for x in cur.description]
+        # todo missing a status line because sqlexecute.get_result was not used
+        return [SQLResult(header=header, rows=cur)]
     else:
-        return [SQLResult(status="")]
+        return [SQLResult()]
 
 
 @special_command(
@@ -86,11 +86,11 @@ def status(cur: Cursor, **_) -> list[SQLResult]:
         status = {k.decode("utf-8"): v.decode("utf-8") for k, v in status.items()}
 
     # Create output buffers.
-    title = []
+    preamble = []
     output = []
     footer = []
 
-    title.append("--------------")
+    preamble.append("--------------")
 
     # Output the mycli client information.
     implementation = platform.python_implementation()
@@ -98,7 +98,7 @@ def status(cur: Cursor, **_) -> list[SQLResult]:
     client_info = []
     client_info.append(f'mycli {__version__}')
     client_info.append(f'running on {implementation} {version}')
-    title.append(" ".join(client_info) + "\n")
+    preamble.append(" ".join(client_info) + "\n")
 
     # Build the output that will be displayed as a table.
     output.append(("Connection id:", cur.connection.thread_id()))
@@ -174,4 +174,4 @@ def status(cur: Cursor, **_) -> list[SQLResult]:
 
     footer.append("--------------")
 
-    return [SQLResult(title="\n".join(title), results=output, headers="", postamble="\n".join(footer))]
+    return [SQLResult(preamble="\n".join(preamble), rows=output, postamble="\n".join(footer))]

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -267,7 +267,6 @@ def set_redirect(command_part: str | None, file_operator_part: str | None, file_
 
 @special_command("\\f", "\\f [name [args..]]", "List or execute favorite queries.", arg_type=ArgType.PARSED_QUERY, case_sensitive=True)
 def execute_favorite_query(cur: Cursor, arg: str, **_) -> Generator[SQLResult, None, None]:
-    """Returns (title, rows, headers, status)"""
     if arg == "":
         yield from list_favorite_queries()
 
@@ -286,7 +285,7 @@ def execute_favorite_query(cur: Cursor, arg: str, **_) -> Generator[SQLResult, N
         else:
             for sql in sqlparse.split(query):
                 sql = sql.rstrip(";")
-                title = f"> {sql}" if is_show_favorite_query() else None
+                preamble = f"> {sql}" if is_show_favorite_query() else None
                 is_special = False
                 for special in SPECIAL_COMMANDS:
                     if sql.lower().startswith(special.lower()):
@@ -294,30 +293,29 @@ def execute_favorite_query(cur: Cursor, arg: str, **_) -> Generator[SQLResult, N
                         break
                 if is_special:
                     for result in special_execute(cur, sql):
-                        result.title = title
+                        result.preamble = preamble
                         # special_execute() already returns a SQLResult
                         yield result
                 else:
                     cur.execute(sql)
                     if cur.description:
-                        headers = [x[0] for x in cur.description]
-                        yield SQLResult(title=title, results=cur, headers=headers)
+                        header = [x[0] for x in cur.description]
+                        yield SQLResult(preamble=preamble, header=header, rows=cur)
                     else:
-                        yield SQLResult(title=title)
+                        yield SQLResult(preamble=preamble)
 
 
 def list_favorite_queries() -> list[SQLResult]:
-    """List of all favorite queries.
-    Returns (title, rows, headers, status)"""
+    """List of all favorite queries."""
 
-    headers = ["Name", "Query"]
+    header = ["Name", "Query"]
     rows = [(r, FavoriteQueries.instance.get(r)) for r in FavoriteQueries.instance.list()]
 
     if not rows:
         status = "\nNo favorite queries found." + FavoriteQueries.instance.usage
     else:
         status = ""
-    return [SQLResult(title="", results=rows, headers=headers, status=status)]
+    return [SQLResult(header=header, rows=rows, status=status)]
 
 
 def subst_favorite_query_args(query: str, args: list[str]) -> list[str | None]:
@@ -338,8 +336,7 @@ def subst_favorite_query_args(query: str, args: list[str]) -> list[str | None]:
 
 @special_command("\\fs", "\\fs <name> <query>", "Save a favorite query.")
 def save_favorite_query(arg: str, **_) -> list[SQLResult]:
-    """Save a new favorite query.
-    Returns (title, rows, headers, status)"""
+    """Save a new favorite query."""
 
     usage = "Syntax: \\fs name query.\n\n" + FavoriteQueries.instance.usage
     if not arg:
@@ -601,17 +598,17 @@ def watch_query(arg: str, **kwargs) -> Generator[SQLResult, None, None]:
             # Somewhere in the code the pager its activated after every yield,
             # so we disable it in every iteration
             set_pager_enabled(False)
-            for sql, title in sql_list:
+            for sql, preamble in sql_list:
                 cur.execute(sql)
                 command: dict[str, str | float] = {
                     "name": "watch",
                     "seconds": seconds,
                 }
                 if cur.description:
-                    headers = [x[0] for x in cur.description]
-                    yield SQLResult(title=title, results=cur, headers=headers, command=command)
+                    header = [x[0] for x in cur.description]
+                    yield SQLResult(preamble=preamble, header=header, rows=cur, command=command)
                 else:
-                    yield SQLResult(title=title, command=command)
+                    yield SQLResult(preamble=preamble, command=command)
             sleep(seconds)
         except KeyboardInterrupt:
             # This prints the Ctrl-C character in its own line, which prevents

--- a/mycli/packages/special/llm.py
+++ b/mycli/packages/special/llm.py
@@ -226,9 +226,9 @@ def handle_llm(
 ) -> tuple[str, str | None, float]:
     _, verbosity, arg = parse_special_command(text)
     if not LLM_IMPORTED:
-        raise FinishIteration(results=[SQLResult(title=NEED_DEPENDENCIES, results=[])])
+        raise FinishIteration(results=[SQLResult(preamble=NEED_DEPENDENCIES)])
     if arg.strip().lower() in ['', 'help', '?', r'\?']:
-        raise FinishIteration(results=[SQLResult(title=USAGE, results=[])])
+        raise FinishIteration(results=[SQLResult(preamble=USAGE)])
     parts = shlex.split(arg)
     restart = False
     if "-c" in parts:
@@ -255,14 +255,14 @@ def handle_llm(
         if capture_output:
             click.echo("Calling llm command")
             start = time()
-            _, result = run_external_cmd("llm", *args, capture_output=capture_output)
+            _, output = run_external_cmd("llm", *args, capture_output=capture_output)
             end = time()
-            match = re.search(_SQL_CODE_FENCE, result, re.DOTALL)
+            match = re.search(_SQL_CODE_FENCE, output, re.DOTALL)
             if match:
                 sql = match.group(1).strip()
             else:
-                raise FinishIteration(results=[SQLResult(title=result, results=[])])
-            return (result if verbosity == Verbosity.SUCCINCT else "", sql, end - start)
+                raise FinishIteration(results=[SQLResult(preamble=output)])
+            return (output if verbosity == Verbosity.SUCCINCT else "", sql, end - start)
         else:
             run_external_cmd("llm", *args, restart_cli=restart)
             raise FinishIteration(results=None)

--- a/mycli/packages/special/main.py
+++ b/mycli/packages/special/main.py
@@ -161,13 +161,13 @@ def execute(cur: Cursor, sql: str) -> list[SQLResult]:
     "help", "help [term]", "Show this help, or search for a term on the server.", arg_type=ArgType.NO_QUERY, aliases=["\\?", "?"]
 )
 def show_help(*_args) -> list[SQLResult]:
-    headers = ["Command", "Shortcut", "Usage", "Description"]
+    header = ["Command", "Shortcut", "Usage", "Description"]
     result = []
 
     for _, value in sorted(COMMANDS.items()):
         if not value.hidden:
             result.append((value.command, value.shortcut, value.usage, value.description))
-    return [SQLResult(results=result, headers=headers, postamble=f'Docs index — {DOCS_URL}')]
+    return [SQLResult(header=header, rows=result, postamble=f'Docs index — {DOCS_URL}')]
 
 
 def show_keyword_help(cur: Cursor, arg: str) -> list[SQLResult]:
@@ -182,13 +182,13 @@ def show_keyword_help(cur: Cursor, arg: str) -> list[SQLResult]:
     logger.debug(query)
     cur.execute(query, keyword)
     if cur.description and cur.rowcount > 0:
-        headers = [x[0] for x in cur.description]
-        return [SQLResult(results=cur, headers=headers)]
+        header = [x[0] for x in cur.description]
+        return [SQLResult(header=header, rows=cur)]
     logger.debug(query)
     cur.execute(query, (f'%{keyword}%',))
     if cur.description and cur.rowcount > 0:
-        headers = [x[0] for x in cur.description]
-        return [SQLResult(title='Similar terms:', results=cur, headers=headers)]
+        header = [x[0] for x in cur.description]
+        return [SQLResult(preamble='Similar terms:', header=header, rows=cur)]
     else:
         return [SQLResult(status=f'No help found for "{keyword}".')]
 

--- a/mycli/packages/sqlresult.py
+++ b/mycli/packages/sqlresult.py
@@ -5,9 +5,9 @@ from pymysql.cursors import Cursor
 
 @dataclass
 class SQLResult:
-    title: str | None = None
-    results: Cursor | list[tuple] | None = None
-    headers: list[str] | str | None = None
+    preamble: str | None = None
+    header: list[str] | str | None = None
+    rows: Cursor | list[tuple] | None = None
     postamble: str | None = None
     status: str | None = None
     command: dict[str, str | float] | None = None
@@ -16,4 +16,4 @@ class SQLResult:
         return self
 
     def __str__(self):
-        return f"{self.title}, {self.results}, {self.headers}, {self.postamble}, {self.status}, {self.command}"
+        return f"{self.preamble}, {self.header}, {self.rows}, {self.postamble}, {self.status}, {self.command}"

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -340,10 +340,7 @@ class SQLExecute:
         self.server_info = ServerInfo.from_version_string(conn.server_version)  # type: ignore[attr-defined]
 
     def run(self, statement: str) -> Generator[SQLResult, None, None]:
-        """Execute the sql in the database and return the results. The results
-        are a list of tuples. Each tuple has 4 values
-        (title, rows, headers, status).
-        """
+        """Execute the sql in the database and return the results."""
 
         # Remove spaces and EOL
         statement = statement.strip()
@@ -389,13 +386,13 @@ class SQLExecute:
 
     def get_result(self, cursor: Cursor) -> SQLResult:
         """Get the current result's data from the cursor."""
-        title = headers = None
+        preamble = header = None
 
         # cursor.description is not None for queries that return result sets,
         # e.g. SELECT or SHOW.
         plural = '' if cursor.rowcount == 1 else 's'
         if cursor.description:
-            headers = [x[0] for x in cursor.description]
+            header = [x[0] for x in cursor.description]
             status = f'{cursor.rowcount} row{plural} in set'
         else:
             _logger.debug("No rows in result.")
@@ -405,7 +402,7 @@ class SQLExecute:
             plural = '' if cursor.warning_count == 1 else 's'
             status = f'{status}, {cursor.warning_count} warning{plural}'
 
-        return SQLResult(title=title, results=cursor, headers=headers, status=status)
+        return SQLResult(preamble=preamble, header=header, rows=cursor, status=status)
 
     def tables(self) -> Generator[tuple[str], None, None]:
         """Yields table names"""
@@ -511,7 +508,7 @@ class SQLExecute:
         try:
             results = self.run("select connection_id()")
             for result in results:
-                cur = result.results
+                cur = result.rows
                 if isinstance(cur, Cursor):
                     v = cur.fetchone()
                     self.connection_id = v[0] if v is not None else -1

--- a/test/test_completion_refresher.py
+++ b/test/test_completion_refresher.py
@@ -49,9 +49,9 @@ def test_refresh_called_once(refresher):
     with patch.object(refresher, "_bg_refresh") as bg_refresh:
         actual = refresher.refresh(sqlexecute, callbacks)
         time.sleep(1)  # Wait for the thread to work.
-        assert actual[0].title is None
-        assert actual[0].results is None
-        assert actual[0].headers is None
+        assert actual[0].preamble is None
+        assert actual[0].header is None
+        assert actual[0].rows is None
         assert actual[0].status == "Auto-completion refresh started in the background."
         bg_refresh.assert_called_with(sqlexecute, callbacks, {})
 
@@ -74,16 +74,16 @@ def test_refresh_called_twice(refresher):
 
     actual1 = refresher.refresh(sqlexecute, callbacks)
     time.sleep(1)  # Wait for the thread to work.
-    assert actual1[0].title is None
-    assert actual1[0].results is None
-    assert actual1[0].headers is None
+    assert actual1[0].preamble is None
+    assert actual1[0].header is None
+    assert actual1[0].rows is None
     assert actual1[0].status == "Auto-completion refresh started in the background."
 
     actual2 = refresher.refresh(sqlexecute, callbacks)
     time.sleep(1)  # Wait for the thread to work.
-    assert actual2[0].title is None
-    assert actual2[0].results is None
-    assert actual2[0].headers is None
+    assert actual2[0].preamble is None
+    assert actual2[0].header is None
+    assert actual2[0].rows is None
     assert actual2[0].status == "Auto-completion refresh restarted."
 
 

--- a/test/test_dbspecial.py
+++ b/test/test_dbspecial.py
@@ -56,18 +56,18 @@ def test_list_tables_verbose_preserves_field_results():
     assert len(results) == 1
     result = results[0]
 
-    # The headers should be from SHOW FIELDS
-    assert result.headers == ['Field', 'Type', 'Null', 'Key', 'Default', 'Extra']
+    # The header should be from SHOW FIELDS
+    assert result.header == ['Field', 'Type', 'Null', 'Key', 'Default', 'Extra']
 
     # The results should contain the field data, not be empty
     # Convert to list if it's a cursor or iterable
-    result_data = list(result.results) if hasattr(result.results, '__iter__') else result.results
+    result_data = list(result.rows) if hasattr(result.rows, '__iter__') else result.rows
     assert len(result_data) == 2
     assert result_data[0][0] == 'id'
     assert result_data[1][0] == 'name'
 
-    # The status should contain the CREATE TABLE statement
-    assert 'CREATE TABLE' in result.status
+    # The postamble should contain the CREATE TABLE statement
+    assert 'CREATE TABLE' in result.postamble
 
 
 def test_u_suggests_databases():

--- a/test/test_llm_special.py
+++ b/test/test_llm_special.py
@@ -29,7 +29,7 @@ def test_llm_command_without_args(mock_llm, executor):
     with pytest.raises(FinishIteration) as exc_info:
         handle_llm(test_text, executor, 'mysql', 0, 0)
     # Should return usage message when no args provided
-    assert exc_info.value.results == [SQLResult(title=USAGE, results=[])]
+    assert exc_info.value.results == [SQLResult(preamble=USAGE)]
 
 
 @patch("mycli.packages.special.llm.llm")
@@ -42,7 +42,7 @@ def test_llm_command_with_help_subcommand(mock_llm, executor):
     with pytest.raises(FinishIteration) as exc_info:
         handle_llm(test_text, executor, 'mysql', 0, 0)
     # Should return usage message when "help" subcommand or variant is provided
-    assert exc_info.value.results == [SQLResult(title=USAGE, results=[])]
+    assert exc_info.value.results == [SQLResult(preamble=USAGE)]
 
 
 @patch("mycli.packages.special.llm.llm")
@@ -55,7 +55,7 @@ def test_llm_command_with_c_flag(mock_run_cmd, mock_llm, executor):
     with pytest.raises(FinishIteration) as exc_info:
         handle_llm(test_text, executor, 'mysql', 0, 0)
     # Expect raw output when no SQL fence found
-    assert exc_info.value.results == [SQLResult(title=string, results=[])]
+    assert exc_info.value.results == [SQLResult(preamble=string)]
 
 
 @patch("mycli.packages.special.llm.llm")
@@ -210,4 +210,4 @@ def test_handle_llm_aliases_without_args(prefix, executor, monkeypatch):
     monkeypatch.setattr(llm_module, "llm", object())
     with pytest.raises(FinishIteration) as exc_info:
         handle_llm(prefix, executor, 'mysql', 0, 0)
-    assert exc_info.value.results == [SQLResult(title=USAGE, results=[])]
+    assert exc_info.value.results == [SQLResult(preamble=USAGE)]

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -63,17 +63,14 @@ def test_binary_display_hex(executor, capsys):
     )
     m.explicit_pager = False
     sqlresult = next(m.sqlexecute.run("select b'01101010' AS binary_test"))
-    formatted = m.format_output(
-        sqlresult.title,
-        sqlresult.results,
-        sqlresult.headers,
-        sqlresult.postamble,
-        False,
-        False,
-        "<null>",
-        "right",
-        "hex",
-        None,
+    formatted = m.format_sqlresult(
+        sqlresult,
+        is_expanded=False,
+        is_redirected=False,
+        null_string="<null>",
+        numeric_alignment="right",
+        binary_display="hex",
+        max_width=None,
     )
     m.output(formatted, sqlresult.status)
     expected = " 0x6a "
@@ -103,17 +100,14 @@ def test_binary_display_utf8(executor, capsys):
     )
     m.explicit_pager = False
     sqlresult = next(m.sqlexecute.run("select b'01101010' AS binary_test"))
-    formatted = m.format_output(
-        sqlresult.title,
-        sqlresult.results,
-        sqlresult.headers,
-        sqlresult.postamble,
-        False,
-        False,
-        "<null>",
-        "right",
-        "utf8",
-        None,
+    formatted = m.format_sqlresult(
+        sqlresult,
+        is_expanded=False,
+        is_redirected=False,
+        null_string="<null>",
+        numeric_alignment="right",
+        binary_display="utf8",
+        max_width=None,
     )
     m.output(formatted, sqlresult.status)
     expected = " j "
@@ -230,7 +224,7 @@ def test_reconnect_database_is_selected(executor, capsys):
         raise e
     m.reconnect()
     try:
-        next(m.sqlexecute.run("show tables")).results.fetchall()
+        next(m.sqlexecute.run("show tables")).rows.fetchall()
     except Exception as e:
         raise e
 

--- a/test/test_special_iocommands.py
+++ b/test/test_special_iocommands.py
@@ -116,7 +116,7 @@ def test_favorite_query():
     with db_connection().cursor() as cur:
         query = 'select "✔"'
         mycli.packages.special.execute(cur, f"\\fs check {query}")
-        assert next(mycli.packages.special.execute(cur, "\\f check")).title == "> " + query
+        assert next(mycli.packages.special.execute(cur, "\\f check")).preamble == "> " + query
 
 
 @dbtest
@@ -127,7 +127,7 @@ def test_special_favorite_query():
         mycli.packages.special.execute(cur, rf"\fs special {query}")
         assert (r'\G', None, r'<query>\G', 'Display query results vertically.') in next(
             mycli.packages.special.execute(cur, r'\f special')
-        ).results
+        ).rows
 
 
 def test_once_command():
@@ -216,11 +216,11 @@ def test_watch_query_iteration():
     the desired query and returns the given results."""
     expected_value = "1"
     query = f"SELECT {expected_value}"
-    expected_title = f"> {query}"
+    expected_preamble = f"> {query}"
     with db_connection().cursor() as cur:
         result = next(mycli.packages.special.iocommands.watch_query(arg=query, cur=cur))
-    assert result.title == expected_title
-    assert result.headers[0] == expected_value
+    assert result.preamble == expected_preamble
+    assert result.header[0] == expected_value
 
 
 @dbtest
@@ -239,7 +239,7 @@ def test_watch_query_full():
     wait_interval = 1
     expected_value = "1"
     query = f"SELECT {expected_value}"
-    expected_title = f"> {query}"
+    expected_preamble = f"> {query}"
     expected_results = [4, 5, 6, 7]  # Python 3.14 is skipping ahead to 6 or 7
     ctrl_c_process = send_ctrl_c(wait_interval)
     with db_connection().cursor() as cur:
@@ -247,8 +247,8 @@ def test_watch_query_full():
     ctrl_c_process.join(1)
     assert len(results) in expected_results
     for result in results:
-        assert result.title == expected_title
-        assert result.headers[0] == expected_value
+        assert result.preamble == expected_preamble
+        assert result.header[0] == expected_value
 
 
 @dbtest

--- a/test/test_sqlexecute.py
+++ b/test/test_sqlexecute.py
@@ -10,11 +10,26 @@ from mycli.sqlexecute import ServerInfo, ServerSpecies
 from test.utils import dbtest, is_expanded_output, run, set_expanded_output
 
 
-def assert_result_equal(result, title=None, rows=None, headers=None, status=None, auto_status=True, assert_contains=False):
+def assert_result_equal(
+    result,
+    preamble=None,
+    header=None,
+    rows=None,
+    status=None,
+    postamble=None,
+    auto_status=True,
+    assert_contains=False,
+):
     """Assert that an sqlexecute.run() result matches the expected values."""
     if status is None and auto_status and rows:
         status = f"{len(rows)} row{'s' if len(rows) > 1 else ''} in set"
-    fields = {"title": title, "rows": rows, "headers": headers, "status": status}
+    fields = {
+        "preamble": preamble,
+        "header": header,
+        "rows": rows,
+        "postamble": postamble,
+        "status": status,
+    }
 
     if assert_contains:
         # Do a loose match on the results using the *in* operator.
@@ -62,7 +77,7 @@ def test_conn(executor):
     run(executor, """insert into test values('abc')""")
     results = run(executor, """select * from test""")
 
-    assert_result_equal(results, headers=["a"], rows=[("abc",)])
+    assert_result_equal(results, header=["a"], rows=[("abc",)])
 
 
 @dbtest
@@ -71,7 +86,7 @@ def test_bools(executor):
     run(executor, """insert into test values(True)""")
     results = run(executor, """select * from test""")
 
-    assert_result_equal(results, headers=["a"], rows=[(1,)])
+    assert_result_equal(results, header=["a"], rows=[(1,)])
 
 
 @dbtest
@@ -86,7 +101,7 @@ def test_binary(executor):
         b"\xac\xdeC@"
     )
 
-    assert_result_equal(results, headers=["geom"], rows=[(geom,)])
+    assert_result_equal(results, header=["geom"], rows=[(geom,)])
 
 
 @dbtest
@@ -125,7 +140,7 @@ def test_unicode_support_in_output(executor):
 
     # See issue #24, this raises an exception without proper handling
     results = run(executor, "select * from unicodechars")
-    assert_result_equal(results, headers=["t"], rows=[("é",)])
+    assert_result_equal(results, header=["t"], rows=[("é",)])
 
 
 @dbtest
@@ -133,8 +148,8 @@ def test_multiple_queries_same_line(executor):
     results = run(executor, "select 'foo'; select 'bar'")
 
     expected = [
-        {"title": None, "headers": ["foo"], "rows": [("foo",)], "status": "1 row in set"},
-        {"title": None, "headers": ["bar"], "rows": [("bar",)], "status": "1 row in set"},
+        {"preamble": None, "header": ["foo"], "rows": [("foo",)], "postamble": None, "status": "1 row in set"},
+        {"preamble": None, "header": ["bar"], "rows": [("bar",)], "postamble": None, "status": "1 row in set"},
     ]
     assert expected == results
 
@@ -158,7 +173,7 @@ def test_favorite_query(executor):
     assert_result_equal(results, status="Saved.")
 
     results = run(executor, "\\f test-a")
-    assert_result_equal(results, title="> select * from test where a like 'a%'", headers=["a"], rows=[("abc",)], auto_status=False)
+    assert_result_equal(results, preamble="> select * from test where a like 'a%'", header=["a"], rows=[("abc",)], auto_status=False)
 
     results = run(executor, "\\fd test-a")
     assert_result_equal(results, status="test-a: Deleted.")
@@ -177,8 +192,8 @@ def test_favorite_query_multiple_statement(executor):
 
     results = run(executor, "\\f test-ad")
     expected = [
-        {"title": "> select * from test where a like 'a%'", "headers": ["a"], "rows": [("abc",)], "status": None},
-        {"title": "> select * from test where a like 'd%'", "headers": ["a"], "rows": [("def",)], "status": None},
+        {"preamble": "> select * from test where a like 'a%'", "header": ["a"], "rows": [("abc",)], "postamble": None, "status": None},
+        {"preamble": "> select * from test where a like 'd%'", "header": ["a"], "rows": [("def",)], "postamble": None, "status": None},
     ]
     assert expected == results
 
@@ -198,7 +213,7 @@ def test_favorite_query_expanded_output(executor):
 
     results = run(executor, "\\f test-ae \\G")
     assert is_expanded_output() is True
-    assert_result_equal(results, title="> select * from test", headers=["a"], rows=[("abc",)], auto_status=False)
+    assert_result_equal(results, preamble="> select * from test", header=["a"], rows=[("abc",)], auto_status=False)
 
     set_expanded_output(False)
 
@@ -216,7 +231,7 @@ def test_collapsed_output_special_command(executor):
 @dbtest
 def test_special_command(executor):
     results = run(executor, "\\?")
-    assert_result_equal(results, rows=("quit", "\\q", "quit", "Quit."), headers="Command", assert_contains=True, auto_status=False)
+    assert_result_equal(results, rows=("quit", "\\q", "quit", "Quit."), header="Command", assert_contains=True, auto_status=False)
 
 
 @dbtest
@@ -278,7 +293,7 @@ def test_cd_command_current_dir(executor):
 @dbtest
 def test_unicode_support(executor):
     results = run(executor, "SELECT '日本語' AS japanese;")
-    assert_result_equal(results, headers=["japanese"], rows=[("日本語",)])
+    assert_result_equal(results, header=["japanese"], rows=[("日本語",)])
 
 
 @dbtest
@@ -286,7 +301,7 @@ def test_timestamp_null(executor):
     run(executor, """create table ts_null(a timestamp null)""")
     run(executor, """insert into ts_null values(null)""")
     results = run(executor, """select * from ts_null""")
-    assert_result_equal(results, headers=["a"], rows=[(None,)])
+    assert_result_equal(results, header=["a"], rows=[(None,)])
 
 
 @dbtest
@@ -294,7 +309,7 @@ def test_datetime_null(executor):
     run(executor, """create table dt_null(a datetime null)""")
     run(executor, """insert into dt_null values(null)""")
     results = run(executor, """select * from dt_null""")
-    assert_result_equal(results, headers=["a"], rows=[(None,)])
+    assert_result_equal(results, header=["a"], rows=[(None,)])
 
 
 @dbtest
@@ -302,7 +317,7 @@ def test_date_null(executor):
     run(executor, """create table date_null(a date null)""")
     run(executor, """insert into date_null values(null)""")
     results = run(executor, """select * from date_null""")
-    assert_result_equal(results, headers=["a"], rows=[(None,)])
+    assert_result_equal(results, header=["a"], rows=[(None,)])
 
 
 @dbtest
@@ -310,7 +325,7 @@ def test_time_null(executor):
     run(executor, """create table time_null(a time null)""")
     run(executor, """insert into time_null values(null)""")
     results = run(executor, """select * from time_null""")
-    assert_result_equal(results, headers=["a"], rows=[(None,)])
+    assert_result_equal(results, header=["a"], rows=[(None,)])
 
 
 @dbtest
@@ -324,8 +339,8 @@ def test_multiple_results(executor):
 
     results = run(executor, "call dmtest;")
     expected = [
-        {"title": None, "rows": [(1,)], "headers": ["1"], "status": "1 row in set"},
-        {"title": None, "rows": [(2,)], "headers": ["2"], "status": "1 row in set"},
+        {"preamble": None, "header": ["1"], "rows": [(1,)], "postamble": None, "status": "1 row in set"},
+        {"preamble": None, "header": ["2"], "rows": [(2,)], "postamble": None, "status": "1 row in set"},
     ]
     assert results == expected
 

--- a/test/test_tabular_output.py
+++ b/test/test_tabular_output.py
@@ -23,7 +23,7 @@ def mycli():
 @dbtest
 def test_sql_output(mycli):
     """Test the sql output adapter."""
-    headers = ["letters", "number", "optional", "float", "binary"]
+    header = ["letters", "number", "optional", "float", "binary"]
 
     class FakeCursor:
         def __init__(self):
@@ -52,7 +52,7 @@ def test_sql_output(mycli):
     assert list(mycli.change_table_format("sql-update")) == [SQLResult(status="Changed table format to sql-update")]
     mycli.main_formatter.query = ""
     mycli.redirect_formatter.query = ""
-    output = mycli.format_output(None, FakeCursor(), headers, None, False, False)
+    output = mycli.format_sqlresult(SQLResult(header=header, rows=FakeCursor()))
     actual = "\n".join(output)
     assert actual == dedent("""\
             UPDATE `DUAL` SET
@@ -71,7 +71,7 @@ def test_sql_output(mycli):
     assert list(mycli.change_table_format("sql-update-2")) == [SQLResult(status="Changed table format to sql-update-2")]
     mycli.main_formatter.query = ""
     mycli.redirect_formatter.query = ""
-    output = mycli.format_output(None, FakeCursor(), headers, None, False, False)
+    output = mycli.format_sqlresult(SQLResult(header=header, rows=FakeCursor()))
     assert "\n".join(output) == dedent("""\
             UPDATE `DUAL` SET
               `optional` = NULL
@@ -87,7 +87,7 @@ def test_sql_output(mycli):
     assert list(mycli.change_table_format("sql-insert")) == [SQLResult(status="Changed table format to sql-insert")]
     mycli.main_formatter.query = ""
     mycli.redirect_formatter.query = ""
-    output = mycli.format_output(None, FakeCursor(), headers, None, False, False)
+    output = mycli.format_sqlresult(SQLResult(header=header, rows=FakeCursor()))
     assert "\n".join(output) == dedent("""\
             INSERT INTO `DUAL` (`letters`, `number`, `optional`, `float`, `binary`) VALUES
               ('abc', 1, NULL, 10.0e0, 0xaa)
@@ -97,7 +97,7 @@ def test_sql_output(mycli):
     assert list(mycli.change_table_format("sql-insert")) == [SQLResult(status="Changed table format to sql-insert")]
     mycli.main_formatter.query = "SELECT * FROM `table`"
     mycli.redirect_formatter.query = "SELECT * FROM `table`"
-    output = mycli.format_output(None, FakeCursor(), headers, None, False, False)
+    output = mycli.format_sqlresult(SQLResult(header=header, rows=FakeCursor()))
     assert "\n".join(output) == dedent("""\
             INSERT INTO table (`letters`, `number`, `optional`, `float`, `binary`) VALUES
               ('abc', 1, NULL, 10.0e0, 0xaa)
@@ -107,7 +107,7 @@ def test_sql_output(mycli):
     assert list(mycli.change_table_format("sql-insert")) == [SQLResult(status="Changed table format to sql-insert")]
     mycli.main_formatter.query = "SELECT * FROM `database`.`table`"
     mycli.redirect_formatter.query = "SELECT * FROM `database`.`table`"
-    output = mycli.format_output(None, FakeCursor(), headers, None, False, False)
+    output = mycli.format_sqlresult(SQLResult(header=header, rows=FakeCursor()))
     assert "\n".join(output) == dedent("""\
             INSERT INTO database.table (`letters`, `number`, `optional`, `float`, `binary`) VALUES
               ('abc', 1, NULL, 10.0e0, 0xaa)
@@ -115,14 +115,14 @@ def test_sql_output(mycli):
             ;""")
     # Test binary output format is a hex string
     assert list(mycli.change_table_format("psql")) == [SQLResult(status="Changed table format to psql")]
-    output = mycli.format_output(None, FakeCursor(), headers, None, False, False)
+    output = mycli.format_sqlresult(SQLResult(header=header, rows=FakeCursor()))
     assert '0xaabb' in '\n'.join(output)
 
 
 @dbtest
 def test_postamble_output(mycli):
     """Test the postamble output property."""
-    headers = ['letters', 'number', 'optional', 'float']
+    header = ['letters', 'number', 'optional', 'float']
 
     class FakeCursor:
         def __init__(self):
@@ -149,6 +149,6 @@ def test_postamble_output(mycli):
     postamble = 'postamble:\nfooter content'
     mycli.change_table_format('ascii')
     mycli.main_formatter.query = ''
-    output = mycli.format_output(None, FakeCursor(), headers, postamble, False, False)
+    output = mycli.format_sqlresult(SQLResult(header=header, rows=FakeCursor(), postamble=postamble))
     actual = "\n".join(output)
     assert actual.endswith(postamble)

--- a/test/utils.py
+++ b/test/utils.py
@@ -52,12 +52,14 @@ def run(executor, sql, rows_as_list=True):
     results = []
 
     for result in executor.run(sql):
-        title = result.title
-        rows = result.results
-        headers = result.headers
-        status = result.status
-        rows = list(rows) if (rows_as_list and rows) else rows
-        results.append({"title": title, "rows": rows, "headers": headers, "status": status})
+        rows = list(result.rows) if (rows_as_list and result.rows) else result.rows
+        results.append({
+            "preamble": result.preamble,
+            "header": result.header,
+            "rows": rows,
+            "postamble": result.postamble,
+            "status": result.status,
+        })
 
     return results
 


### PR DESCRIPTION
## Description
 * `SQLResult.title` -> `SQLResult.preamble` (to match `postamble`).
 * `SQLResult.headers` -> `SQLResult.header` (without an "s", compare with "rows", plural.  This is because the header is one row.).
 * `SQLResult.results` -> `SQLResult.rows` (this is the tabular output).
 * `SQLResult.postamble` stays the same.
 * `SQLResult.status` stays the same.
 * Put references in the above order wherever possible in callers and tests (not `header` after `rows`).
 * Recast `format_output()` method as `format_sqlresult()`.  This was always confusing because the formatter has its own `format_output()`.
 * Let `format_sqlresult()` take a single positional argument: the SQLResult instance, and let all other arguments be named parameters.
 * Use the `SQLResult` dataclass properties directly whenever possible, avoiding temporary variables.
 * Change variables to be passed to `SQLResult.header` to also be singular for clarity and consistency in callers.  _ie_, not `SQLResult(header=headers)`
 * Remove some needless parameters in `SQLResult` constructors.
 * Remove some outdated docstrings describing the return of tuples.
 * Recast a confusing variable name from `results` -> `output`.
 * Move `\dt+` `SHOW CREATE TABLE` content from `status` to `postamble` to make it pageable, per a todo comment.
 * Note that some special commands lack a consistent status line.

The only functional change is that `\dt+ <table>` now captures the `SHOW CREATE TABLE` statement in pageable output, because that content is now assigned to a different `SQLResult` property.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
