### PR TITLE
Set `$VISUAL` whenever `$EDITOR` is set

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@ Internal
 * Refactor `SQLResult` dataclass.
 * Avoid depending on string matches into host info.
 * Add more URL constants.
+* Set `$VISUAL` whenever `$EDITOR` is set.
 
 
 1.58.0 (2026/02/28)

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -31,6 +31,7 @@ def before_all(context):
     """Set env parameters."""
     os.environ["LINES"] = "100"
     os.environ["COLUMNS"] = "100"
+    os.environ["VISUAL"] = "ex"
     os.environ["EDITOR"] = "ex"
     os.environ["LC_ALL"] = "en_US.UTF-8"
     os.environ["PROMPT_TOOLKIT_NO_CPR"] = "1"


### PR DESCRIPTION
## Description
Set `$VISUAL` whenever `$EDITOR` is set, since prompt_toolkit consults `$VISUAL` first for the `\edit` command.

https://github.com/prompt-toolkit/python-prompt-toolkit/blob/c7c629c38b22b5f22a0a5e80a1ae7e758ac595bb/src/prompt_toolkit/buffer.py#L1626

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
