### PR TITLE
perf: skip LLM imports when MYCLI_LLM_OFF is set

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ Internal
 * Add CI on macOS.
 * Add limited CI on Windows.
 * Add limited CI on Windows WSL.
+* Speed up startup by skipping LLM imports when `MYCLI_LLM_OFF` is set.
 
 
 1.73.1 (2026/05/29)

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -117,6 +117,7 @@ Contributors:
   * yurenchen000
   * Linuxdazhao
   * Puneet Dixit
+  * Liu Zhenlong
 
 
 Created by:

--- a/mycli/packages/special/__init__.py
+++ b/mycli/packages/special/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from mycli.packages.special.dbcommands import (
     list_databases,
     list_tables,
@@ -41,12 +43,30 @@ from mycli.packages.special.iocommands import (
     write_pipe_once,
     write_tee,
 )
-from mycli.packages.special.llm import (
-    FinishIteration,
-    handle_llm,
-    is_llm_command,
-    sql_using_llm,
-)
+
+if not os.environ.get('MYCLI_LLM_OFF'):
+    from mycli.packages.special.llm import (
+        FinishIteration,
+        handle_llm,
+        is_llm_command,
+        sql_using_llm,
+    )
+else:
+
+    class FinishIteration(Exception):  # type: ignore[no-redef]
+        def __init__(self, results=None):
+            self.results = results
+
+    def is_llm_command(command: str) -> bool:  # type: ignore[no-redef]
+        return False
+
+    def handle_llm(*args, **kwargs):  # type: ignore[no-redef, misc]
+        raise FinishIteration(results=None)
+
+    def sql_using_llm(*args, **kwargs):  # type: ignore[no-redef, misc]
+        raise FinishIteration(results=None)
+
+
 from mycli.packages.special.main import (
     CommandNotFound,
     SpecialCommandAlias,


### PR DESCRIPTION
## Description
`special/__init__.py` unconditionally imported LLM symbols on every startup, pulling in the entire `openai` package even when LLM features are unused. `llm.py` and `main.py` already guarded their imports with `MYCLI_LLM_OFF`, but `__init__.py` bypassed that protection.

This PR brings `__init__.py` in line with the rest: when `MYCLI_LLM_OFF=1`, LLM imports are skipped and lightweight stubs are provided instead, reducing startup time.



## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
