### PR TITLE
Make LLM timings use the same format as others

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Bug Fixes
+---------
+* Make LLM timings use the same format as other timings.
+
+
 1.68.1 (2026/04/16)
 ==============
 

--- a/mycli/main_modes/repl.py
+++ b/mycli/main_modes/repl.py
@@ -585,7 +585,7 @@ def _one_iteration(
                     click.echo(context)
                     click.echo('---')
                 if special.is_timing_enabled():
-                    mycli.output_timing(f'Time: {duration:.2f} seconds')
+                    mycli.output_timing(f'Time: {duration:0.03f}s')
                 assert mycli.prompt_session is not None
                 text = mycli.prompt_session.prompt(
                     default=sql or '',


### PR DESCRIPTION
## Description
Make LLM timings use the same format as other timings, just for consistency.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
