### PR TITLE
Add back hidden CLI arguments for recent removals

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -266,6 +266,60 @@ class CliArgs:
         is_flag=True,
         help='Run a checkup on your configuration.',
     )
+    # hidden options which have no effect as of mycli 2.0.0, 2026-07.
+    # todo: remove the hidden options, since they are still advertised
+    # in spelling corrections.
+    ssl: bool | None = clickdc.option(
+        '--ssl/--no-ssl',
+        clickdc=None,
+        hidden=True,
+        deprecated='No effect. See --ssl-mode.',
+    )
+    ssh_user: str | None = clickdc.option(
+        type=str,
+        hidden=True,
+        deprecated='No effect. See https://github.com/dbcli/mycli/issues/1960 .',
+    )
+    ssh_host: str | None = clickdc.option(
+        type=str,
+        hidden=True,
+        deprecated='No effect. See https://github.com/dbcli/mycli/issues/1960 .',
+    )
+    ssh_port: int = clickdc.option(
+        type=int,
+        hidden=True,
+        deprecated='No effect. See https://github.com/dbcli/mycli/issues/1960 .',
+    )
+    ssh_password: str | None = clickdc.option(
+        type=str,
+        hidden=True,
+        deprecated='No effect. See https://github.com/dbcli/mycli/issues/1960 .',
+    )
+    ssh_key_filename: str | None = clickdc.option(
+        type=str,
+        hidden=True,
+        deprecated='No effect. See https://github.com/dbcli/mycli/issues/1960 .',
+    )
+    ssh_config_path: str = clickdc.option(
+        type=str,
+        hidden=True,
+        deprecated='No effect. See https://github.com/dbcli/mycli/issues/1960 .',
+    )
+    ssh_config_host: str | None = clickdc.option(
+        type=str,
+        hidden=True,
+        deprecated='No effect. See https://github.com/dbcli/mycli/issues/1960 .',
+    )
+    list_ssh_config: bool = clickdc.option(
+        is_flag=True,
+        hidden=True,
+        deprecated='No effect. See https://github.com/dbcli/mycli/issues/1960 .',
+    )
+    ssh_warning_off: bool = clickdc.option(
+        is_flag=True,
+        hidden=True,
+        deprecated='No effect. See https://github.com/dbcli/mycli/issues/1960 .',
+    )
 
 
 def get_password_from_file(password_file: str | None) -> str | None:

--- a/test/pytests/test_main.py
+++ b/test/pytests/test_main.py
@@ -772,6 +772,8 @@ def test_help_strings_end_with_periods():
     """Make sure click options have help text that end with a period."""
     for param in click_entrypoint.params:
         if isinstance(param, click.core.Option):
+            if param.hidden:
+                continue
             assert hasattr(param, "help")
             assert param.help.endswith(".")
 


### PR DESCRIPTION
## Description
`click` supports hidden+deprecated CLI arguments which are not advertised in the helpdoc.

To make breaking changes easier and clearer, we can accept the recently removed SSL and SSH CLI arguments in hidden+deprecated mode.  If such an option is given, the user gets a message like the following, in red:

    DeprecationWarning: The option 'ssl' is deprecated. No effect. See --ssl-mode.

We should still ultimately remove (or reimplement) these hidden arguments, since `click`'s `hidden` property is incomplete: the hidden arguments are still advertised in spelling-correction mode.

xref #1948, #1947

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
