### PR TITLE
Grammar nitpick in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ Install the `less` pager, for example by `scoop install less`.
 Follow the instructions on this blogpost: https://web.archive.org/web/20221006045208/https://www.codewall.co.uk/installing-using-mycli-on-windows/
 
 The libraries used in mycli are Windows-compatible, but there are known
-limitations according to the test suite.   The basics work without any
-modifications, but isn't supported software at this time.
+limitations according to the test suite.  The basics work without any
+modifications, but this configuration isn't supported software at this time.
 
 PRs to address shortcomings on Windows would be welcome!
 


### PR DESCRIPTION
## Description
Grammar nitpick in README.md, noticed when syncing content with mycli.net

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
