### PR TITLE
Remove support for deprecated `$MYSQL_UNIX_PORT` environment variable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming (TBD)
 Breaking Changes
 * Change default table format to `mysql_unicode`.
 * Remove support for deprecated environment variable `$DSN`.
+* Remove support for deprecated environment variable `$MYSQL_UNIX_PORT`.
 
 
 Internal

--- a/mycli/cli_runner.py
+++ b/mycli/cli_runner.py
@@ -167,17 +167,6 @@ def run_from_cli_args(cli_args: 'CliArgs', client_factory: ClientFactory) -> Non
     if cli_args.list_ssh_config:
         sys.exit(main_list_ssh_config(mycli, cli_args))
 
-    if 'MYSQL_UNIX_PORT' in os.environ:
-        # deprecated 2026-03
-        click.secho(
-            "The MYSQL_UNIX_PORT environment variable is deprecated in favor of MYSQL_UNIX_SOCKET.  "
-            "MYSQL_UNIX_PORT will be removed in a future release.",
-            err=True,
-            fg="red",
-        )
-        if not cli_args.socket:
-            cli_args.socket = os.environ['MYSQL_UNIX_PORT']
-
     # Choose which ever one has a valid value.
     database = cli_args.dbname or cli_args.database
 

--- a/test/pytests/test_cli_runner.py
+++ b/test/pytests/test_cli_runner.py
@@ -143,31 +143,24 @@ def test_run_from_cli_args_rejects_conflicting_format_flags(
     assert secho_calls == [(message, {'err': True, 'fg': 'red'})]
 
 
-def test_run_from_cli_args_uses_deprecated_mysql_unix_port_and_database_alias(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_run_from_cli_args_treats_database_as_dsn_alias(monkeypatch: pytest.MonkeyPatch) -> None:
     cli_args = make_cli_args()
     cli_args.database = 'prod'
     client = DummyMyCli(
         config={
             **default_config(),
-            'alias_dsn': {'prod': 'mysql://dsn_user:dsn_pass@dsn_host:3307/dsn_db'},
+            'alias_dsn': {'prod': 'mysql://u:p@h/db'},
         }
     )
-    secho_calls: list[str] = []
-    monkeypatch.setenv('MYSQL_UNIX_PORT', '/tmp/mysql.sock')
-    monkeypatch.setattr(cli_runner.click, 'secho', lambda text, **_kwargs: secho_calls.append(text))
 
     run_with_client(monkeypatch, cli_args, client)
 
     assert client.dsn_alias == 'prod'
-    assert client.connect_calls[-1]['database'] == 'dsn_db'
-    assert client.connect_calls[-1]['user'] == 'dsn_user'
-    assert client.connect_calls[-1]['passwd'] == 'dsn_pass'
-    assert client.connect_calls[-1]['host'] == 'dsn_host'
-    assert client.connect_calls[-1]['port'] == 3307
-    assert client.connect_calls[-1]['socket'] == '/tmp/mysql.sock'
-    assert any('MYSQL_UNIX_PORT environment variable is deprecated' in call for call in secho_calls)
+    connect_call = client.connect_calls[-1]
+    assert connect_call['user'] == 'u'
+    assert connect_call['passwd'] == 'p'
+    assert connect_call['host'] == 'h'
+    assert connect_call['database'] == 'db'
 
 
 def test_run_from_cli_args_leaves_dsn_alias_env_vars_disabled_by_default(


### PR DESCRIPTION
## Description
Remove support for deprecated `$MYSQL_UNIX_PORT` environment variable, in favor of `$MYSQL_UNIX_SOCKET`.  This has only been deprecated since March 2026, but it was also never documented.

Preparation for 2.0 release.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
