### PR TITLE
Remove implicit read of `.myclirc` files in the current working directory

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Breaking Changes
 * Remove support for `--ssl/--no-ssl` CLI arguments in favor of `--ssl-mode`.
 * Remove support for deprecated SSH jump functionality.
 * Remove support for `my.cnf` vendor MySQL option files.
+* Remove support for `.myclirc` files in the current working directory.
 
 
 Documentation

--- a/mycli/client.py
+++ b/mycli/client.py
@@ -61,8 +61,6 @@ class MyCli(AppStateMixin, OutputMixin, ClientCommandsMixin, ClientConnectionMix
         os.path.join(os.path.expanduser(xdg_config_home), "mycli", "myclirc"),
     ]
 
-    pwd_config_file = os.path.join(os.getcwd(), ".myclirc")
-
     def __init__(
         self,
         sqlexecute: SQLExecute | None = None,
@@ -87,7 +85,7 @@ class MyCli(AppStateMixin, OutputMixin, ClientCommandsMixin, ClientConnectionMix
         self.checkpoint: IO | None = None
 
         # Load config.
-        config_files: list[str | IO[str]] = self.system_config_files + [myclirc] + [self.pwd_config_file]
+        config_files: list[str | IO[str]] = self.system_config_files + [myclirc]
 
         c = self.config = read_config_files(config_files)
         # only needed in --checkup mode. todo: only load when needed

--- a/test/myclirc
+++ b/test/myclirc
@@ -22,7 +22,7 @@ prefetch_schemas_mode = always
 
 # Comma-separated list of schemas to prefetch when
 # prefetch_schemas_mode = listed.  Ignored in other modes.
-prefetch_schemas_list =
+prefetch_schemas_list = ""
 
 # Expand whole DSN alias values in the form ${VAR} from the environment.
 expand_dsn_alias_env_vars = False
@@ -57,7 +57,7 @@ log_level = DEBUG
 # line below.
 # audit_log = ~/.mycli-audit.log
 
-# Timing of sql statements and table rendering.
+# Timing of SQL statements and table rendering, or LLM commands.
 timing = True
 
 # Show the full SQL when running a favorite query. Set to False to hide.
@@ -143,7 +143,7 @@ wider_completion_menu = False
 #   ANSI color example: prompt = '\x1b[31mroot\x1b[0m@localhost:\d> '
 # * \<html> - a leading sequence indicating that the rest of the prompt be styled like HTML.
 #   See https://python-prompt-toolkit.readthedocs.io/en/stable/pages/printing_text.html#html .
-#   Characters such as "&" or literal "<" and ">" must be HTML-escaped in this mode
+#   Characters such as "&" or literal "<" and ">" must be HTML-escaped in this mode.
 #   HTML styles cannot be combined with ANSI sequences.  HTML mode takes precedence.
 #   HTML color example: prompt = '\<html><red><u>root</u></red>@localhost:\d&gt; '
 #
@@ -160,29 +160,29 @@ prompt_continuation = ->
 # lines can be added with \n.  If \B is not included, the customized toolbar
 # can be a single line.  An empty value is the same as the default "\B".  The
 # special literal value "None" will suppress the toolbar from appearing.
-toolbar = ''
+toolbar = ""
 
 # Use the same prompt format strings to construct a terminal tab title.
 # The original XTerm docs call this title the "window title", but it now
 # probably refers to a terminal tab.  This title is only updated as frequently
 # as the database is changed.
-terminal_tab_title = ''
+terminal_tab_title = ""
 
 # Use the same prompt format strings to construct a terminal window title.
 # The original XTerm docs call this title the "icon title", but it now
 # probably refers to a terminal window which contains tabs.  This title is
 # only updated as frequently as the database is changed.
-terminal_window_title = ''
+terminal_window_title = ""
 
 # Use the same prompt format strings to construct a window title in a terminal
 # multiplexer.  Currently only tmux is supported.  This title is only updated
 # as frequently as the database is changed.
-multiplex_window_title = ''
+multiplex_window_title = ""
 
 # Use the same prompt format strings to construct a pane title in a terminal
 # multiplexer.  Currently only tmux is supported.  This title is only updated
 # as frequently as the database is changed.
-multiplex_pane_title = ''
+multiplex_pane_title = ""
 
 # Skip intro info on startup and outro info on exit, and generally reduce
 # feedback.  This is equivalent to giving --quiet at the command line.
@@ -242,19 +242,19 @@ default_keepalive_ticks = 0
 default_ssl_mode = auto
 
 # SSL CA file for connections without --ssl-ca being set
-default_ssl_ca =
+default_ssl_ca = ""
 
 # SSL CA directory for connections without --ssl-capath being set
-default_ssl_capath =
+default_ssl_capath = ""
 
 # SSL X509 cert path for connections without --ssl-cert being set
-default_ssl_cert =
+default_ssl_cert = ""
 
 # SSL X509 key for connections without --ssl-key being set
-default_ssl_key =
+default_ssl_key = ""
 
 # SSL cipher to use for connections without --ssl-cipher being set
-default_ssl_cipher =
+default_ssl_cipher = ""
 
 # whether to verify server's "Common Name" in its cert, for connections without
 # --ssl-verify-server-cert being set
@@ -306,17 +306,17 @@ emacs_ttimeoutlen = 0.5
 # Attributes: (no)blink, bold, dim, hidden, inherit, italic, reverse, strike, underline.
 [colors]
 # Completion menus
-completion-menu.completion.current = 'bg:#ffffff #000000'
-completion-menu.completion = 'bg:#008888 #ffffff'
-completion-menu.meta.completion.current = 'bg:#44aaaa #000000'
-completion-menu.meta.completion = 'bg:#448888 #ffffff'
-completion-menu.multi-column-meta = 'bg:#aaffff #000000'
-scrollbar.arrow = 'bg:#003333'
-scrollbar = 'bg:#00aaaa'
+completion-menu.completion.current = "bg:#ffffff #000000"
+completion-menu.completion = "bg:#008888 #ffffff"
+completion-menu.meta.completion.current = "bg:#44aaaa #000000"
+completion-menu.meta.completion = "bg:#448888 #ffffff"
+completion-menu.multi-column-meta = "bg:#aaffff #000000"
+scrollbar.arrow = "bg:#003333"
+scrollbar = "bg:#00aaaa"
 
 # The prompt
-prompt = ''
-continuation = ''
+prompt = ""
+continuation = ""
 
 # Colored table output (query results)
 output.table-separator = ""
@@ -329,29 +329,29 @@ output.status.warning-count = ""
 output.timing = ""
 
 # Selected text (native selection; currently unused)
-selected = '#ffffff bg:#6666aa'
+selected = "#ffffff bg:#6666aa"
 
 # Search matches (for reverse i-search, not fuzzy search)
-search = '#ffffff bg:#4444aa'
-search.current = '#ffffff bg:#44aa44'
+search = "#ffffff bg:#4444aa"
+search.current = "#ffffff bg:#44aa44"
 
 # UI elements: bottom toolbar
-bottom-toolbar = 'bg:#222222 #aaaaaa'
-bottom-toolbar.off = 'bg:#222222 #888888'
-bottom-toolbar.on = 'bg:#222222 #ffffff'
-bottom-toolbar.transaction.valid = 'bg:#222222 #00ff5f bold'
-bottom-toolbar.transaction.failed = 'bg:#222222 #ff005f bold'
+bottom-toolbar = "bg:#222222 #aaaaaa"
+bottom-toolbar.off = "bg:#222222 #888888"
+bottom-toolbar.on = "bg:#222222 #ffffff"
+bottom-toolbar.transaction.valid = "bg:#222222 #00ff5f bold"
+bottom-toolbar.transaction.failed = "bg:#222222 #ff005f bold"
 
 # UI elements: other toolbars (currently unused)
-search-toolbar = 'noinherit bold'
-search-toolbar.text = 'nobold'
-system-toolbar = 'noinherit bold'
-arg-toolbar = 'noinherit bold'
-arg-toolbar.text = 'nobold'
+search-toolbar = noinherit bold
+search-toolbar.text = nobold
+system-toolbar = noinherit bold
+arg-toolbar = noinherit bold
+arg-toolbar.text = nobold
 
 # SQL enhacements: matching brackets
-matching-bracket.cursor = '#ff8888 bg:#880000'
-matching-bracket.other = '#000000 bg:#aacccc'
+matching-bracket.cursor = "#ff8888 bg:#880000"
+matching-bracket.other = "#000000 bg:#aacccc"
 
 # SQL syntax highlighting overrides: normally defined by main.syntax_style
 # sql.comment = 'italic #408080'

--- a/test/pytests/test_client.py
+++ b/test/pytests/test_client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from io import TextIOWrapper
-import os
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -20,7 +19,6 @@ def write_myclirc(tmp_path: Path, content: str) -> str:
 
 def patch_constructor_side_effects(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(MyCli, 'system_config_files', [])
-    monkeypatch.setattr(MyCli, 'pwd_config_file', os.devnull)
     monkeypatch.setattr(MyCli, 'initialize_logging', lambda self: None)
     monkeypatch.setattr(MyCli, 'register_special_commands', lambda self: None)
     monkeypatch.setattr(client_module, 'get_mylogin_cnf_path', lambda: None)

--- a/test/pytests/test_main.py
+++ b/test/pytests/test_main.py
@@ -861,7 +861,6 @@ def test_reserved_space_is_integer(monkeypatch):
 
 def test_list_dsn(monkeypatch):
     monkeypatch.setattr(MyCli, "system_config_files", [])
-    monkeypatch.setattr(MyCli, "pwd_config_file", os.devnull)
     runner = CliRunner()
     # keep Windows from locking the file with delete=False
     with NamedTemporaryFile(prefix=TEMPFILE_PREFIX, mode="w", delete=False) as myclirc:
@@ -2064,7 +2063,6 @@ def test_execute_arg_supersedes_batch_file(monkeypatch):
 @dbtest
 def test_null_string_config(monkeypatch):
     monkeypatch.setattr(MyCli, 'system_config_files', [])
-    monkeypatch.setattr(MyCli, 'pwd_config_file', os.devnull)
     runner = CliRunner()
     # keep Windows from locking the file with delete=False
     with NamedTemporaryFile(mode='w', delete=False) as myclirc:


### PR DESCRIPTION
## Description
This was never documented, and should not have been possible without at least a warning to the user.  The functionality could be added back with some form of explicit argument.

Requires reformatting of `test/myclirc` to keep the repository git-clean after running `behave`.  We should probably also fix that so that the behave suite does not write back to `myclirc`.

Preparation for release 2.0.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
