### PR TITLE
Prepare changelog for release v1.74.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,16 +1,16 @@
-Upcoming (TBD)
+1.74.0 (2026/06/06)
 ==============
 
 Features
 --------
-* Detect Apache Doris and display its real version instead of the MySQL-compat placeholder.
+* Detect Apache Doris and display its real version.
 
 
 Bug Fixes
 ---------
-* Keep completion-menu Escape cancellation eager only in Vi mode so Emacs Alt-key bindings keep working while completions are open.
+* Fix Emacs-mode Alt-key bindings while completions are open.
 * Keep identifiers that start with `set` highlighted as names.
-* Fix version display for MySQL distributions that return a plain `X.Y.Z` version string with no suffix (e.g. Homebrew MySQL).
+* Fix version display for MySQL distributions that return a plain `X.Y.Z`.
 * Speed up startup by skipping LLM imports when `MYCLI_LLM_OFF` is set.
 
 


### PR DESCRIPTION
Prepare changelog for release v1.74.0, tightening up some long entries to match the short style.
