### PR TITLE
Improve `ssh_options` configuration commentary

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ Documentation
 ---------
 * Add `--ssh-jump` to TIPS.
 * Better document `/dsn show`.
+* Improve `ssh_options` commentary.
 
 
 Internal

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -310,6 +310,7 @@ emacs_ttimeoutlen = 0.5
 ssh_executable = ssh
 
 # Options to pass to the ssh executable when making a tunnel.
+# The defaults may need to be changed if not using OpenSSH.
 ssh_options = -a -o ServerAliveInterval=60 -o ExitOnForwardFailure=yes -o IPQoS=af13 -o LogLevel=FATAL
 
 # Method for establishing the local side of the SSH tunnel: auto, port, socket.

--- a/test/myclirc
+++ b/test/myclirc
@@ -310,6 +310,7 @@ emacs_ttimeoutlen = 0.5
 ssh_executable = ssh
 
 # Options to pass to the ssh executable when making a tunnel.
+# The defaults may need to be changed if not using OpenSSH.
 ssh_options = -a -o ServerAliveInterval=60 -o ExitOnForwardFailure=yes -o IPQoS=af13 -o LogLevel=FATAL
 
 # Method for establishing the local side of the SSH tunnel: auto, port, socket.


### PR DESCRIPTION
## Description
The default options contain values particular to OpenSSH.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
