### PR TITLE
Improve startup banner/tips test coverage

### DIFF
--- a/test/pytests/test_main_modes_repl.py
+++ b/test/pytests/test_main_modes_repl.py
@@ -359,6 +359,19 @@ def test_repl_show_startup_banner_and_prompt_helpers(monkeypatch: pytest.MonkeyP
     assert repl_mode._get_continuation(cli, 4, 0, 0) == [('class:continuation', ' ')]
 
 
+def test_repl_show_startup_banner_thanks_sponsor(monkeypatch: pytest.MonkeyPatch) -> None:
+    cli = make_repl_cli(SimpleNamespace(server_info='Server'))
+    cli.less_chatty = False
+    printed: list[str] = []
+    monkeypatch.setattr(builtins, 'print', lambda *args, **kwargs: printed.append(' '.join(str(x) for x in args)))
+    monkeypatch.setattr(repl_mode.random, 'random', lambda: 0.25)
+    monkeypatch.setattr(repl_mode, '_sponsors_picker', lambda: 'Carol')
+
+    repl_mode._show_startup_banner(cli, cli.sqlexecute)
+
+    assert any('Thanks to the sponsor' in line and 'Carol' in line for line in printed)
+
+
 def test_prompt_toolbar_and_title_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
     class PromptCursor:
         def __enter__(self) -> 'PromptCursor':


### PR DESCRIPTION
## Description
Improve startup banner/tips test coverage.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
