### PR TITLE
Give example for ANSI prompt colors in myclirc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 Upcoming (TBD)
 ==============
 
+Documentation
+---------
+* Give example for ANSI prompt colors in `~/.myclirc`.
+
+
 Internal
 ---------
 * Remove unused fixture data.

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -136,7 +136,8 @@ wider_completion_menu = False
 # * \n - a newline
 # * \_ - a space
 # * \\ - a literal backslash
-# * \x1b[...m - an ANSI escape sequence (can style with color)
+# * \x1b[...m - an ANSI escape sequence (can style with color or attributes)
+#   ANSI color example: prompt = '\x1b[31mroot\x1b[0m@localhost:\d> '
 prompt = '\t \u@\h:\d> '
 prompt_continuation = '->'
 

--- a/test/myclirc
+++ b/test/myclirc
@@ -134,7 +134,8 @@ wider_completion_menu = False
 # * \n - a newline
 # * \_ - a space
 # * \\ - a literal backslash
-# * \x1b[...m - an ANSI escape sequence (can style with color)
+# * \x1b[...m - an ANSI escape sequence (can style with color or attributes)
+#   ANSI color example: prompt = '\x1b[31mroot\x1b[0m@localhost:\d> '
 prompt = "\t \u@\h:\d> "
 prompt_continuation = ->
 


### PR DESCRIPTION
## Description
Give example for ANSI prompt colors in myclirc.

Commentary only; no functional change.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
