### PR TITLE
Remove unused method `get_completions()` from `main.py`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -52,6 +52,7 @@ Internal
 * Move special commands out of `main.py`.
 * Modernize orthography of prompt_toolkit filters.
 * Pin all GitHub Actions to hashes.
+* Remove unused method `get_completions()`.
 
 
 1.67.1 (2026/03/28)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -30,8 +30,6 @@ import clickdc
 from configobj import ConfigObj
 import keyring
 from prompt_toolkit import print_formatted_text
-from prompt_toolkit.completion import Completion
-from prompt_toolkit.document import Document
 from prompt_toolkit.formatted_text import (
     ANSI,
     HTML,
@@ -1032,10 +1030,6 @@ class MyCli:
             # After refreshing, redraw the CLI to clear the statusbar
             # "Refreshing completions..." indicator
             self.prompt_session.app.invalidate()
-
-    def get_completions(self, text: str, cursor_position: int) -> Iterable[Completion]:
-        with self._completer_lock:
-            return self.completer.get_completions(Document(text=text, cursor_position=cursor_position), None)
 
     def run_query(
         self,

--- a/test/pytests/test_main.py
+++ b/test/pytests/test_main.py
@@ -2236,15 +2236,6 @@ def test_on_completions_refreshed_updates_completer_and_invalidates_prompt() -> 
     assert entered_lock['count'] == 1
 
 
-def test_get_completions_uses_current_completer() -> None:
-    cli = make_bare_mycli()
-    entered_lock = {'count': 0}
-    cli._completer_lock = cast(Any, ReusableLock(lambda: entered_lock.__setitem__('count', entered_lock['count'] + 1)))
-    cli.completer = cast(Any, SimpleNamespace(get_completions=lambda document, event: ['done']))
-    assert list(main.MyCli.get_completions(cli, 'select', 6)) == ['done']
-    assert entered_lock['count'] == 1
-
-
 def test_click_entrypoint_callback_covers_dsn_list_init_commands(monkeypatch: pytest.MonkeyPatch) -> None:
     dummy_class = make_dummy_mycli_class(
         config={


### PR DESCRIPTION
## Description
Remove unused method `get_completions()` from `main.py`

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
