### PR TITLE
Set up prompt/continuation color configuration

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features
 ---------
 * Offer filename completions on more special commands, such as `\edit`.
 * Allow styling of status, timing, and warnings text.
+* Set up customization of prompt/continuation colors in `~/.myclirc`.
 
 
 Bug Fixes

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -244,6 +244,8 @@ arg-toolbar = 'noinherit bold'
 arg-toolbar.text = 'nobold'
 bottom-toolbar.transaction.valid = 'bg:#222222 #00ff5f bold'
 bottom-toolbar.transaction.failed = 'bg:#222222 #ff005f bold'
+prompt = ''
+continuation = ''
 
 # style classes for colored table output
 output.header = "#00ff5f bold"

--- a/test/myclirc
+++ b/test/myclirc
@@ -242,6 +242,8 @@ arg-toolbar = noinherit bold
 arg-toolbar.text = nobold
 bottom-toolbar.transaction.valid = "bg:#222222 #00ff5f bold"
 bottom-toolbar.transaction.failed = "bg:#222222 #ff005f bold"
+prompt = ''
+continuation = ''
 
 # style classes for colored table output
 output.header = "#00ff5f bold"


### PR DESCRIPTION
## Description
The prompt and continuation color configurations were already available in the code, but examples of the relevant settings were not present in `~/.myclirc`.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
