### PR TITLE
Gracefully fail on background completion connection issues

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ Features
 * Allow styling prompts with HTML-like tags.
 
 
+Bug Fixes
+---------
+* Gracefully fail on background completion-refresh connection issues.
+
+
 Documentation
 ---------
 * Document the `\g` special command to send a query.

--- a/mycli/completion_refresher.py
+++ b/mycli/completion_refresher.py
@@ -1,6 +1,8 @@
 import threading
 from typing import Callable
 
+import pymysql
+
 from mycli.packages.special.main import COMMANDS
 from mycli.packages.sqlresult import SQLResult
 from mycli.sqlcompleter import SQLCompleter
@@ -58,22 +60,25 @@ class CompletionRefresher:
 
         # Create a new sqlexecute method to populate the completions.
         e = sqlexecute
-        executor = SQLExecute(
-            e.dbname,
-            e.user,
-            e.password,
-            e.host,
-            e.port,
-            e.socket,
-            e.character_set,
-            e.local_infile,
-            e.ssl,
-            e.ssh_user,
-            e.ssh_host,
-            e.ssh_port,
-            e.ssh_password,
-            e.ssh_key_filename,
-        )
+        try:
+            executor = SQLExecute(
+                e.dbname,
+                e.user,
+                e.password,
+                e.host,
+                e.port,
+                e.socket,
+                e.character_set,
+                e.local_infile,
+                e.ssl,
+                e.ssh_user,
+                e.ssh_host,
+                e.ssh_port,
+                e.ssh_password,
+                e.ssh_key_filename,
+            )
+        except pymysql.err.OperationalError:
+            return
 
         # If callbacks is a single function then push it into a list.
         if callable(callbacks):


### PR DESCRIPTION
## Description
If we fail to make a connection for background completion refresh, catch the error and return without performing the refresh.

This issue is happening to me frequently on certain hosts, with the symptom that a noisy trace is dumped into the REPL session.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
