### PR TITLE
Avoid depending on a string match into `host_info` property, in `status` output.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ Internal
 ---------
 * Use prompt_toolkit's `bell()`.
 * Refactor `SQLResult` dataclass.
+* Avoid depending on string matches into host info.
 
 
 1.58.0 (2026/02/28)

--- a/mycli/packages/special/dbcommands.py
+++ b/mycli/packages/special/dbcommands.py
@@ -128,7 +128,7 @@ def status(cur: Cursor, **_) -> list[SQLResult]:
     output.append(("Protocol version:", variables["protocol_version"]))
     output.append(('SSL/TLS version:', get_ssl_version(cur)))
 
-    if getattr(cur.connection, 'unix_socket', None) is not None:
+    if getattr(cur.connection, 'unix_socket', None):
         host_info = cur.connection.host_info
     else:
         host_info = f'{cur.connection.host} via TCP/IP'
@@ -147,10 +147,10 @@ def status(cur: Cursor, **_) -> list[SQLResult]:
     output.append(("Client characterset:", charset[2]))
     output.append(("Conn. characterset:", charset[3]))
 
-    if "TCP/IP" in host_info:
-        output.append(("TCP port:", cur.connection.port))
+    if getattr(cur.connection, 'unix_socket', None):
+        output.append(('UNIX socket:', variables['socket']))
     else:
-        output.append(("UNIX socket:", variables["socket"]))
+        output.append(('TCP port:', cur.connection.port))
 
     if "Uptime" in status:
         output.append(("Uptime:", format_uptime(status["Uptime"])))


### PR DESCRIPTION
## Description
Detecting the `unix_socket` property should be more robust.

Same as #1598 .

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
