### PR TITLE
Add `--ssh-options` CLI argument

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 Upcoming (TBD)
 ==============
 
+Features
+---------
+* Add `--ssh-options` CLI argument to pass extra options with `--ssh-jump`.
+
+
 Internal
 ---------
 * Configurable tunnel method for `--ssh-jump`, making UDS usually default.

--- a/mycli/cli_runner.py
+++ b/mycli/cli_runner.py
@@ -343,6 +343,7 @@ def run_from_cli_args(cli_args: 'CliArgs', client_factory: ClientFactory) -> Non
             reset_keyring=reset_keyring,
             keepalive_ticks=keepalive_ticks,
             ssh_jump=cli_args.ssh_jump,
+            ssh_cli_options=cli_args.ssh_options,
         )
 
         if combined_init_cmd:

--- a/mycli/client_connection.py
+++ b/mycli/client_connection.py
@@ -61,6 +61,7 @@ class ClientConnectionMixin:
         reset_keyring: bool | None = None,
         keepalive_ticks: int | None = None,
         ssh_jump: str | None = None,
+        ssh_cli_options: str | None = None,
     ) -> None:
         mylogin_cnf: dict[str, Any] = self.read_mylogin_cnf(self.mylogin_cnf)
         # Fall back to .mylogin.cnf values only if user did not specify a value.
@@ -83,7 +84,7 @@ class ClientConnectionMixin:
             remote_port = int_port or DEFAULT_PORT
             remote_socket = socket or None
             ssh_executable = self.config.get('ssh', {}).get('ssh_executable', 'ssh') or 'ssh'
-            ssh_options = self.config.get('ssh', {}).get('ssh_options')
+            ssh_config_options = self.config.get('ssh', {}).get('ssh_options')
             tunnel_method: Literal['auto', 'socket', 'port'] = self.config.get('ssh', {}).get('tunnel_method', 'auto').lower() or 'auto'
             try:
                 self.ssh_tunnel = SshTunnel.from_target(
@@ -92,7 +93,8 @@ class ClientConnectionMixin:
                     remote_port=int(remote_port),
                     remote_socket=remote_socket,
                     ssh_executable=ssh_executable,
-                    ssh_options=ssh_options,
+                    ssh_config_options=ssh_config_options,
+                    ssh_cli_options=ssh_cli_options,
                     tunnel_method=tunnel_method,
                 )
                 self.ssh_tunnel.start()

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -275,6 +275,10 @@ class CliArgs:
         type=str,
         help='Open an SSH tunnel via [user@]host[:port] and connect to MySQL through it.',
     )
+    ssh_options: str | None = clickdc.option(
+        type=str,
+        help='Extra CLI arguments for SSH with --ssh-jump, placed after options from myclirc.',
+    )
     checkup: bool = clickdc.option(
         is_flag=True,
         help='Run a checkup on your configuration.',

--- a/mycli/ssh_tunnel.py
+++ b/mycli/ssh_tunnel.py
@@ -66,13 +66,15 @@ class SshTunnel:
         remote_port: int,
         remote_socket: str | None = None,
         ssh_executable: str = DEFAULT_SSH_EXECUTABLE,
-        ssh_options: str | None = None,
+        ssh_config_options: str | None = None,
+        ssh_cli_options: str | None = None,
         ssh_port: int | None = None,
         ready_timeout: float = 30.0,
         tunnel_method: Literal['auto', 'socket', 'port'] = DEFAULT_TUNNEL_METHOD,
     ) -> None:
         self.ssh_executable = ssh_executable
-        self.ssh_options = ssh_options
+        self.ssh_config_options = ssh_config_options
+        self.ssh_cli_options = ssh_cli_options
         self.ssh_target = ssh_target
         self.ssh_port = ssh_port
         self.remote_host = remote_host
@@ -102,7 +104,8 @@ class SshTunnel:
         remote_port: int,
         remote_socket: str | None = None,
         ssh_executable: str = DEFAULT_SSH_EXECUTABLE,
-        ssh_options: str | None = None,
+        ssh_config_options: str | None = None,
+        ssh_cli_options: str | None = None,
         tunnel_method: Literal['auto', 'socket', 'port'] = DEFAULT_TUNNEL_METHOD,
     ) -> SshTunnel:
         target = SshTunnelTarget.parse(ssh_jump_spec)
@@ -113,7 +116,8 @@ class SshTunnel:
             remote_port=remote_port,
             remote_socket=remote_socket,
             ssh_executable=ssh_executable,
-            ssh_options=ssh_options,
+            ssh_config_options=ssh_config_options,
+            ssh_cli_options=ssh_cli_options,
             tunnel_method=tunnel_method,
         )
 
@@ -128,7 +132,8 @@ class SshTunnel:
             return f'{self.local_host}:{self.local_port}:{self.remote_host}:{self.remote_port}'
 
     def command(self) -> list[str]:
-        opts = shlex.split(self.ssh_options or '')
+        opts = shlex.split(self.ssh_config_options or '')
+        opts.extend(shlex.split(self.ssh_cli_options or ''))
         command = [
             self.ssh_executable,
             *opts,

--- a/test/pytests/test_cli_runner.py
+++ b/test/pytests/test_cli_runner.py
@@ -423,6 +423,16 @@ def test_run_from_cli_args_uses_explicit_keyring_flag(monkeypatch: pytest.Monkey
     assert client.connect_calls[-1]['reset_keyring'] is False
 
 
+def test_run_from_cli_args_passes_ssh_options_to_connect(monkeypatch: pytest.MonkeyPatch) -> None:
+    cli_args = make_cli_args()
+    cli_args.ssh_options = '-o Compression=yes'
+    client = DummyMyCli()
+
+    run_with_client(monkeypatch, cli_args, client)
+
+    assert client.connect_calls[-1]['ssh_cli_options'] == '-o Compression=yes'
+
+
 @pytest.mark.parametrize(
     ('ssh_connection', 'expected_use_keyring'),
     (

--- a/test/pytests/test_client_connection.py
+++ b/test/pytests/test_client_connection.py
@@ -338,7 +338,8 @@ def test_connect_uses_ssh_jump_with_remote_socket(monkeypatch: pytest.MonkeyPatc
             remote_port: int,
             remote_socket: str | None = None,
             ssh_executable: str = 'ssh',
-            ssh_options: str | None = None,
+            ssh_config_options: str | None = None,
+            ssh_cli_options: str | None = None,
             tunnel_method: Literal['auto', 'socket', 'port'] = 'auto',
         ) -> 'FakeTunnel':
             tunnel_calls.append({
@@ -347,7 +348,8 @@ def test_connect_uses_ssh_jump_with_remote_socket(monkeypatch: pytest.MonkeyPatc
                 'remote_port': remote_port,
                 'remote_socket': remote_socket,
                 'ssh_executable': ssh_executable,
-                'ssh_options': None,
+                'ssh_config_options': None,
+                'ssh_cli_options': None,
             })
             return cls()
 
@@ -375,7 +377,8 @@ def test_connect_uses_ssh_jump_with_remote_socket(monkeypatch: pytest.MonkeyPatc
             'remote_port': 3306,
             'remote_socket': '/var/run/mysqld/mysqld.sock',
             'ssh_executable': '/opt/bin/ssh',
-            'ssh_options': None,
+            'ssh_config_options': None,
+            'ssh_cli_options': None,
         }
     ]
     assert FakeSQLExecute.calls[-1]['host'] is None
@@ -398,7 +401,8 @@ def test_connect_uses_ssh_jump_with_local_port(monkeypatch: pytest.MonkeyPatch) 
             remote_port: int,
             remote_socket: str | None = None,
             ssh_executable: str = 'ssh',
-            ssh_options: str | None = None,
+            ssh_config_options: str | None = None,
+            ssh_cli_options: str | None = None,
             tunnel_method: Literal['auto', 'socket', 'port'] = 'auto',
         ) -> 'FakeTunnel':
             return cls()
@@ -419,6 +423,52 @@ def test_connect_uses_ssh_jump_with_local_port(monkeypatch: pytest.MonkeyPatch) 
     assert FakeSQLExecute.calls[-1]['socket'] is None
 
 
+def test_connect_passes_config_and_cli_ssh_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    tunnel_calls: list[dict[str, Any]] = []
+
+    class FakeTunnel:
+        local_socket = '/tmp/mycli-ssh.sock'
+
+        @classmethod
+        def from_target(
+            cls,
+            ssh_jump: str,
+            *,
+            remote_host: str,
+            remote_port: int,
+            remote_socket: str | None = None,
+            ssh_executable: str = 'ssh',
+            ssh_config_options: str | None = None,
+            ssh_cli_options: str | None = None,
+            tunnel_method: Literal['auto', 'socket', 'port'] = 'auto',
+        ) -> 'FakeTunnel':
+            tunnel_calls.append({
+                'ssh_jump': ssh_jump,
+                'ssh_config_options': ssh_config_options,
+                'ssh_cli_options': ssh_cli_options,
+            })
+            return cls()
+
+        def start(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(client_connection, 'SshTunnel', FakeTunnel)
+    client = DummyClient(config={'main': {}, 'ssh': {'ssh_options': '-o LogLevel=ERROR'}, 'connection': {}})
+
+    client.connect(host='db.internal', ssh_jump='bastion', ssh_cli_options='-o Compression=yes')
+
+    assert tunnel_calls == [
+        {
+            'ssh_jump': 'bastion',
+            'ssh_config_options': '-o LogLevel=ERROR',
+            'ssh_cli_options': '-o Compression=yes',
+        }
+    ]
+
+
 def test_connect_reports_ssh_jump_start_error_and_closes_tunnel(monkeypatch: pytest.MonkeyPatch) -> None:
     close_calls: list[bool] = []
     secho_calls: list[tuple[str, dict[str, Any]]] = []
@@ -436,7 +486,8 @@ def test_connect_reports_ssh_jump_start_error_and_closes_tunnel(monkeypatch: pyt
             remote_port: int,
             remote_socket: str | None = None,
             ssh_executable: str = 'ssh',
-            ssh_options: str | None = None,
+            ssh_config_options: str | None = None,
+            ssh_cli_options: str | None = None,
             tunnel_method: Literal['auto', 'socket', 'port'] = 'auto',
         ) -> 'FakeTunnel':
             return cls()
@@ -474,7 +525,8 @@ def test_connect_swallows_ssh_jump_cleanup_error(monkeypatch: pytest.MonkeyPatch
             remote_port: int,
             remote_socket: str | None = None,
             ssh_executable: str = 'ssh',
-            ssh_options: str | None = None,
+            ssh_config_options: str | None = None,
+            ssh_cli_options: str | None = None,
             tunnel_method: Literal['auto', 'socket', 'port'] = 'auto',
         ) -> 'FakeTunnel':
             return cls()

--- a/test/pytests/test_ssh_tunnel.py
+++ b/test/pytests/test_ssh_tunnel.py
@@ -112,6 +112,29 @@ def test_ssh_tunnel_command_uses_configured_ssh_executable(monkeypatch: pytest.M
     assert tunnel.command()[0] == '/opt/bin/ssh'
 
 
+def test_ssh_tunnel_command_appends_cli_options_after_config_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: '/tmp/mycli-ssh.sock')
+    tunnel = SshTunnel(
+        ssh_target='alice@bastion',
+        remote_host='db.internal',
+        remote_port=3307,
+        ssh_config_options='-o LogLevel=ERROR',
+        ssh_cli_options='-o Compression=yes',
+    )
+
+    assert tunnel.command() == [
+        'ssh',
+        '-o',
+        'LogLevel=ERROR',
+        '-o',
+        'Compression=yes',
+        '-N',
+        '-L',
+        '/tmp/mycli-ssh.sock:db.internal:3307',
+        'alice@bastion',
+    ]
+
+
 def test_ssh_tunnel_command_forwards_remote_socket(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: '/tmp/mycli-ssh.sock')
     tunnel = SshTunnel(


### PR DESCRIPTION
## Description
Add `--ssh-options` CLI argument, to pass arbitrary extra options to the SSH executable with `--ssh-jump` on the fly.

This covers the case of options that would be passed on a host-by-host basis, and would be inconvenient to add to ssh.options in `~/.myclirc`.

`--ssh-options` values from the CLI are placed after ssh.options from the config file, which, according to the precedence rules of openSSH, sometimes means the CLI arguments will override, and other times means they will not.  They will not override in the case of conflicting `-o` settings, for example.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
