### PR TITLE
Always show Apache Doris in vendor lists

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -36,6 +36,7 @@ Documentation
 * Prefer forward-slash /command forms in TIPS.
 * Prefer forward-slash /command forms in markdown documentation.
 * Update README, especially for installation instructions.
+* Always show Apache Doris in vendor lists.
 
 
 Internal

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -130,7 +130,7 @@ wider_completion_menu = False
 # * \k - connection socket basename OR the port
 # * \K - full connection socket path OR the port
 # * \T - connection SSL/TLS version
-# * \t - database vendor (Percona, MySQL, MariaDB, TiDB)
+# * \t - database vendor (Percona, MySQL, MariaDB, TiDB, Doris)
 # * \u - username
 # * \w - number of warnings, or "(none)" (requires frequent trips to the server)
 # * \W - number of warnings, or the empty string (requires frequent trips to the server)

--- a/test/myclirc
+++ b/test/myclirc
@@ -130,7 +130,7 @@ wider_completion_menu = False
 # * \k - connection socket basename OR the port
 # * \K - full connection socket path OR the port
 # * \T - connection SSL/TLS version
-# * \t - database vendor (Percona, MySQL, MariaDB, TiDB)
+# * \t - database vendor (Percona, MySQL, MariaDB, TiDB, Doris)
 # * \u - username
 # * \w - number of warnings, or "(none)" (requires frequent trips to the server)
 # * \W - number of warnings, or the empty string (requires frequent trips to the server)


### PR DESCRIPTION
## Description
Support for recognizing Apache Doris was added, but not documented everywhere.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
