### PR TITLE
fix: display version for Homebrew MySQL

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Bug Fixes
 ---------
 * Keep completion-menu Escape cancellation eager only in Vi mode so Emacs Alt-key bindings keep working while completions are open.
 * Keep identifiers that start with `set` highlighted as names.
+* Fix version display for MySQL distributions that return a plain `X.Y.Z` version string with no suffix (e.g. Homebrew MySQL).
 
 
 Internal

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -68,7 +68,8 @@ class ServerInfo:
             (r"(?P<version>[0-9\.]+)-MariaDB", ServerSpecies.MariaDB),
             (r"[0-9\.]*-TiDB-v(?P<version>[0-9\.]+)-?(?P<comment>[a-z0-9\-]*)", ServerSpecies.TiDB),
             (r"(?P<version>[0-9\.]+)[a-z0-9]*-(?P<comment>[0-9]+$)", ServerSpecies.Percona),
-            (r"(?P<version>[0-9\.]+)[a-z0-9]*-(?P<comment>[A-Za-z0-9_]+)", ServerSpecies.MySQL),
+            # Also matches plain "X.Y.Z" with no suffix (e.g. Homebrew MySQL).
+            (r"(?P<version>[0-9]+\.[0-9]+\.[0-9]+)[a-z0-9]*(-(?P<comment>[A-Za-z0-9_]+))?", ServerSpecies.MySQL),
         )
         for regexp, species in re_species:
             match = re.search(regexp, version_string)

--- a/test/pytests/test_sqlexecute.py
+++ b/test/pytests/test_sqlexecute.py
@@ -429,6 +429,8 @@ def test_multiple_results(executor):
         ("5.5.5-10.5.8-MariaDB-1:10.5.8+maria~focal", "MariaDB", "10.5.8", 100508),
         ("5.0.16-pro-nt-log", "MySQL", "5.0.16", 50016),
         ("5.1.5a-alpha", "MySQL", "5.1.5", 50105),
+        # Plain X.Y.Z with no suffix (e.g. Homebrew MySQL)
+        ("5.7.99", "MySQL", "5.7.99", 50799),
         ("unexpected version string", None, "", 0),
         ("", None, "", 0),
         (None, None, "", 0),


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
  MySQL installed via Homebrew (and some other distributions) reports a plain `X.Y.Z` version string during the handshake with no trailing suffix — for example `9.6.0` instead of the more common `9.6.0-log` or `8.0.32-debian`.

  `ServerInfo.from_version_string()` uses a series of regex patterns to detect the server species and extract the version number. All existing patterns  require a `-` separator, so a plain `X.Y.Z` string falls through to the  `else` branch, which previously hardcoded `parsed_version = ""`.

 As a result, the welcome banner displayed `MySQL ` with a trailing space and  no version number.

  **Fix**: in the `else` branch, attempt to extract the version with a simple`X.Y.Z` regex before falling back to an empty string. The species remains `MySQL` — only the displayed version number changes.

  **Before:**
  MySQL
  mycli 1.73.0

  **After:**
  MySQL 9.6.0
  mycli 1.73.0


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
