### PR TITLE
Remove support for deprecated `$DSN` environment variable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,8 @@ Upcoming (TBD)
 ==============
 
 Breaking Changes
----------
 * Change default table format to `mysql_unicode`.
+* Remove support for deprecated environment variable `$DSN`.
 
 
 Internal

--- a/mycli/cli_runner.py
+++ b/mycli/cli_runner.py
@@ -178,16 +178,6 @@ def run_from_cli_args(cli_args: 'CliArgs', client_factory: ClientFactory) -> Non
         if not cli_args.socket:
             cli_args.socket = os.environ['MYSQL_UNIX_PORT']
 
-    if 'DSN' in os.environ:
-        # deprecated 2026-03
-        click.secho(
-            "The DSN environment variable is deprecated in favor of MYSQL_DSN.  Support for DSN will be removed in a future release.",
-            err=True,
-            fg="red",
-        )
-        if not cli_args.dsn:
-            cli_args.dsn = os.environ['DSN']
-
     # Choose which ever one has a valid value.
     database = cli_args.dbname or cli_args.database
 

--- a/test/pytests/test_main.py
+++ b/test/pytests/test_main.py
@@ -1285,59 +1285,6 @@ def test_mysql_dsn_envvar(monkeypatch):
     )
 
 
-def test_legacy_dsn_envvar_warns_and_falls_back(monkeypatch):
-    class Formatter:
-        format_name = None
-
-    class Logger:
-        def debug(self, *args, **args_dict):
-            pass
-
-        def warning(self, *args, **args_dict):
-            pass
-
-    class MockMyCli:
-        config = {
-            'main': {},
-            'alias_dsn': {},
-            'connection': {
-                'default_keepalive_ticks': 0,
-            },
-        }
-
-        def __init__(self, **_args):
-            self.logger = Logger()
-            self.destructive_warning = False
-            self.main_formatter = Formatter()
-            self.redirect_formatter = Formatter()
-            self.ssl_mode = 'auto'
-            self.my_cnf = {'client': {}, 'mysqld': {}}
-            self.default_keepalive_ticks = 0
-
-        def connect(self, **args):
-            MockMyCli.connect_args = args
-
-        def run_query(self, query, new_line=True):
-            pass
-
-    import mycli.main
-
-    monkeypatch.setattr(mycli.main, 'MyCli', MockMyCli)
-    monkeypatch.setenv('DSN', 'mysql://dsn_user:dsn_passwd@dsn_host:8/dsn_database')
-    runner = CliRunner()
-
-    result = runner.invoke(mycli.main.click_entrypoint)
-    assert result.exit_code == 0, result.output + ' ' + str(result.exception)
-    assert 'The DSN environment variable is deprecated' in result.output
-    assert (
-        MockMyCli.connect_args['user'] == 'dsn_user'
-        and MockMyCli.connect_args['passwd'] == 'dsn_passwd'
-        and MockMyCli.connect_args['host'] == 'dsn_host'
-        and MockMyCli.connect_args['port'] == 8
-        and MockMyCli.connect_args['database'] == 'dsn_database'
-    )
-
-
 def test_password_flag_uses_sentinel(monkeypatch):
     class Formatter:
         format_name = None


### PR DESCRIPTION
## Description
Remove support for deprecated `$DSN` environment variable in favor of `$MYSQL_DSN`.  This has only been deprecated since March 2026, but it was also never documented.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
