### PR TITLE
[chore] Clean up rapidfuzz dupe checking logic to be more concise

### DIFF
--- a/mycli/sqlcompleter.py
+++ b/mycli/sqlcompleter.py
@@ -1319,18 +1319,9 @@ class SQLCompleter(Completer):
                 limit=20,
                 score_cutoff=75,
             )
+            existing = {c[0] for c in completions}
             for item, _score, _type in rapidfuzz_matches:
-                if len(item) < len(text) / 1.5:
-                    continue
-                if (item, Fuzziness.PERFECT) in completions:
-                    continue
-                if (item, Fuzziness.REGEX) in completions:
-                    continue
-                if (item, Fuzziness.UNDER_WORDS) in completions:
-                    continue
-                if (item, Fuzziness.CAMEL_CASE) in completions:
-                    continue
-                if (item, Fuzziness.RAPIDFUZZ) in completions:
+                if len(item) < len(text) / 1.5 or item in existing:
                     continue
                 completions.append((item, Fuzziness.RAPIDFUZZ))
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Simplifies the rapidfuzz dupe checking logic to be more concise.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [X] I added this contribution to the `changelog.md` file.
- [X] I added my name to the `AUTHORS` file (or it's already there).
- [X] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
