### PR TITLE
Prefer long argument to `pip`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ via `pip`.  This pakage is always up to date.
 You might need `sudo` on Linux.
 
 ```bash
-pip install -U 'mycli[all]'
+pip install --upgrade 'mycli[all]'
 ```
 
 or, only on macOS (`fzf` and `pygments` are optional):


### PR DESCRIPTION
## Description
Nitpick to sync with mycli.net install instructions.  Already covered by a changelog entry.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
