### PR TITLE
`--ssh-jump` Unix Domain Socket tunnel method

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Internal
+---------
+* Configurable tunnel method for `--ssh-jump`, making UDS usually default.
+
+
 2.1.1 (2026/07/08)
 ==============
 

--- a/mycli/client_connection.py
+++ b/mycli/client_connection.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import sys
 import traceback
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import quote as urlquote
 
 import click
@@ -84,6 +84,7 @@ class ClientConnectionMixin:
             remote_socket = socket or None
             ssh_executable = self.config.get('ssh', {}).get('ssh_executable', 'ssh') or 'ssh'
             ssh_options = self.config.get('ssh', {}).get('ssh_options')
+            tunnel_method: Literal['auto', 'socket', 'port'] = self.config.get('ssh', {}).get('tunnel_method', 'auto').lower() or 'auto'
             try:
                 self.ssh_tunnel = SshTunnel.from_target(
                     ssh_jump,
@@ -92,6 +93,7 @@ class ClientConnectionMixin:
                     remote_socket=remote_socket,
                     ssh_executable=ssh_executable,
                     ssh_options=ssh_options,
+                    tunnel_method=tunnel_method,
                 )
                 self.ssh_tunnel.start()
             except (OSError, ValueError, SshTunnelError) as exc:
@@ -194,7 +196,11 @@ class ClientConnectionMixin:
             'init_command': init_command,
             'unbuffered': unbuffered,
         }
-        if self.ssh_tunnel:
+        if self.ssh_tunnel and self.ssh_tunnel.local_socket:
+            connection_info['host'] = None
+            connection_info['port'] = None
+            connection_info['socket'] = self.ssh_tunnel.local_socket
+        elif self.ssh_tunnel:
             connection_info['host'] = self.ssh_tunnel.local_host
             connection_info['port'] = self.ssh_tunnel.local_port
             connection_info['socket'] = None

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -305,6 +305,17 @@ vi_ttimeoutlen = 0.1
 # How long to wait for an Escape key sequence in Emacs mode.
 emacs_ttimeoutlen = 0.5
 
+[ssh]
+# Path to the ssh executable used by --ssh-jump.
+ssh_executable = ssh
+
+# Options to pass to the ssh executable when making a tunnel.
+ssh_options = -a -o ServerAliveInterval=60 -o ExitOnForwardFailure=yes -o IPQoS=af13 -o LogLevel=FATAL
+
+# Method for establishing the local side of the SSH tunnel: auto, port, socket.
+# auto means: port if on Windows, socket otherwise.
+tunnel_method = auto
+
 # Custom colors for the completion menu, toolbar, etc, with actual support
 # depending on the terminal, and the property being set.
 # Colors: #ffffff, bg:#ffffff, border:#ffffff.
@@ -407,10 +418,3 @@ matching-bracket.other = '#000000 bg:#aacccc'
 [alias_dsn.init-commands]
 # Define one or more SQL statements per alias (semicolon-separated).
 # example_dsn = "SET sql_select_limit=1000; SET time_zone='+00:00'"
-
-[ssh]
-# Path to the ssh executable used by --ssh-jump.
-ssh_executable = ssh
-
-# options to pass to the ssh executable when making a tunnel
-ssh_options = -a -o ServerAliveInterval=60 -o ExitOnForwardFailure=yes -o IPQoS=af13 -o LogLevel=FATAL

--- a/mycli/ssh_tunnel.py
+++ b/mycli/ssh_tunnel.py
@@ -1,21 +1,47 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import os
 import shlex
 import socket
 import subprocess
+import tempfile
 import threading
 import time
+from typing import Literal
+
+from mycli.compat import WIN
+
+DEFAULT_LOCALHOST = 'localhost'
+DEFAULT_SSH_EXECUTABLE = 'ssh'
+DEFAULT_TUNNEL_METHOD: Literal['auto', 'socket', 'port'] = 'auto'
+MAX_UNIX_SOCKET_PATH_BYTES = 103
 
 
 class SshTunnelError(RuntimeError):
     pass
 
 
-def _find_free_local_port() -> int:
+def _find_free_local_port(local_host: str | None) -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(('127.0.0.1', 0))
+        sock.bind((local_host or DEFAULT_LOCALHOST, 0))
         return int(sock.getsockname()[1])
+
+
+def _make_local_socket_path() -> str:
+    fd, path = tempfile.mkstemp(prefix='mycli-ssh-', suffix='.sock')
+    os.close(fd)
+    os.unlink(path)
+    _check_local_socket_path_limit(path)
+    return path
+
+
+def _check_local_socket_path_limit(path: str) -> None:
+    path_bytes = len(os.fsencode(path))
+    if path_bytes > MAX_UNIX_SOCKET_PATH_BYTES:
+        raise SshTunnelError(
+            f'Local SSH socket path is too long for sockaddr_un: {path_bytes} bytes > {MAX_UNIX_SOCKET_PATH_BYTES} bytes: {path}'
+        )
 
 
 @dataclass(slots=True)
@@ -39,11 +65,11 @@ class SshTunnel:
         remote_host: str,
         remote_port: int,
         remote_socket: str | None = None,
-        ssh_executable: str = 'ssh',
+        ssh_executable: str = DEFAULT_SSH_EXECUTABLE,
         ssh_options: str | None = None,
         ssh_port: int | None = None,
-        local_port: int | None = None,
         ready_timeout: float = 30.0,
+        tunnel_method: Literal['auto', 'socket', 'port'] = DEFAULT_TUNNEL_METHOD,
     ) -> None:
         self.ssh_executable = ssh_executable
         self.ssh_options = ssh_options
@@ -52,8 +78,14 @@ class SshTunnel:
         self.remote_host = remote_host
         self.remote_port = remote_port
         self.remote_socket = remote_socket
-        self.local_host = '127.0.0.1'
-        self.local_port = local_port or _find_free_local_port()
+        self.tunnel_method = tunnel_method
+        if tunnel_method == 'auto':
+            self.true_tunnel_method: Literal['socket', 'port'] = 'port' if WIN else 'socket'
+        else:
+            self.true_tunnel_method = tunnel_method
+        self.local_socket = _make_local_socket_path() if self.true_tunnel_method == 'socket' else None
+        self.local_host = DEFAULT_LOCALHOST if self.true_tunnel_method == 'port' else None
+        self.local_port = _find_free_local_port(self.local_host) if self.true_tunnel_method == 'port' else None
         self.ready_timeout = ready_timeout
         self.process: subprocess.Popen | None = None
         self._startup_error: OSError | None = None
@@ -69,8 +101,9 @@ class SshTunnel:
         remote_host: str,
         remote_port: int,
         remote_socket: str | None = None,
-        ssh_executable: str = 'ssh',
+        ssh_executable: str = DEFAULT_SSH_EXECUTABLE,
         ssh_options: str | None = None,
+        tunnel_method: Literal['auto', 'socket', 'port'] = DEFAULT_TUNNEL_METHOD,
     ) -> SshTunnel:
         target = SshTunnelTarget.parse(ssh_jump_spec)
         return cls(
@@ -81,12 +114,18 @@ class SshTunnel:
             remote_socket=remote_socket,
             ssh_executable=ssh_executable,
             ssh_options=ssh_options,
+            tunnel_method=tunnel_method,
         )
 
     def _forward_spec(self) -> str:
-        if self.remote_socket:
-            return f'{self.local_host}:{self.local_port}:{self.remote_socket}'
-        return f'{self.local_host}:{self.local_port}:{self.remote_host}:{self.remote_port}'
+        if self.local_socket:
+            if self.remote_socket:
+                return f'{self.local_socket}:{self.remote_socket}'
+            return f'{self.local_socket}:{self.remote_host}:{self.remote_port}'
+        else:
+            if self.remote_socket:
+                return f'{self.local_host}:{self.local_port}:{self.remote_socket}'
+            return f'{self.local_host}:{self.local_port}:{self.remote_host}:{self.remote_port}'
 
     def command(self) -> list[str]:
         opts = shlex.split(self.ssh_options or '')
@@ -130,6 +169,11 @@ class SshTunnel:
                 process.wait()
         if self._thread is not None and self._thread.is_alive():
             self._thread.join(timeout=5)
+        try:
+            if self.local_socket:
+                os.unlink(self.local_socket)
+        except FileNotFoundError:
+            pass
 
     def _run(self) -> None:
         try:
@@ -149,7 +193,15 @@ class SshTunnel:
 
     def _is_listening(self) -> bool:
         try:
-            with socket.create_connection((self.local_host, self.local_port), timeout=0.05):
-                return True
+            if self.local_socket:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                    sock.settimeout(0.05)
+                    sock.connect(self.local_socket)
+                    return True
+            elif self.local_host and self.local_port:
+                with socket.create_connection((self.local_host, self.local_port), timeout=0.05):
+                    return True
+            else:
+                return False
         except OSError:
             return False

--- a/test/myclirc
+++ b/test/myclirc
@@ -305,6 +305,17 @@ vi_ttimeoutlen = 0.1
 # How long to wait for an Escape key sequence in Emacs mode.
 emacs_ttimeoutlen = 0.5
 
+[ssh]
+# Path to the ssh executable used by --ssh-jump.
+ssh_executable = ssh
+
+# Options to pass to the ssh executable when making a tunnel.
+ssh_options = -a -o ServerAliveInterval=60 -o ExitOnForwardFailure=yes -o IPQoS=af13 -o LogLevel=FATAL
+
+# Method for establishing the local side of the SSH tunnel: auto, port, socket.
+# auto means: port if on Windows, socket otherwise.
+tunnel_method = auto
+
 # Custom colors for the completion menu, toolbar, etc, with actual support
 # depending on the terminal, and the property being set.
 # Colors: #ffffff, bg:#ffffff, border:#ffffff.
@@ -410,10 +421,3 @@ global_limit = set sql_select_limit=9999
 [alias_dsn.init-commands]
 # Define one or more SQL statements per alias (semicolon-separated).
 # example_dsn = "SET sql_select_limit=1000; SET time_zone='+00:00'"
-
-[ssh]
-# Path to the ssh executable used by --ssh-jump.
-ssh_executable = ssh
-
-# options to pass to the ssh executable when making a tunnel
-ssh_options = -a -o ServerAliveInterval=60 -o ExitOnForwardFailure=yes -o IPQoS=af13 -o LogLevel=FATAL

--- a/test/pytests/test_client_connection.py
+++ b/test/pytests/test_client_connection.py
@@ -4,7 +4,7 @@ import builtins
 import importlib.util
 import sys
 from types import ModuleType, SimpleNamespace
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import pymysql
 import pytest
@@ -307,12 +307,26 @@ def test_connect_reports_keyring_save_errors(monkeypatch: pytest.MonkeyPatch) ->
     assert secho_calls == [('Password not saved to the system keyring: locked', {'err': True, 'fg': 'red'})]
 
 
+def test_connect_does_not_save_empty_password_to_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = DummyClient()
+    set_password_calls: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(client_connection.keyring, 'get_password', lambda domain, identifier: None)
+    monkeypatch.setattr(
+        client_connection.keyring,
+        'set_password',
+        lambda domain, identifier, password: set_password_calls.append((domain, identifier, password)),
+    )
+
+    client.connect(user='alice', host='db', port=3307, passwd='', use_keyring=True)
+
+    assert set_password_calls == []
+
+
 def test_connect_uses_ssh_jump_with_remote_socket(monkeypatch: pytest.MonkeyPatch) -> None:
     tunnel_calls: list[dict[str, Any]] = []
 
     class FakeTunnel:
-        local_host = '127.0.0.1'
-        local_port = 4406
+        local_socket = '/tmp/mycli-ssh.sock'
         remote_socket = '/var/run/mysqld/mysqld.sock'
 
         @classmethod
@@ -325,6 +339,7 @@ def test_connect_uses_ssh_jump_with_remote_socket(monkeypatch: pytest.MonkeyPatc
             remote_socket: str | None = None,
             ssh_executable: str = 'ssh',
             ssh_options: str | None = None,
+            tunnel_method: Literal['auto', 'socket', 'port'] = 'auto',
         ) -> 'FakeTunnel':
             tunnel_calls.append({
                 'ssh_jump': ssh_jump,
@@ -347,7 +362,7 @@ def test_connect_uses_ssh_jump_with_remote_socket(monkeypatch: pytest.MonkeyPatc
 
     client.connect(
         user='alice',
-        host='db.internal',
+        host=None,
         port=None,
         socket='/var/run/mysqld/mysqld.sock',
         ssh_jump='bastion',
@@ -356,13 +371,49 @@ def test_connect_uses_ssh_jump_with_remote_socket(monkeypatch: pytest.MonkeyPatc
     assert tunnel_calls == [
         {
             'ssh_jump': 'bastion',
-            'remote_host': 'db.internal',
+            'remote_host': 'localhost',
             'remote_port': 3306,
             'remote_socket': '/var/run/mysqld/mysqld.sock',
             'ssh_executable': '/opt/bin/ssh',
             'ssh_options': None,
         }
     ]
+    assert FakeSQLExecute.calls[-1]['host'] is None
+    assert FakeSQLExecute.calls[-1]['port'] is None
+    assert FakeSQLExecute.calls[-1]['socket'] == '/tmp/mycli-ssh.sock'
+
+
+def test_connect_uses_ssh_jump_with_local_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeTunnel:
+        local_socket = None
+        local_host = '127.0.0.1'
+        local_port = 4406
+
+        @classmethod
+        def from_target(
+            cls,
+            _ssh_jump: str,
+            *,
+            remote_host: str,
+            remote_port: int,
+            remote_socket: str | None = None,
+            ssh_executable: str = 'ssh',
+            ssh_options: str | None = None,
+            tunnel_method: Literal['auto', 'socket', 'port'] = 'auto',
+        ) -> 'FakeTunnel':
+            return cls()
+
+        def start(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(client_connection, 'SshTunnel', FakeTunnel)
+    client = DummyClient()
+
+    client.connect(host='db.internal', port=3307, ssh_jump='bastion')
+
     assert FakeSQLExecute.calls[-1]['host'] == '127.0.0.1'
     assert FakeSQLExecute.calls[-1]['port'] == 4406
     assert FakeSQLExecute.calls[-1]['socket'] is None
@@ -373,8 +424,7 @@ def test_connect_reports_ssh_jump_start_error_and_closes_tunnel(monkeypatch: pyt
     secho_calls: list[tuple[str, dict[str, Any]]] = []
 
     class FakeTunnel:
-        local_host = '127.0.0.1'
-        local_port = 4406
+        local_socket = '/tmp/mycli-ssh.sock'
         remote_socket = None
 
         @classmethod
@@ -387,6 +437,7 @@ def test_connect_reports_ssh_jump_start_error_and_closes_tunnel(monkeypatch: pyt
             remote_socket: str | None = None,
             ssh_executable: str = 'ssh',
             ssh_options: str | None = None,
+            tunnel_method: Literal['auto', 'socket', 'port'] = 'auto',
         ) -> 'FakeTunnel':
             return cls()
 
@@ -411,8 +462,7 @@ def test_connect_reports_ssh_jump_start_error_and_closes_tunnel(monkeypatch: pyt
 
 def test_connect_swallows_ssh_jump_cleanup_error(monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeTunnel:
-        local_host = '127.0.0.1'
-        local_port = 4406
+        local_socket = '/tmp/mycli-ssh.sock'
         remote_socket = None
 
         @classmethod
@@ -425,6 +475,7 @@ def test_connect_swallows_ssh_jump_cleanup_error(monkeypatch: pytest.MonkeyPatch
             remote_socket: str | None = None,
             ssh_executable: str = 'ssh',
             ssh_options: str | None = None,
+            tunnel_method: Literal['auto', 'socket', 'port'] = 'auto',
         ) -> 'FakeTunnel':
             return cls()
 

--- a/test/pytests/test_ssh_tunnel.py
+++ b/test/pytests/test_ssh_tunnel.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import socket
+from pathlib import Path
 import subprocess
 from typing import Any, cast
 
@@ -8,6 +8,67 @@ import pytest
 
 from mycli import ssh_tunnel
 from mycli.ssh_tunnel import SshTunnel, SshTunnelError, SshTunnelTarget
+
+
+def test_find_free_local_port_binds_default_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, Any]] = []
+
+    class FakeSocket:
+        def __enter__(self) -> 'FakeSocket':
+            return self
+
+        def __exit__(self, *_args: Any) -> None:
+            pass
+
+        def bind(self, address: tuple[str, int]) -> None:
+            calls.append(('bind', address))
+
+        def getsockname(self) -> tuple[str, int]:
+            return ('localhost', 4406)
+
+    def fake_socket(family: int, kind: int) -> FakeSocket:
+        calls.append(('socket', (family, kind)))
+        return FakeSocket()
+
+    monkeypatch.setattr(ssh_tunnel.socket, 'socket', fake_socket)
+
+    assert ssh_tunnel._find_free_local_port(None) == 4406
+    assert calls == [
+        ('socket', (ssh_tunnel.socket.AF_INET, ssh_tunnel.socket.SOCK_STREAM)),
+        ('bind', ('localhost', 0)),
+    ]
+
+
+def test_make_local_socket_path_unlinks_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, Any]] = []
+
+    def fake_mkstemp(*, prefix: str, suffix: str) -> tuple[int, str]:
+        calls.append(('mkstemp', (prefix, suffix)))
+        return (7, '/tmp/mycli-ssh.sock')
+
+    monkeypatch.setattr(ssh_tunnel.tempfile, 'mkstemp', fake_mkstemp)
+    monkeypatch.setattr(ssh_tunnel.os, 'close', lambda fd: calls.append(('close', fd)))
+    monkeypatch.setattr(ssh_tunnel.os, 'unlink', lambda path: calls.append(('unlink', path)))
+
+    assert ssh_tunnel._make_local_socket_path() == '/tmp/mycli-ssh.sock'
+    assert calls == [
+        ('mkstemp', ('mycli-ssh-', '.sock')),
+        ('close', 7),
+        ('unlink', '/tmp/mycli-ssh.sock'),
+    ]
+
+
+def test_check_local_socket_path_limit_accepts_maximum_length() -> None:
+    path = '/' + 's' * (ssh_tunnel.MAX_UNIX_SOCKET_PATH_BYTES - 1)
+
+    ssh_tunnel._check_local_socket_path_limit(path)
+
+
+def test_check_local_socket_path_limit_rejects_too_long_path() -> None:
+    path = '/' + 's' * ssh_tunnel.MAX_UNIX_SOCKET_PATH_BYTES
+
+    with pytest.raises(SshTunnelError, match='Local SSH socket path is too long for sockaddr_un'):
+        ssh_tunnel._check_local_socket_path_limit(path)
 
 
 def test_ssh_tunnel_target_parse_handles_target_with_port() -> None:
@@ -24,59 +85,89 @@ def test_ssh_tunnel_target_parse_handles_target_without_port() -> None:
     assert target.ssh_port is None
 
 
-def test_ssh_tunnel_command_includes_forward_and_ssh_port() -> None:
+def test_ssh_tunnel_command_includes_forward_and_ssh_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: '/tmp/mycli-ssh.sock')
     tunnel = SshTunnel(
         ssh_target='alice@bastion',
         ssh_port=2222,
         remote_host='db.internal',
         remote_port=3307,
-        local_port=4406,
     )
 
     assert tunnel.command()[0] == 'ssh'
-    assert '127.0.0.1:4406:db.internal:3307' in tunnel.command()
+    assert '/tmp/mycli-ssh.sock:db.internal:3307' in tunnel.command()
     assert 'alice@bastion' in tunnel.command()
     assert '2222' in tunnel.command()
 
 
-def test_ssh_tunnel_command_uses_configured_ssh_executable() -> None:
+def test_ssh_tunnel_command_uses_configured_ssh_executable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: '/tmp/mycli-ssh.sock')
     tunnel = SshTunnel(
         ssh_target='alice@bastion',
         remote_host='db.internal',
         remote_port=3307,
-        local_port=4406,
         ssh_executable='/opt/bin/ssh',
     )
 
     assert tunnel.command()[0] == '/opt/bin/ssh'
 
 
-def test_ssh_tunnel_command_forwards_remote_socket() -> None:
+def test_ssh_tunnel_command_forwards_remote_socket(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: '/tmp/mycli-ssh.sock')
     tunnel = SshTunnel(
         ssh_target='alice@bastion',
         remote_host='db.internal',
         remote_port=3307,
         remote_socket='/var/run/mysqld/mysqld.sock',
-        local_port=4406,
     )
 
-    assert '127.0.0.1:4406:/var/run/mysqld/mysqld.sock' in tunnel.command()
-    assert '127.0.0.1:4406:db.internal:3307' not in tunnel.command()
+    assert '/tmp/mycli-ssh.sock:/var/run/mysqld/mysqld.sock' in tunnel.command()
+    assert '/tmp/mycli-ssh.sock:db.internal:3307' not in tunnel.command()
 
 
-def test_ssh_tunnel_from_target_allocates_local_port(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(ssh_tunnel, '_find_free_local_port', lambda: 4406)
+def test_ssh_tunnel_command_uses_local_port_forward(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ssh_tunnel, '_find_free_local_port', lambda local_host: 4406)
+
+    tunnel = SshTunnel(
+        ssh_target='alice@bastion',
+        remote_host='db.internal',
+        remote_port=3307,
+        tunnel_method='port',
+    )
+
+    assert tunnel.true_tunnel_method == 'port'
+    assert 'localhost:4406:db.internal:3307' in tunnel.command()
+
+
+def test_ssh_tunnel_command_uses_local_port_forward_for_remote_socket(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ssh_tunnel, '_find_free_local_port', lambda local_host: 4406)
+
+    tunnel = SshTunnel(
+        ssh_target='alice@bastion',
+        remote_host='db.internal',
+        remote_port=3307,
+        remote_socket='/var/run/mysqld/mysqld.sock',
+        tunnel_method='port',
+    )
+
+    assert 'localhost:4406:/var/run/mysqld/mysqld.sock' in tunnel.command()
+    assert 'localhost:4406:db.internal:3307' not in tunnel.command()
+
+
+def test_ssh_tunnel_from_target_allocates_local_socket(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: '/tmp/mycli-ssh.sock')
 
     tunnel = SshTunnel.from_target('alice@bastion:2222', remote_host='db.internal', remote_port=3307)
 
     assert tunnel.ssh_target == 'alice@bastion'
     assert tunnel.ssh_port == 2222
-    assert tunnel.local_port == 4406
     assert tunnel.remote_host == 'db.internal'
     assert tunnel.remote_port == 3307
 
 
-def test_ssh_tunnel_from_target_uses_configured_ssh_executable() -> None:
+def test_ssh_tunnel_from_target_uses_configured_ssh_executable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: '/tmp/mycli-ssh.sock')
+
     tunnel = SshTunnel.from_target(
         'alice@bastion',
         remote_host='db.internal',
@@ -87,7 +178,20 @@ def test_ssh_tunnel_from_target_uses_configured_ssh_executable() -> None:
     assert tunnel.ssh_executable == '/opt/bin/ssh'
 
 
-def test_ssh_tunnel_start_waits_until_local_port_listens(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_ssh_tunnel_auto_uses_port_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ssh_tunnel, 'WIN', True)
+    monkeypatch.setattr(ssh_tunnel, '_find_free_local_port', lambda local_host: 4406)
+
+    tunnel = SshTunnel.from_target('alice@bastion', remote_host='db.internal', remote_port=3307)
+
+    assert tunnel.tunnel_method == 'auto'
+    assert tunnel.true_tunnel_method == 'port'
+    assert tunnel.local_host == 'localhost'
+    assert tunnel.local_port == 4406
+    assert tunnel.local_socket is None
+
+
+def test_ssh_tunnel_start_waits_until_local_socket_listens(monkeypatch: pytest.MonkeyPatch) -> None:
     started_commands: list[list[str]] = []
 
     class FakeProcess:
@@ -107,11 +211,11 @@ def test_ssh_tunnel_start_waits_until_local_port_listens(monkeypatch: pytest.Mon
             pass
 
     monkeypatch.setattr(ssh_tunnel.subprocess, 'Popen', FakeProcess)
+    monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: '/tmp/mycli-ssh.sock')
     tunnel = SshTunnel(
         ssh_target='bastion',
         remote_host='db.internal',
         remote_port=3306,
-        local_port=4406,
     )
     checks = iter([False, True])
     monkeypatch.setattr(tunnel, '_is_listening', lambda: next(checks))
@@ -134,11 +238,11 @@ def test_ssh_tunnel_start_reports_process_exit_before_ready(monkeypatch: pytest.
             return 255
 
     monkeypatch.setattr(ssh_tunnel.subprocess, 'Popen', FakeProcess)
+    monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: '/tmp/mycli-ssh.sock')
     tunnel = SshTunnel(
         ssh_target='bastion',
         remote_host='db.internal',
         remote_port=3306,
-        local_port=4406,
     )
     monkeypatch.setattr(tunnel, '_is_listening', lambda: False)
 
@@ -151,11 +255,11 @@ def test_ssh_tunnel_start_reports_process_start_error(monkeypatch: pytest.Monkey
         raise FileNotFoundError('missing ssh')
 
     monkeypatch.setattr(ssh_tunnel.subprocess, 'Popen', fail_popen)
+    monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: '/tmp/mycli-ssh.sock')
     tunnel = SshTunnel(
         ssh_target='bastion',
         remote_host='db.internal',
         remote_port=3306,
-        local_port=4406,
     )
     monkeypatch.setattr(tunnel, '_is_listening', lambda: False)
 
@@ -166,11 +270,11 @@ def test_ssh_tunnel_start_reports_process_start_error(monkeypatch: pytest.Monkey
 
 
 def test_ssh_tunnel_start_reports_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: '/tmp/mycli-ssh.sock')
     tunnel = SshTunnel(
         ssh_target='bastion',
         remote_host='db.internal',
         remote_port=3306,
-        local_port=4406,
         ready_timeout=0,
     )
     monkeypatch.setattr(tunnel, '_run', lambda: None)
@@ -179,7 +283,7 @@ def test_ssh_tunnel_start_reports_timeout(monkeypatch: pytest.MonkeyPatch) -> No
         tunnel.start()
 
 
-def test_ssh_tunnel_close_terminates_running_process() -> None:
+def test_ssh_tunnel_close_terminates_running_process(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[str] = []
 
     class FakeProcess:
@@ -193,11 +297,11 @@ def test_ssh_tunnel_close_terminates_running_process() -> None:
             calls.append(f'wait:{timeout}')
             return 0
 
+    monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: '/tmp/mycli-ssh.sock')
     tunnel = SshTunnel(
         ssh_target='bastion',
         remote_host='db.internal',
         remote_port=3306,
-        local_port=4406,
     )
     tunnel.process = cast(Any, FakeProcess())
 
@@ -206,7 +310,7 @@ def test_ssh_tunnel_close_terminates_running_process() -> None:
     assert calls == ['terminate', 'wait:5']
 
 
-def test_ssh_tunnel_close_kills_process_after_terminate_timeout() -> None:
+def test_ssh_tunnel_close_kills_process_after_terminate_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[str] = []
 
     class FakeProcess:
@@ -230,11 +334,11 @@ def test_ssh_tunnel_close_kills_process_after_terminate_timeout() -> None:
         def kill(self) -> None:
             calls.append('kill')
 
+    monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: '/tmp/mycli-ssh.sock')
     tunnel = SshTunnel(
         ssh_target='bastion',
         remote_host='db.internal',
         remote_port=3306,
-        local_port=4406,
     )
     tunnel.process = cast(Any, FakeProcess())
 
@@ -243,7 +347,7 @@ def test_ssh_tunnel_close_kills_process_after_terminate_timeout() -> None:
     assert calls == ['terminate', 'wait:5', 'kill', 'wait:None']
 
 
-def test_ssh_tunnel_close_joins_running_thread() -> None:
+def test_ssh_tunnel_close_joins_running_thread(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[str] = []
 
     class FakeThread:
@@ -253,11 +357,11 @@ def test_ssh_tunnel_close_joins_running_thread() -> None:
         def join(self, timeout: float | None = None) -> None:
             calls.append(f'join:{timeout}')
 
+    monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: '/tmp/mycli-ssh.sock')
     tunnel = SshTunnel(
         ssh_target='bastion',
         remote_host='db.internal',
         remote_port=3306,
-        local_port=4406,
     )
     tunnel._thread = cast(Any, FakeThread())
 
@@ -266,7 +370,86 @@ def test_ssh_tunnel_close_joins_running_thread() -> None:
     assert calls == ['join:5']
 
 
+def test_ssh_tunnel_close_removes_local_socket_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    local_socket = tmp_path / 'mycli-ssh.sock'
+    monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: str(local_socket))
+    local_socket.touch()
+    tunnel = SshTunnel(
+        ssh_target='bastion',
+        remote_host='db.internal',
+        remote_port=3306,
+    )
+
+    tunnel.close()
+
+    assert not local_socket.exists()
+
+
 def test_ssh_tunnel_is_listening_returns_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, Any]] = []
+
+    class FakeSocket:
+        def __enter__(self) -> 'FakeSocket':
+            return self
+
+        def __exit__(self, *_args: Any) -> None:
+            pass
+
+        def settimeout(self, timeout: float) -> None:
+            calls.append(('settimeout', timeout))
+
+        def connect(self, address: str) -> None:
+            calls.append(('connect', address))
+
+    def fake_socket(family: int, kind: int) -> FakeSocket:
+        calls.append(('socket', (family, kind)))
+        return FakeSocket()
+
+    monkeypatch.setattr(ssh_tunnel.socket, 'socket', fake_socket)
+    monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: '/tmp/mycli-ssh.sock')
+    tunnel = SshTunnel(
+        ssh_target='bastion',
+        remote_host='db.internal',
+        remote_port=3306,
+    )
+
+    assert tunnel._is_listening() is True
+    assert calls == [
+        ('socket', (ssh_tunnel.socket.AF_UNIX, ssh_tunnel.socket.SOCK_STREAM)),
+        ('settimeout', 0.05),
+        ('connect', '/tmp/mycli-ssh.sock'),
+    ]
+
+
+def test_ssh_tunnel_is_listening_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeSocket:
+        def __enter__(self) -> 'FakeSocket':
+            return self
+
+        def __exit__(self, *_args: Any) -> None:
+            pass
+
+        def settimeout(self, _timeout: float) -> None:
+            pass
+
+        def connect(self, _address: str) -> None:
+            raise OSError
+
+    def fake_socket(*_args: Any, **_kwargs: Any) -> FakeSocket:
+        return FakeSocket()
+
+    monkeypatch.setattr(ssh_tunnel.socket, 'socket', fake_socket)
+    monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: '/tmp/mycli-ssh.sock')
+    tunnel = SshTunnel(
+        ssh_target='bastion',
+        remote_host='db.internal',
+        remote_port=3306,
+    )
+
+    assert tunnel._is_listening() is False
+
+
+def test_ssh_tunnel_is_listening_checks_local_port(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[tuple[tuple[str, int], float]] = []
 
     class FakeConnection:
@@ -281,27 +464,26 @@ def test_ssh_tunnel_is_listening_returns_true(monkeypatch: pytest.MonkeyPatch) -
         return FakeConnection()
 
     monkeypatch.setattr(ssh_tunnel.socket, 'create_connection', fake_create_connection)
+    monkeypatch.setattr(ssh_tunnel, '_find_free_local_port', lambda local_host: 4406)
     tunnel = SshTunnel(
         ssh_target='bastion',
         remote_host='db.internal',
         remote_port=3306,
-        local_port=4406,
+        tunnel_method='port',
     )
 
     assert tunnel._is_listening() is True
-    assert calls == [(('127.0.0.1', 4406), 0.05)]
+    assert calls == [(('localhost', 4406), 0.05)]
 
 
-def test_ssh_tunnel_is_listening_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fail_create_connection(*_args: Any, **_kwargs: Any) -> None:
-        raise socket.timeout
-
-    monkeypatch.setattr(ssh_tunnel.socket, 'create_connection', fail_create_connection)
+def test_ssh_tunnel_is_listening_returns_false_without_local_endpoint() -> None:
     tunnel = SshTunnel(
         ssh_target='bastion',
         remote_host='db.internal',
         remote_port=3306,
-        local_port=4406,
+        tunnel_method='port',
     )
+    tunnel.local_host = None
+    tunnel.local_port = None
 
     assert tunnel._is_listening() is False


### PR DESCRIPTION
## Description
 * improved security posture with UDS
 * paths are unlimited compared to ports
 * the tunnel method is configurable, but defaults to "auto" which means: "port" on Windows, "socket" (UDS) otherwise

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
