### PR TITLE
Skip flaky external-editor test in CI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,11 +5,13 @@ Features
 --------
 * Detect Apache Doris and display its real version instead of the MySQL-compat placeholder.
 
+
 Bug Fixes
 ---------
 * Keep completion-menu Escape cancellation eager only in Vi mode so Emacs Alt-key bindings keep working while completions are open.
 * Keep identifiers that start with `set` highlighted as names.
 * Fix version display for MySQL distributions that return a plain `X.Y.Z` version string with no suffix (e.g. Homebrew MySQL).
+* Speed up startup by skipping LLM imports when `MYCLI_LLM_OFF` is set.
 
 
 Internal
@@ -20,7 +22,7 @@ Internal
 * Add CI on macOS.
 * Add limited CI on Windows.
 * Add limited CI on Windows WSL.
-* Speed up startup by skipping LLM imports when `MYCLI_LLM_OFF` is set.
+* Skip flaky external-editor test in CI.
 
 
 1.73.1 (2026/05/29)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,8 @@ passenv = ['PYTEST_HOST',
            'PYTEST_USER',
            'PYTEST_PASSWORD',
            'PYTEST_PORT',
-           'PYTEST_CHARSET']
+           'PYTEST_CHARSET',
+           'GITHUB_ACTION']
 commands = [['uv', 'pip', 'install', '-e', '.[dev,ssh,llm]'],
             ['coverage', 'run', '-m', 'pytest', '-v', 'test'],
             ['coverage', 'report', '-m', '--sort=Miss'],

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -105,6 +105,9 @@ def before_scenario(context, arg):
     # Skip scenarios marked skip_py312 when running on Python 3.12
     if sys.version_info[:2] == (3, 12) and "skip_py312" in arg.tags:
         arg.skip("Skipped on Python 3.12")
+    # Skip flaky editor test in CI
+    if os.getenv('GITHUB_ACTION') and 'skip_ci' in arg.tags:
+        arg.skip('Skipped in CI')
     with open(test_log_file, "w") as f:
         f.write("")
     if arg.location.filename not in SELF_CONNECTING_FEATURES:

--- a/test/features/iocommands.feature
+++ b/test/features/iocommands.feature
@@ -1,5 +1,6 @@
 Feature: I/O commands
 
+  @skip_ci
   Scenario: edit sql in file with external editor
      When we start external editor providing a file name
       and we type "select * from abc" in the editor


### PR DESCRIPTION
## Description
This test often fails, which is unhelpful.

Incidentally move an item in the changelog.

I don't know the `behave` suite very well, but hope this works based on the Python 3.12 example.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
