### PR TITLE
Omit deprecated file from test coverage stats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,3 +154,7 @@ addopts = ['--ignore=mycli/packages/paramiko_stub/__init__.py', '--random-order'
 
 [tool.coverage.run]
 source = ['mycli']
+omit = [
+    # deprecated
+    'mycli/packages/paramiko_stub/__init__.py',
+]


### PR DESCRIPTION
## Description
Omit deprecated file from test coverage stats.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
