### PR TITLE
Remove deprecated `ssl` as a DSN query parameter, in favor of `ssl_mode`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 Upcoming (TBD)
 ==============
 
+Breaking Changes
+---------
+* `ssl` is no longer supported as a DSN parameter.  Use `ssl_mode` instead.
+
+
 Features
 ---------
 * Add `--ssh-options` CLI argument to pass extra options with `--ssh-jump`.

--- a/mycli/cli_runner.py
+++ b/mycli/cli_runner.py
@@ -9,7 +9,7 @@ from urllib.parse import parse_qs, unquote, urlparse
 import click
 
 from mycli.config import str_to_bool
-from mycli.constants import EMPTY_PASSWORD_FLAG_SENTINEL, ISSUES_URL
+from mycli.constants import EMPTY_PASSWORD_FLAG_SENTINEL
 from mycli.main_modes.batch import main_batch_from_stdin, main_batch_with_progress_bar, main_batch_without_progress_bar
 from mycli.main_modes.checkup import main_checkup
 from mycli.main_modes.execute import main_execute_from_cli
@@ -26,7 +26,6 @@ KNOWN_DSN_QUERY_PARAMS = {
     'keepalive_ticks',
     'socket',
     'ssh_jump',
-    'ssl',
     'ssl_ca',
     'ssl_capath',
     'ssl_cert',
@@ -239,16 +238,6 @@ def run_from_cli_args(cli_args: 'CliArgs', client_factory: ClientFactory) -> Non
                 fg='yellow',
             )
 
-        if params := dsn_params.get('ssl'):
-            click.secho(
-                'Warning: The "ssl" DSN URI parameter is deprecated and will be removed in a future release. '
-                'Please use the "ssl_mode" parameter instead. '
-                f'See issue {ISSUES_URL}/1507',
-                err=True,
-                fg='yellow',
-            )
-            if params[0].lower() == 'true':
-                cli_args.ssl_mode = 'on'
         if params := dsn_params.get('ssl_mode'):
             cli_args.ssl_mode = cli_args.ssl_mode or params[0]
         if params := dsn_params.get('ssl_ca'):

--- a/test/pytests/test_cli_runner.py
+++ b/test/pytests/test_cli_runner.py
@@ -475,7 +475,7 @@ def test_run_from_cli_args_prefers_cli_ssh_jump_over_dsn_parameter(
 def test_run_from_cli_args_maps_dsn_ssl_parameters(monkeypatch: pytest.MonkeyPatch) -> None:
     cli_args = make_cli_args()
     cli_args.dsn = (
-        'mysql://user:pass@host:3306/db?ssl=true&ssl_ca=~/ca.pem&ssl_capath=/capath'
+        'mysql://user:pass@host:3306/db?ssl_mode=on&ssl_ca=~/ca.pem&ssl_capath=/capath'
         '&ssl_cert=~/cert.pem&ssl_key=~/key.pem&ssl_cipher=AES256&tls_version=TLSv1.3'
         '&ssl_verify_server_cert=true'
     )
@@ -496,7 +496,6 @@ def test_run_from_cli_args_maps_dsn_ssl_parameters(monkeypatch: pytest.MonkeyPat
         'tls_version': 'TLSv1.3',
         'check_hostname': True,
     }
-    assert any('"ssl" DSN URI parameter is deprecated' in call for call in secho_calls)
 
 
 def test_run_from_cli_args_merges_global_list_and_alias_scalar_init_commands(


### PR DESCRIPTION
## Description
This was overlooked in https://github.com/dbcli/mycli/pull/1947, which removed the corresponding CLI options.  It should have been removed there, and included in the 2.0.0 release.

But the DSN usage has been emitting a deprecation warning for six months, and is okay to just remove now.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
