### PR TITLE
Fix completion escape eagerness

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 Upcoming (TBD)
 ==============
 
+Bug Fixes
+---------
+* Keep completion-menu Escape cancellation eager only in Vi mode so Emacs Alt-key bindings keep working while completions are open.
+
+
 Internal
 ---------
 * Factor `main.py` into several files using mixins.

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -116,6 +116,7 @@ Contributors:
   * Abhay Kumar
   * yurenchen000
   * Linuxdazhao
+  * Puneet Dixit
 
 
 Created by:

--- a/mycli/key_bindings.py
+++ b/mycli/key_bindings.py
@@ -10,6 +10,7 @@ from prompt_toolkit.filters import (
     completion_is_selected,
     control_is_searchable,
     emacs_mode,
+    vi_mode,
 )
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.bindings.named_commands import register as ptoolkit_register
@@ -161,7 +162,7 @@ def mycli_bindings(mycli) -> KeyBindings:
         elif 'summon' in behaviors:
             b.start_completion(select_first=False)
 
-    @kb.add("escape", eager=True, filter=in_completion)
+    @kb.add("escape", eager=vi_mode, filter=in_completion)
     def _(event: KeyPressEvent) -> None:
         """Cancel completion menu.
 

--- a/test/pytests/test_key_bindings.py
+++ b/test/pytests/test_key_bindings.py
@@ -158,6 +158,7 @@ def binding(kb: prompt_toolkit.key_binding.KeyBindings, *keys: str | Keys) -> An
 
 def patch_filter_app(monkeypatch, app: DummyApp) -> None:
     monkeypatch.setitem(key_bindings.emacs_mode.func.__globals__, 'get_app', lambda: app)
+    monkeypatch.setitem(key_bindings.vi_mode.func.__globals__, 'get_app', lambda: app)
     monkeypatch.setitem(key_bindings.completion_is_selected.func.__globals__, 'get_app', lambda: app)
     monkeypatch.setitem(key_bindings.control_is_searchable.func.__globals__, 'get_app', lambda: app)
 
@@ -330,13 +331,26 @@ def test_tab_binding_supports_configured_behaviors(
     assert event.app.current_buffer.cancel_completion_calls == expected_cancel
 
 
-def test_escape_binding_cancels_completion_menu(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    ('editing_mode', 'expected_eager'),
+    (
+        (EditingMode.VI, True),
+        (EditingMode.EMACS, False),
+    ),
+)
+def test_escape_binding_cancels_completion_menu(
+    monkeypatch,
+    editing_mode: EditingMode,
+    expected_eager: bool,
+) -> None:
     mycli = DummyMyCli(DummyKeysConfig())
     kb = key_bindings.mycli_bindings(mycli)
     event = make_event(DummyBuffer(complete_state=object()))
+    event.app.editing_mode = editing_mode
     monkeypatch.setattr(key_bindings, 'get_app', lambda: event.app)
+    patch_filter_app(monkeypatch, event.app)
 
-    assert binding(kb, Keys.Escape).eager() is True
+    assert binding(kb, Keys.Escape).eager() is expected_eager
     assert binding_filter(kb, Keys.Escape)() is True
 
     inactive_event = make_event(DummyBuffer(complete_state=None))


### PR DESCRIPTION
## Description

Fixes #1911.

The completion-menu Escape binding was always eager while completions were open. Because terminals encode Alt-key combinations as Escape-prefixed sequences, that eager binding consumed the Escape prefix before prompt-toolkit could resolve Emacs Alt bindings such as Alt-f.

This keeps the completion-menu Escape binding eager only in Vi mode. Emacs mode still cancels the completion menu with Escape, but allows prompt-toolkit to wait for the rest of an Alt-key sequence.

Verification:

- `PYTHONPATH=. UV_CACHE_DIR=/tmp/mycli-1911-uv-cache UV_PROJECT_ENVIRONMENT=/tmp/mycli-1911-venv uv run pytest test/pytests/test_key_bindings.py -k escape_binding_cancels_completion_menu -q`
- `PYTHONPATH=. UV_CACHE_DIR=/tmp/mycli-1911-uv-cache UV_PROJECT_ENVIRONMENT=/tmp/mycli-1911-venv uv run pytest test/pytests/test_key_bindings.py -q`
- `UV_CACHE_DIR=/tmp/mycli-1911-uv-cache UV_PROJECT_ENVIRONMENT=/tmp/mycli-1911-venv uv run ruff check`
- `UV_CACHE_DIR=/tmp/mycli-1911-uv-cache UV_PROJECT_ENVIRONMENT=/tmp/mycli-1911-venv uv run ruff format`
- `UV_CACHE_DIR=/tmp/mycli-1911-uv-cache UV_PROJECT_ENVIRONMENT=/tmp/mycli-1911-venv uv run mypy --install-types --non-interactive .`
- `git diff --check`

## Checklist

- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
