### PR TITLE
Better document `/dsn show`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ Internal
 Documentation
 ---------
 * Add `--ssh-jump` to TIPS.
+* Better document `/dsn show`.
 
 
 2.1.1 (2026/07/08)

--- a/mycli/packages/special/dsn_aliases.py
+++ b/mycli/packages/special/dsn_aliases.py
@@ -11,6 +11,10 @@ directly or by using this command.
 
 Examples:
 
+    # Show a DSN for the current connection
+    mysql> /dsn show
+    mysql://mycli@localhost/mysql
+
     # List all DSN aliases
     mysql> /dsn list
     ┌───────┬───────────────────────────────┐


### PR DESCRIPTION
## Description
Previously, `/dsn show` was listed only in the output of `/help`.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
