### PR TITLE
Prepare doc files for release v1.71.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-Upcoming (TBD)
+1.71.0 (2026/05/01)
 ==============
 
 Features
@@ -10,6 +10,8 @@ Features
 Documentation
 ---------
 * Give example for ANSI prompt colors in `~/.myclirc`.
+* Fix typos in `TIPS` file.
+* Lightly reorganize `AUTHORS` file.
 
 
 Internal

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -12,6 +12,7 @@ Core Developers:
   * Darik Gamble
   * Dick Marinus
   * Amjith Ramanujam
+  * Scott Nemes
 
 Contributors:
 -------------
@@ -73,7 +74,6 @@ Contributors:
   * Nicolas Palumbo
   * Phil Cohen
   * QiaoHou Peng
-  * Roland Walker
   * Ryan Smith
   * Scrappy Soft
   * Seamile
@@ -111,7 +111,6 @@ Contributors:
   * keltaklo
   * 924060929
   * tmijieux
-  * Scott Nemes
   * Angelino Storm
   * Abhay Kumar
   * yurenchen000


### PR DESCRIPTION
## Description
 * add missing changelog item
 * move Roland Walker and Scott Nemes out of the general Contributors section in `AUTHORS`

