### PR TITLE
Document the `\g` special command to send a query

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 Upcoming (TBD)
 ==============
 
+Documentation
+---------
+* Document the `\g` special command to send a query.
+
+
 Internal
 ---------
 * Independent case-sensitivity for special command aliases.

--- a/mycli/packages/special/main.py
+++ b/mycli/packages/special/main.py
@@ -182,7 +182,7 @@ def show_help(*_args) -> list[SQLResult]:
     header = ["Command", "Shortcut", "Usage", "Description"]
     result = []
 
-    for _, value in sorted(COMMANDS.items()):
+    for _, value in sorted(COMMANDS.items(), key=lambda x: str.casefold(x[0])):
         if value.hidden:
             continue
         if value.aliases:
@@ -277,6 +277,13 @@ def quit_(*_args):
     "\\G",
     "<query>\\G",
     "Display query results vertically.",
+    arg_type=ArgType.NO_QUERY,
+    case_sensitive=True,
+)
+@special_command(
+    "\\g",
+    "<query>\\g",
+    "Display query results (mnemonic: go).",
     arg_type=ArgType.NO_QUERY,
     case_sensitive=True,
 )

--- a/test/features/fixture_data/help_commands.txt
+++ b/test/features/fixture_data/help_commands.txt
@@ -1,7 +1,6 @@
 +----------------+----------+---------------------------------+-------------------------------------------------------------+
 | Command        | Shortcut | Usage                           | Description                                                 |
 +----------------+----------+---------------------------------+-------------------------------------------------------------+
-| \G             | <null>   | <query>\G                       | Display query results vertically.                           |
 | \bug           | <null>   | \bug                            | File a bug on GitHub.                                       |
 | \clip          | <null>   | <query>\clip                    | Copy query to the system clipboard.                         |
 | \dt            | <null>   | \dt[+] [table]                  | List or describe tables.                                    |
@@ -9,6 +8,8 @@
 | \f             | <null>   | \f [name [args..]]              | List or execute favorite queries.                           |
 | \fd            | <null>   | \fd <name>                      | Delete a favorite query.                                    |
 | \fs            | <null>   | \fs <name> <query>              | Save a favorite query.                                      |
+| \g             | <null>   | <query>\g                       | Display query results (mnemonic: go).                       |
+| \G             | <null>   | <query>\G                       | Display query results vertically.                           |
 | \l             | <null>   | \l                              | List databases.                                             |
 | \llm           | \ai      | \llm [arguments]                | Interrogate an LLM.  See "\llm help".                       |
 | \once          | \o       | \once [-o] <filename>           | Append next result to an output file (overwrite using -o).  |


### PR DESCRIPTION
## Description
Document the `\g` special command to send a query, and sort the help table such that `\g` and `\G` occur together.

This was already implemented and there was already a test for it.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
