### PR TITLE
docs: mention MariaDB in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 [![Build Status](https://github.com/dbcli/mycli/workflows/mycli/badge.svg)](https://github.com/dbcli/mycli/actions?query=workflow%3Amycli)
 
-A command line client for MySQL and MariaDB that can do auto-completion and syntax highlighting.
+A command line client for MySQL that can do auto-completion and syntax highlighting.
 
 Homepage: [https://mycli.net](https://mycli.net)
 Documentation: [https://mycli.net/docs](https://mycli.net/docs)
 
 ![Completion](doc/screenshots/tables.png)
 ![CompletionGif](doc/screenshots/main.gif)
+
+Mycli is compatible with MySQL, MariaDB, Percona, and TiDB.
 
 Postgres Equivalent: [https://pgcli.com](https://pgcli.com)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/dbcli/mycli/workflows/mycli/badge.svg)](https://github.com/dbcli/mycli/actions?query=workflow%3Amycli)
 
-A command line client for MySQL that can do auto-completion and syntax highlighting.
+A command line client for MySQL and MariaDB that can do auto-completion and syntax highlighting.
 
 Homepage: [https://mycli.net](https://mycli.net)
 Documentation: [https://mycli.net/docs](https://mycli.net/docs)

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -74,6 +74,7 @@ Contributors:
   * Nicolas Palumbo
   * Phil Cohen
   * QiaoHou Peng
+  * Robert Silen
   * Ryan Smith
   * Scrappy Soft
   * Seamile


### PR DESCRIPTION
## Summary

Updates the README tagline to mention MariaDB alongside MySQL. mycli is commonly used with MariaDB over the MySQL protocol; the changelog already includes MariaDB-related fixes.

Documentation only; no code or deployment changes.

## Test plan

- [x] README only