### PR TITLE
Show section when recommending setting for `default_character_set`

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Mycli is tested on macOS and Linux, and requires Python 3.10 or better.
 To connect to MySQL versions earlier than 5.5, you may need to set the following in `~/.myclirc`:
 
 ```
+[connection]
 # character set for connections without --charset being set at the CLI
 default_character_set = utf8
 ```

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,11 @@ Breaking Changes
 * Remove support for deprecated SSH jump functionality.
 
 
+Documentation
+---------
+* Show section when recommending `default_character_set` setting.
+
+
 Internal
 ---------
 * Improve test coverage for DSN variable expansion.


### PR DESCRIPTION
## Description
Show section when recommending setting for `default_character_set`, since it doesn't belong in `[main]` (but is still respected when present there).

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
