### PR TITLE
Make `/dsn show` correct with `--ssh-jump`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ Features
 * Add `--ssh-options` CLI argument to pass extra options with `--ssh-jump`.
 
 
+Bug Fixes
+---------
+* Allow `/dsn` command to show correct values with `--ssh-jump`.
+
+
 Internal
 ---------
 * Configurable tunnel method for `--ssh-jump`, making UDS usually default.

--- a/mycli/client_connection.py
+++ b/mycli/client_connection.py
@@ -22,6 +22,7 @@ from mycli.constants import (
     ER_MUST_CHANGE_PASSWORD_LOGIN,
 )
 from mycli.packages.filepaths import guess_socket_location
+from mycli.packages.special.utils import format_connection_dsn
 from mycli.sqlexecute import SQLExecute
 from mycli.ssh_tunnel import SshTunnel, SshTunnelError
 
@@ -188,6 +189,17 @@ class ClientConnectionMixin:
         # should not fail, but will help the typechecker
         assert not isinstance(passwd, int)
 
+        display_dsn = None
+        if self.ssh_tunnel:
+            display_dsn = format_connection_dsn(
+                user=user,
+                host=remote_host,
+                port=remote_port,
+                socket=remote_socket,
+                database=database,
+                character_set=character_set,
+            )
+
         connection_info: dict[str, Any] = {
             'database': database,
             'user': user,
@@ -197,6 +209,7 @@ class ClientConnectionMixin:
             'ssl': ssl_config,
             'init_command': init_command,
             'unbuffered': unbuffered,
+            'display_dsn': display_dsn,
         }
         if self.ssh_tunnel and self.ssh_tunnel.local_socket:
             connection_info['host'] = None

--- a/mycli/packages/special/utils.py
+++ b/mycli/packages/special/utils.py
@@ -147,21 +147,42 @@ def get_local_timezone() -> str:
     return datetime.datetime.now().astimezone().tzname() or ''
 
 
-def compute_current_dsn(cur: Cursor) -> str:
-    conn = cur.connection
-    user = urlquote(conn.user or '')
-    host = conn.host or 'localhost'
-    port = f':{conn.port}'
-    db = urlquote(conn.db.decode() if isinstance(conn.db, bytes) else (conn.db or ''))
+def format_connection_dsn(
+    *,
+    user: str | None,
+    host: str | None,
+    port: int | None,
+    database: str | None,
+    socket: str | None,
+    character_set: str | None,
+) -> str:
+    user = urlquote(user or '')
+    host = host or 'localhost'
+    port_part = f':{port}' if port is not None else ''
+    db = urlquote(database or '')
     if db:
         db = f'/{db}'
     query_part = {}
-    if getattr(conn, 'unix_socket', None):
-        query_part['socket'] = conn.unix_socket
-        port = ''
-    if getattr(conn, 'charset', None) and conn.charset != 'utf8mb4':
-        query_part['character_set'] = conn.charset
-    dsn = f'mysql://{user}@{host}{port}{db}'
+    if socket:
+        query_part['socket'] = socket
+        port_part = ''
+    if character_set and character_set != 'utf8mb4':
+        query_part['character_set'] = character_set
+    dsn = f'mysql://{user}@{host}{port_part}{db}'
     if query_part:
         dsn += '?' + urlencode(query_part)
     return dsn
+
+
+def compute_current_dsn(cur: Cursor) -> str:
+    conn = cur.connection
+    if display_dsn := getattr(conn, '_mycli_display_dsn', None):
+        return display_dsn
+    return format_connection_dsn(
+        user=conn.user.decode() if isinstance(conn.user, bytes) else conn.user,
+        host=conn.host,
+        port=conn.port,
+        database=conn.db.decode() if isinstance(conn.db, bytes) else conn.db,
+        socket=getattr(conn, 'unix_socket', None),
+        character_set=getattr(conn, 'charset', None),
+    )

--- a/mycli/sqlexecute.py
+++ b/mycli/sqlexecute.py
@@ -167,6 +167,7 @@ class SQLExecute:
         ssl: dict[str, Any] | None,
         init_command: str | None = None,
         unbuffered: bool | None = None,
+        display_dsn: str | None = None,
     ) -> None:
         self.dbname = database
         self.user = user
@@ -177,6 +178,7 @@ class SQLExecute:
         self.character_set = character_set
         self.local_infile = local_infile
         self.ssl = ssl
+        self.display_dsn = display_dsn
         self.server_info: ServerInfo | None = None
         self.connection_id: int | None = None
         self.init_command = init_command
@@ -295,6 +297,8 @@ class SQLExecute:
             except pymysql.err.Error:
                 pass
         self.conn = conn
+        if self.display_dsn is not None:
+            self.conn._mycli_display_dsn = self.display_dsn  # type: ignore[attr-defined]
         # Update them after the connection is made to ensure that it was a
         # successful connection.
         self.dbname = db

--- a/test/pytests/test_client_connection.py
+++ b/test/pytests/test_client_connection.py
@@ -384,6 +384,7 @@ def test_connect_uses_ssh_jump_with_remote_socket(monkeypatch: pytest.MonkeyPatc
     assert FakeSQLExecute.calls[-1]['host'] is None
     assert FakeSQLExecute.calls[-1]['port'] is None
     assert FakeSQLExecute.calls[-1]['socket'] == '/tmp/mycli-ssh.sock'
+    assert FakeSQLExecute.calls[-1]['display_dsn'] == 'mysql://alice@localhost?socket=%2Fvar%2Frun%2Fmysqld%2Fmysqld.sock'
 
 
 def test_connect_uses_ssh_jump_with_local_port(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -416,11 +417,12 @@ def test_connect_uses_ssh_jump_with_local_port(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr(client_connection, 'SshTunnel', FakeTunnel)
     client = DummyClient()
 
-    client.connect(host='db.internal', port=3307, ssh_jump='bastion')
+    client.connect(user='alice', host='db.internal', port=3307, ssh_jump='bastion')
 
     assert FakeSQLExecute.calls[-1]['host'] == '127.0.0.1'
     assert FakeSQLExecute.calls[-1]['port'] == 4406
     assert FakeSQLExecute.calls[-1]['socket'] is None
+    assert FakeSQLExecute.calls[-1]['display_dsn'] == 'mysql://alice@db.internal:3307'
 
 
 def test_connect_passes_config_and_cli_ssh_options(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/test/pytests/test_special_utils.py
+++ b/test/pytests/test_special_utils.py
@@ -296,6 +296,21 @@ def test_compute_current_dsn_for_tcp_connection() -> None:
     assert compute_current_dsn(cursor) == 'mysql://user%40example.com@db.example.com:3307/my%20db'
 
 
+def test_compute_current_dsn_prefers_mycli_display_dsn() -> None:
+    connection = SimpleNamespace(
+        _mycli_display_dsn='mysql://alice@db.example.com:3307/prod',
+        user='alice',
+        host='localhost',
+        port=4406,
+        db='prod',
+        unix_socket=None,
+        charset='utf8mb4',
+    )
+    cursor = SimpleNamespace(connection=connection)
+
+    assert compute_current_dsn(cursor) == 'mysql://alice@db.example.com:3307/prod'
+
+
 def test_compute_current_dsn_for_socket_connection() -> None:
     connection = SimpleNamespace(
         user='alice',

--- a/test/pytests/test_sqlexecute.py
+++ b/test/pytests/test_sqlexecute.py
@@ -641,6 +641,7 @@ def make_executor_for_connect_tests() -> SQLExecute:
     executor.character_set = 'utf8mb4'
     executor.local_infile = True
     executor.ssl = {'ca': '/stored/ca.pem'}
+    executor.display_dsn = None
     executor.server_info = None
     executor.connection_id = None
     executor.init_command = 'select 1'
@@ -663,6 +664,7 @@ def test_connect_updates_connection_state_and_merges_overrides(monkeypatch) -> N
         close_error=pymysql.err.Error(),
     )
     executor.conn = previous_conn
+    executor.display_dsn = 'mysql://display@example.com/db'
 
     new_conn = DummyConnection(server_version='8.0.36-0ubuntu0.22.04.1')
     connect_kwargs = {}
@@ -718,6 +720,7 @@ def test_connect_updates_connection_state_and_merges_overrides(monkeypatch) -> N
     assert connect_kwargs['program_name'] == 'mycli'
     assert previous_conn.close_calls == 1
     assert executor.conn is new_conn
+    assert new_conn._mycli_display_dsn == 'mysql://display@example.com/db'
     assert executor.dbname == 'override_db'
     assert executor.user == 'override_user'
     assert executor.password == 'override_password'


### PR DESCRIPTION
## Description
Previously, `/dsn show` would show the transient local connection arranged by `--ssh-jump`, when it should show the more permanent remote specification from the CLI or config file.

The implementation is slightly hacky: we attach a displayable property to the connection.

Fixes #1994.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
