### PR TITLE
Add warnings-count prompt format strings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ Features
 * Allow styling of status, timing, and warnings text.
 * Set up customization of prompt/continuation colors in `~/.myclirc`.
 * Allow customization of the toolbar with prompt format strings.
+* Add warnings-count prompt format strings: `\w` and `\W`.
 
 
 Bug Fixes

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -77,7 +77,7 @@ from mycli.packages.parseutils import is_destructive, is_dropping_database, is_v
 from mycli.packages.prompt_utils import confirm, confirm_destructive_query
 from mycli.packages.special.favoritequeries import FavoriteQueries
 from mycli.packages.special.main import ArgType
-from mycli.packages.special.utils import format_uptime, get_ssl_version, get_uptime
+from mycli.packages.special.utils import format_uptime, get_ssl_version, get_uptime, get_warning_count
 from mycli.packages.sqlresult import SQLResult
 from mycli.packages.tabular_output import sql_format
 from mycli.packages.toolkit.history import FileHistoryWithTimestamp
@@ -1589,6 +1589,18 @@ class MyCli:
                     string = string.replace('\\T', get_ssl_version(cur) or '(none)')
         else:
             string = string.replace('\\T', '(none)')
+        if hasattr(sqlexecute, 'conn') and sqlexecute.conn is not None:
+            if '\\w' in string:
+                with sqlexecute.conn.cursor() as cur:
+                    string = string.replace('\\w', str(get_warning_count(cur) or '(none)'))
+        else:
+            string = string.replace('\\w', '(none)')
+        if hasattr(sqlexecute, 'conn') and sqlexecute.conn is not None:
+            if '\\W' in string:
+                with sqlexecute.conn.cursor() as cur:
+                    string = string.replace('\\W', str(get_warning_count(cur) or ''))
+        else:
+            string = string.replace('\\W', '')
         return string
 
     def run_query(

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -116,6 +116,8 @@ wider_completion_menu = False
 # * \T - connection SSL/TLS version
 # * \t - database vendor (Percona, MySQL, MariaDB, TiDB)
 # * \u - username
+# * \w - number of warnings, or "(none)" (requires frequent trips to the server)
+# * \W - number of warnings, or the empty string (requires frequent trips to the server)
 # * \y - uptime in seconds (requires frequent trips to the server)
 # * \Y - uptime in words (requires frequent trips to the server)
 # * \A - DSN alias

--- a/mycli/packages/special/utils.py
+++ b/mycli/packages/special/utils.py
@@ -83,6 +83,22 @@ def get_uptime(cur: Cursor) -> int:
     return uptime
 
 
+def get_warning_count(cur: Cursor) -> int:
+    query = 'SHOW COUNT(*) WARNINGS'
+    logger.debug(query)
+
+    warning_count = 0
+
+    try:
+        cur.execute(query)
+        if one := cur.fetchone():
+            warning_count = int(one[0] or 0)
+    except pymysql.err.OperationalError:
+        pass
+
+    return warning_count
+
+
 def get_ssl_version(cur: Cursor) -> str | None:
     cache_key = (id(cur.connection), cur.connection.thread_id())
 

--- a/test/myclirc
+++ b/test/myclirc
@@ -113,6 +113,8 @@ wider_completion_menu = False
 # * \K - full connection socket path OR the port
 # * \T - connection SSL/TLS version
 # * \t - database vendor (Percona, MySQL, MariaDB, TiDB)
+# * \w - number of warnings, or "(none)" (requires frequent trips to the server)
+# * \W - number of warnings, or the empty string  (requires frequent trips to the server)
 # * \y - uptime in seconds (requires frequent trips to the server)
 # * \Y - uptime in words (requires frequent trips to the server)
 # * \u - username


### PR DESCRIPTION
## Description
 * `\w` - number of warnings, or "(none)" if none
 * `\W` - number of warnings, or the empty string

This is an alternative to having `SHOW WARNINGS` turned on.  An example is shown in the prompt, but it is likely to be more useful in the toolbar.

<img width="458" height="484" alt="warnings_in_prompt" src="https://github.com/user-attachments/assets/1a0ae5f2-1fe9-49a2-a516-4d96776156c7" />

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
