### PR TITLE
Prefer `os.path.samefile()` for checkpoint file distinctness test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@ Internal
 * Improve test coverage for DSN variable expansion.
 * Test on all platforms in the Publish GitHub Action.
 * Remove unused support for writing `.mylogin.cnf` files.
+* Prefer `os.path.samefile()` for checkpoint distinctness test.
 
 
 1.76.0 (2026/06/20)

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -329,7 +329,7 @@ def preprocess_cli_args(
         and cli_args.batch != '-'
         and os.path.exists(cli_args.batch)
     ):
-        if os.stat(cli_args.batch) == os.stat(cli_args.checkpoint):
+        if os.path.samefile(cli_args.batch, cli_args.checkpoint):
             click.secho('Error: --batch and --checkpoint must be different files.', err=True, fg='red')
             sys.exit(1)
 


### PR DESCRIPTION
## Description

xref https://github.com/dbcli/mycli/pull/1962


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
