### PR TITLE
Make flaky `/watch` test more lenient for CI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,15 +11,16 @@ Bug Fixes
 * Allow `/dsn` command to show correct values with `--ssh-jump`.
 
 
-Internal
----------
-* Configurable tunnel method for `--ssh-jump`, making UDS usually default.
-
-
 Documentation
 ---------
 * Add `--ssh-jump` to TIPS.
 * Better document `/dsn show`.
+
+
+Internal
+---------
+* Configurable tunnel method for `--ssh-jump`, making UDS usually default.
+* Make flaky `/watch` test more lenient for CI.
 
 
 2.1.1 (2026/07/08)

--- a/test/pytests/test_special_iocommands.py
+++ b/test/pytests/test_special_iocommands.py
@@ -396,9 +396,9 @@ def test_watch_query_full():
     expected_value = "1"
     query = f"SELECT {expected_value}"
     expected_preamble = f"> {query}"
-    # Python 3.14 is skipping ahead to 6, 7, or even 8 on Mac and Windows
+    # Python 3.14 is skipping ahead to 6, 7, 8, or 9
     # Python 3.11 is as slow as 3
-    expected_results = [3, 4, 5, 6, 7, 8]
+    expected_results = [3, 4, 5, 6, 7, 8, 9]
     ctrl_c_process = send_ctrl_c(wait_interval)
     with db_connection().cursor() as cur:
         results = list(mycli.packages.special.iocommands.watch_query(arg=f"{watch_seconds} {query}", cur=cur))


### PR DESCRIPTION
## Description
Make flaky `/watch` test more lenient for CI, incidentally reordering changelog sections for Upcoming.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
