### PR TITLE
Remove support for legacy `--ssl`/`--no-ssl` CLI arguments

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,11 @@ Upcoming (TBD)
 ==============
 
 Breaking Changes
+---------
 * Change default table format to `mysql_unicode`.
 * Remove support for deprecated environment variable `$DSN`.
 * Remove support for deprecated environment variable `$MYSQL_UNIX_PORT`.
+* Remove support for `--ssl/--no-ssl` CLI arguments in favor of `--ssl-mode`.
 
 
 Internal

--- a/mycli/cli_runner.py
+++ b/mycli/cli_runner.py
@@ -134,15 +134,6 @@ def run_from_cli_args(cli_args: 'CliArgs', client_factory: ClientFactory) -> Non
     if cli_args.table:
         cli_args.format = 'table'
 
-    if cli_args.deprecated_ssl is not None:
-        click.secho(
-            "Warning: The --ssl/--no-ssl CLI options are deprecated and will be removed in a future release. "
-            "Please use the \"default_ssl_mode\" config option or --ssl-mode CLI flag instead. "
-            f"See issue {ISSUES_URL}/1507",
-            err=True,
-            fg="yellow",
-        )
-
     # ssh_port and ssh_config_path have truthy defaults and are not included
     if (
         any([
@@ -288,25 +279,12 @@ def run_from_cli_args(cli_args: 'CliArgs', client_factory: ClientFactory) -> Non
     keepalive_ticks = cli_args.keepalive_ticks if cli_args.keepalive_ticks is not None else mycli.default_keepalive_ticks
     ssl_mode = cli_args.ssl_mode or mycli.ssl_mode
 
-    # if there is a mismatch between the ssl_mode value and other sources of ssl config, show a warning
-    # specifically using "is False" to not pickup the case where cli_args.deprecated_ssl is None (not set by the user)
-    if cli_args.deprecated_ssl and ssl_mode == "off" or cli_args.deprecated_ssl is False and ssl_mode in ("auto", "on"):
-        click.secho(
-            f"Warning: The current ssl_mode value of '{ssl_mode}' is overriding the value provided by "
-            f"either the --ssl/--no-ssl CLI options or a DSN URI parameter (ssl={cli_args.deprecated_ssl}).",
-            err=True,
-            fg="yellow",
-        )
-
-    # configure SSL if ssl_mode is auto/on or if
-    # cli_args.deprecated_ssl = True (from --ssl or a DSN URI) and ssl_mode is None
-    if ssl_mode in ("auto", "on") or (cli_args.deprecated_ssl and ssl_mode is None):
+    if ssl_mode in ("auto", "on"):
         if cli_args.socket and ssl_mode == 'auto':
             ssl = None
         else:
             ssl = {
                 "mode": ssl_mode,
-                "enable": cli_args.deprecated_ssl,  # todo: why is this set at all?
                 "ca": cli_args.ssl_ca and os.path.expanduser(cli_args.ssl_ca),
                 "cert": cli_args.ssl_cert and os.path.expanduser(cli_args.ssl_cert),
                 "key": cli_args.ssl_key and os.path.expanduser(cli_args.ssl_key),

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -128,13 +128,6 @@ class CliArgs:
         type=click.Choice(['auto', 'on', 'off']),
         help='Set desired SSL behavior. auto=preferred if TCP/IP, on=required, off=off.',
     )
-    deprecated_ssl: bool | None = clickdc.option(
-        '--ssl/--no-ssl',
-        'deprecated_ssl',
-        default=None,
-        clickdc=None,
-        help='Enable SSL for connection (automatically enabled with other flags).',
-    )
     ssl_ca: str | None = clickdc.option(
         type=click.Path(exists=True),
         help='CA file in PEM format.',

--- a/test/pytests/test_main.py
+++ b/test/pytests/test_main.py
@@ -350,28 +350,6 @@ def test_ssl_mode_off(executor, capsys):
 
 
 @dbtest
-def test_ssl_mode_overrides_ssl(executor, capsys):
-    runner = CliRunner()
-    ssl_mode = "off"
-    sql = "select * from performance_schema.session_status where variable_name = 'Ssl_cipher'"
-    result = runner.invoke(click_entrypoint, args=CLI_ARGS + ["--csv", "--ssl-mode", ssl_mode, "--ssl"], input=sql)
-    result_dict = next(csv.DictReader(result.stdout.split("\n")))
-    ssl_cipher = result_dict.get("VARIABLE_VALUE", None)
-    assert not ssl_cipher
-
-
-@dbtest
-def test_ssl_mode_overrides_no_ssl(executor, capsys):
-    runner = CliRunner()
-    ssl_mode = "on"
-    sql = "select * from performance_schema.session_status where variable_name = 'Ssl_cipher'"
-    result = runner.invoke(click_entrypoint, args=CLI_ARGS + ["--csv", "--ssl-mode", ssl_mode, "--no-ssl"], input=sql)
-    result_dict = next(csv.DictReader(result.stdout.split("\n")))
-    ssl_cipher = result_dict.get("VARIABLE_VALUE", None)
-    assert ssl_cipher
-
-
-@dbtest
 def test_reconnect_database_is_selected(executor, capsys):
     m = MyCli()
     m.register_special_commands()


### PR DESCRIPTION
## Description
Remove support for legacy `--ssl`/`--no-ssl` CLI arguments, which have enjoyed a lengthy deprecation cycle.  The new form is `--ssl-mode=<on,off,auto>`.

Fixes #1507.

Preparation for release 2.0.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
