### PR TITLE
Use prompt_toolkit's clipboard for the `\clip` command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Internal
+---------
+* Use the clipboard provided by prompt_toolkit for `\clip`.
+
+
 1.58.0 (2026/02/28)
 ==============
 

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -11,8 +11,8 @@ from typing import Any, Generator
 
 import click
 from configobj import ConfigObj
+from prompt_toolkit.clipboard.pyperclip import PyperclipClipboard
 from pymysql.cursors import Cursor
-import pyperclip
 import sqlparse
 
 from mycli.compat import WIN
@@ -246,7 +246,8 @@ def copy_query_to_clipboard(sql: str | None = None) -> str | None:
     message = None
 
     try:
-        pyperclip.copy(f"{sql}")
+        clipboard = PyperclipClipboard()
+        clipboard.set_text(sql)
     except RuntimeError as e:
         message = f"Error clipping query: {e}."
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "sqlglot[rs] == 27.*",
     "configobj ~= 5.0.9",
     "cli_helpers[styles] ~= 2.10.1",
-    "pyperclip ~= 1.11.0",
     "pycryptodomex ~= 3.23.0",
     "pyfzf ~= 0.3.1",
     "rapidfuzz ~= 3.14.3",


### PR DESCRIPTION
## Description
This currently has the same functionality as depending on `pyperclip` directly; however it simplifies things to depend only on `prompt_toolkit`, reducing the chance that there is ever a conflict over the `pyperclip` version declarations.

Incidentally remove a needless f-string.

Part of a series: trying to depend on `prompt_toolkit` more, handroll less, and depend on `click` less for output.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
