### PR TITLE
Complete filenames on more special commands

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 Upcoming (TBD)
 ==============
 
+Features
+---------
+* Offer filename completions on more special commands, such as `\edit`.
+
+
 Bug Fixes
 ---------
 * Make toolbar widths consistent on toggle actions.

--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -231,7 +231,19 @@ def suggest_special(text: str) -> list[dict[str, Any]]:
             {"type": "view", "schema": []},
             {"type": "schema"},
         ]
-    elif cmd.lower() in ["\\.", "source"]:
+    elif cmd.lower() in [
+        r'\.',
+        'source',
+        r'\o',
+        r'\once',
+        r'tee',
+    ]:
+        return [{"type": "file_name"}]
+    # todo: why is \edit case-sensitive?
+    elif cmd in [
+        r'\e',
+        r'\edit',
+    ]:
         return [{"type": "file_name"}]
     if cmd in ["\\llm", "\\ai"]:
         return [{"type": "llm"}]


### PR DESCRIPTION
## Description
Although filename completion has a number of limitations currently, we should still offer it on each special command which accepts a filename, not just `source`.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
