### PR TITLE
Override `min_completion_trigger` for `/command` forms

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@ Features
 * Add `--warn-batch` flag, which is off by default.
 * Add `/help` prompt to initial toolbar help.
 * Advertise forward-slash `/command` forms in `/help` output.
+* Override `min_completion_trigger` for the `/command` form.
 
 
 Bug Fixes

--- a/mycli/main_modes/repl.py
+++ b/mycli/main_modes/repl.py
@@ -102,6 +102,8 @@ def complete_while_typing_filter() -> bool:
         return True
     app = get_app()
     text = app.current_buffer.text.lstrip()
+    if text.startswith('/') and not text.startswith('/*'):
+        return True
     text_len = len(text)
     if text_len < MIN_COMPLETION_TRIGGER:
         return False

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -9,7 +9,8 @@ show_warnings = False
 # possible completions will be listed.
 smart_completion = True
 
-# Minimum characters typed before offering completion suggestions.
+# Minimum characters typed before offering completion suggestions.  Forward
+# slash for a command is an exception which always offers completions.
 # Suggestion: 3.
 min_completion_trigger = 1
 

--- a/test/myclirc
+++ b/test/myclirc
@@ -9,7 +9,8 @@ show_warnings = False
 # possible completions will be listed.
 smart_completion = True
 
-# Minimum characters typed before offering completion suggestions.
+# Minimum characters typed before offering completion suggestions.  Forward
+# slash for a command is an exception which always offers completions.
 # Suggestion: 3.
 min_completion_trigger = 1
 

--- a/test/pytests/test_main_modes_repl.py
+++ b/test/pytests/test_main_modes_repl.py
@@ -283,6 +283,24 @@ def test_complete_while_typing_filter_covers_threshold_and_word_rules(monkeypatc
     assert repl_mode.complete_while_typing_filter() is True
 
 
+def test_complete_while_typing_filter_always_completes_slash_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(repl_mode, 'MIN_COMPLETION_TRIGGER', 3)
+    monkeypatch.setattr(repl_mode, 'get_app', lambda: SimpleNamespace(current_buffer=SimpleNamespace(text='/')))
+
+    assert repl_mode.complete_while_typing_filter() is True
+
+
+def test_complete_while_typing_filter_does_not_treat_block_comments_as_slash_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(repl_mode, 'MIN_COMPLETION_TRIGGER', 3)
+    monkeypatch.setattr(repl_mode, 'get_app', lambda: SimpleNamespace(current_buffer=SimpleNamespace(text='/*')))
+
+    assert repl_mode.complete_while_typing_filter() is False
+
+
 def test_repl_create_history(monkeypatch: pytest.MonkeyPatch) -> None:
     cli = make_repl_cli()
     monkeypatch.setenv('MYCLI_HISTFILE', '~/override-history')


### PR DESCRIPTION
## Description
Ignore the `min_completion_trigger` setting for a forward slash at the start of an entry, always listing the possible commands immediately.

This has no effect unless the default setting is changed.  Though I think we should consider changing that default!

This is part of the transition, at least in advertisement, to consistent forward-slash commands.

Preparation for release 2.0.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
