### PR TITLE
Add sqlglot and pygments versions to `--checkup` output

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,12 +4,18 @@ Upcoming (TBD)
 Features
 ---------
 * Update `cli_helpers` to v2.15.0 for `mysql_heavy` table format.
-
+* Add `sqlglot` and `pygments` to `--checkup` output.
 
 Bug Fixes
 ---------
 * Respect `history_file` setting in the `[main]` section of `~/.myclirc`.
 * Adapt test suite to pygments v2.20.0.
+
+
+Documentation
+---------
+* Add support for other MySQL wire-compatible databases to `README.md`.
+
 
 Internal
 ---------

--- a/mycli/main_modes/checkup.py
+++ b/mycli/main_modes/checkup.py
@@ -28,7 +28,10 @@ def _dependencies_checkup() -> None:
         'cli_helpers',
         'click',
         'prompt_toolkit',
+        'pygments',
         'pymysql',
+        'sqlglot',
+        'sqlglotc',
         'tabulate',
     ]:
         try:

--- a/test/pytests/test_checkup.py
+++ b/test/pytests/test_checkup.py
@@ -47,6 +47,9 @@ def test_dependencies_checkup(monkeypatch, capsys) -> None:
         'click': '2.0.0',
         'prompt_toolkit': '3.0.0',
         'pymysql': '4.0.0',
+        'pygments': '2.19.2',
+        'sqlglot': '30.7.0',
+        'sqlglotc': '30.7.0',
     }
 
     def fake_version(name: str) -> str:


### PR DESCRIPTION
## Description

In particular, the `sqlglot` version has seemed to be tricky lately, as in #1897.

Incidentally update the changelog for a missing documentation item.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
