### PR TITLE
Fix a typo in myclirc commentary

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Documentation
+---------
+* Fix a typo in myclirc commentary.
+
+
 2.0.0 (2026/07/03)
 ==============
 

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -5,7 +5,7 @@
 # after executing a SQL statement when applicable.
 show_warnings = False
 
-# Enables context sensitive auto-completion. If this is disabled the all
+# Enables context sensitive auto-completion. If this is disabled then all
 # possible completions will be listed.
 smart_completion = True
 

--- a/test/myclirc
+++ b/test/myclirc
@@ -5,7 +5,7 @@
 # after executing a SQL statement when applicable.
 show_warnings = False
 
-# Enables context sensitive auto-completion. If this is disabled the all
+# Enables context sensitive auto-completion. If this is disabled then all
 # possible completions will be listed.
 smart_completion = True
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
