### PR TITLE
Add `/help` prompt to initial toolbar help text

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ Breaking Changes
 Features
 ---------
 * Add `--warn-batch` flag, which is off by default.
+* Add `/help` prompt to initial toolbar help.
 
 
 Bug Fixes

--- a/mycli/clitoolbar.py
+++ b/mycli/clitoolbar.py
@@ -64,6 +64,8 @@ def create_toolbar_tokens_func(
         if show_initial_toolbar_help():
             dynamic.append(divider)
             dynamic.append(("class:bottom-toolbar", "right-arrow accepts full-line suggestion"))
+            dynamic.append(divider)
+            dynamic.append(("class:bottom-toolbar", "/help for more"))
 
         if mycli.completion_refresher.is_refreshing():
             dynamic.append(divider)


### PR DESCRIPTION
## Description
This is the first step on advertising forward-slash commands.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
