### PR TITLE
Ensure `--batch` and `--logfile` are distinct files

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,11 @@ Features
 * Add `--warn-batch` flag, which is off by default.
 
 
+Bug Fixes
+---------
+* Ensure that `--batch` and `--logfile` files are distinct.
+
+
 Documentation
 ---------
 * Show section when recommending `default_character_set` setting.

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -333,6 +333,17 @@ def preprocess_cli_args(
             click.secho('Error: --batch and --checkpoint must be different files.', err=True, fg='red')
             sys.exit(1)
 
+    if (
+        cli_args.logfile
+        and os.path.exists(cli_args.logfile.name)
+        and cli_args.batch
+        and cli_args.batch != '-'
+        and os.path.exists(cli_args.batch)
+    ):
+        if os.path.samefile(cli_args.batch, cli_args.logfile.name):
+            click.secho('Error: --batch and --logfile must be different files.', err=True, fg='red')
+            sys.exit(1)
+
     if cli_args.verbose and cli_args.quiet:
         click.secho('Error: --verbose and --quiet are incompatible.', err=True, fg='red')
         sys.exit(1)

--- a/test/pytests/test_main.py
+++ b/test/pytests/test_main.py
@@ -2451,6 +2451,26 @@ def test_preprocess_cli_args_rejects_same_batch_and_checkpoint_file(
     assert 'Error: --batch and --checkpoint must be different files.' in capsys.readouterr().err
 
 
+def test_preprocess_cli_args_rejects_same_batch_and_logfile(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    batch_path = tmp_path / 'batch.sql'
+    batch_path.write_text('select 1;\n', encoding='utf-8')
+    cli_args = CliArgs()
+    cli_args.batch = str(batch_path)
+    cli_args.logfile = batch_path.open('a', encoding='utf-8')  # type: ignore[assignment]
+
+    try:
+        with pytest.raises(SystemExit) as excinfo:
+            preprocess_cli_args(cli_args, valid_connection_scheme)
+    finally:
+        cli_args.logfile.close()
+
+    assert excinfo.value.code == 1
+    assert 'Error: --batch and --logfile must be different files.' in capsys.readouterr().err
+
+
 def test_preprocess_cli_args_rejects_verbose_and_quiet(capsys: pytest.CaptureFixture[str]) -> None:
     cli_args = CliArgs()
     cli_args.verbose = 1


### PR DESCRIPTION
## Description
Motivation: to avoid some kind of infinite loop, in which mycli reads from a file which is constantly being written to.

This is much more succinct than #1931 , which changed the argument type from a file to a string.  In retrospect that change was a mistake.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
