### PR TITLE
Prefer forward-slash `/command` forms in markdown documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Features
     - `SELECT * FROM users WHERE <tab>` will only show column names.
 * Support for multiline queries.
 * Favorite queries with optional positional parameters. Save a query using
-  `\fs <alias> <query>` and execute it with `\f <alias>`.
+  `/fs <alias> <query>` and execute it with `/f <alias>`.
 * Timing of sql statements and table rendering.
 * Log every query and its results to a file (disabled by default).
 * Pretty print tabular data (with colors!).

--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@ Documentation
 ---------
 * Show section when recommending `default_character_set` setting.
 * Prefer forward-slash /command forms in TIPS.
+* Prefer forward-slash /command forms in markdown documentation.
 
 
 Internal

--- a/doc/llm.md
+++ b/doc/llm.md
@@ -1,8 +1,8 @@
-# Using the \llm Command (AI-assisted SQL)
+# Using the /llm Command (AI-assisted SQL)
 
-The `\llm` special command lets you ask natural-language questions and get SQL proposed for you. It uses the open‑source `llm` CLI under the hood and enriches your prompt with database context (schema and one sample row per table) so answers can include runnable SQL.
+The `/llm` special command lets you ask natural-language questions and get SQL proposed for you. It uses the open‑source `llm` CLI under the hood and enriches your prompt with database context (schema and one sample row per table) so answers can include runnable SQL.
 
-Alias: `\ai` works the same as `\llm`.
+Alias: `/ai` works the same as `/llm`.
 
 ---
 
@@ -20,13 +20,13 @@ pip install llm
 2) From the mycli prompt, configure your API key (only needed for remote providers like OpenAI):
 
 ```text
-\llm keys set openai
+/llm keys set openai
 ```
 
 3) Ask a question. The response’s SQL (inside a ```sql fenced block) is extracted and pre-filled at the prompt:
 
 ```text
-World> \llm "Capital of India?"
+World> /llm "Capital of India?"
 -- Answer text from the model...
 -- ```sql
 -- SELECT ...;
@@ -40,7 +40,7 @@ You can now hit Enter to run, or edit the query first.
 
 ## What Context Is Sent
 
-When you ask a plain question via `\llm "..."`, mycli:
+When you ask a plain question via `/llm "..."`, mycli:
 - Sends your question.
 - Adds your current database schema: table names with column types.
 - Adds one sample row (if available) from each table.
@@ -53,27 +53,27 @@ Note: Context is gathered from the current connection. If you are not connected,
 
 ## Using `llm` Subcommands from mycli
 
-You can run any `llm` CLI subcommand by prefixing it with `\llm` inside mycli. Examples:
+You can run any `llm` CLI subcommand by prefixing it with `/llm` inside mycli. Examples:
 
 - List models:
   ```text
-  \llm models
+  /llm models
   ```
 - Set the default model:
   ```text
-  \llm models default gpt-5
+  /llm models default gpt-5
   ```
 - Set provider API key:
   ```text
-  \llm keys set openai
+  /llm keys set openai
   ```
 - Install a plugin (e.g., local models via Ollama):
   ```text
-  \llm install llm-ollama
+  /llm install llm-ollama
   ```
   After installing or uninstalling plugins, mycli will restart to pick up new commands.
 
-Tab completion works for `\llm` subcommands, and even for model IDs under `models default`.
+Tab completion works for `/llm` subcommands, and even for model IDs under `models default`.
 
 Aside: <https://ollama.com/> for using local models.
 
@@ -84,7 +84,7 @@ Aside: <https://ollama.com/> for using local models.
 Ask your question in quotes. mycli sends database context and extracts a SQL block if present.
 
 ```text
-World> \llm "Most visited urls?"
+World> /llm "Most visited urls?"
 ```
 
 Behavior:
@@ -98,9 +98,9 @@ Behavior:
 Use `-c` to ask a follow‑up that continues the previous conversation with the model. This does not re-send the DB context; it relies on the ongoing thread.
 
 ```text
-World> \llm "Top 10 customers by spend"
+World> /llm "Top 10 customers by spend"
 -- model returns analysis and a ```sql block; SQL is prefilled
-World> \llm -c "Now include each customer's email and order count"
+World> /llm -c "Now include each customer's email and order count"
 ```
 
 Behavior:
@@ -115,29 +115,29 @@ Behavior:
 
 - List available models:
   ```text
-  World> \llm models
+  World> /llm models
   ```
 
 - Change default model:
   ```text
-  World> \llm models default llama3
+  World> /llm models default llama3
   ```
 
 - Set API key (for providers that require it):
   ```text
-  World> \llm keys set openai
+  World> /llm keys set openai
   ```
 
 - Ask a question with context:
   ```text
-  World> \llm "Capital of India?"
+  World> /llm "Capital of India?"
   ```
 
 - Use a local model (after installing a plugin such as `llm-ollama`):
   ```text
-  World> \llm install llm-ollama
-  World> \llm models default llama3
-  World> \llm "Top 10 customers by spend"
+  World> /llm install llm-ollama
+  World> /llm models default llama3
+  World> /llm "Top 10 customers by spend"
   ```
 
 See: <https://ollama.com/> for details.
@@ -149,13 +149,13 @@ See: <https://ollama.com/> for details.
 mycli uses a saved `llm` template named `mycli-llm-template` for contextual questions. You can view or edit it:
 
 ```text
-World> \llm templates edit mycli-llm-template
+World> /llm templates edit mycli-llm-template
 ```
 
 Tip: After first use, mycli ensures this template exists. To just view it without editing, use:
 
 ```text
-World> \llm templates show mycli-llm-template
+World> /llm templates show mycli-llm-template
 ```
 
 ---
@@ -164,15 +164,15 @@ World> \llm templates show mycli-llm-template
 
 - No SQL pre-fill: Ensure the model’s response includes a ```sql fenced block. The built‑in prompt encourages this, but some models may omit it; try asking the model to include SQL in a ```sql block.
 - Not connected to a database: Contextual questions require a live connection. Connect first. Follow‑ups with `-c` only help after a successful contextual call.
-- Plugin changes not recognized: After `\llm install` or `\llm uninstall`, mycli restarts automatically to load new commands.
-- Provider/API issues: Use `\llm keys list` and `\llm keys set <provider>` to check credentials. Use `\llm models` to confirm available models.
+- Plugin changes not recognized: After `/llm install` or `/llm uninstall`, mycli restarts automatically to load new commands.
+- Provider/API issues: Use `/llm keys list` and `/llm keys set <provider>` to check credentials. Use `/llm models` to confirm available models.
 
 ---
 
 ## Notes and Safety
 
 - Data sent: Contextual questions send schema (table/column names and types) and a single sample row per table. Review your data sensitivity policies before using remote models; prefer local models (such as ollama) if needed.
-- Help: Running `\llm` with no arguments shows a short usage message.
+- Help: Running `/llm` with no arguments shows a short usage message.
 
 ## Turning Off LLM Support
 


### PR DESCRIPTION
## Description
Prefer forward-slash `/command` forms in markdown documentation:

 * `README.md`
 * `doc/llm.md`

Preparation for release 2.0.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
