### PR TITLE
Change default table format to `mysql_unicode`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 Upcoming (TBD)
 ==============
 
+Breaking Changes
+---------
+* Change default table format to `mysql_unicode`.
+
+
 Internal
 ---------
 * Improve test coverage for DSN variable expansion.

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -73,7 +73,7 @@ beep_after_seconds = 0
 # rst, simple, sql-insert, sql-update, sql-update-1, sql-update-2, textile,
 # tsv, tsv_noheader, vertical.
 # Recommended: mysql_unicode.
-table_format = ascii
+table_format = mysql_unicode
 
 # Redirected otuput format
 # Recommended: csv.


### PR DESCRIPTION
## Description
This is noted as a breaking change, though it will actually only affect new installs.

Rationale: we are the fancy MySQL client.  Let's use the fancy format. In 2026, terminals have Unicode support.

Preparation for release 2.0.

The test myclirc file remains set to `ascii` to avoid changing many tests.

Example (with non-default colors):

<img width="256" height="218" alt="last image" src="https://github.com/user-attachments/assets/334185f2-d82a-42ce-ad78-9293e0fe9515" />


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
