### PR TITLE
Highlight beta nature of Vault support in configuration

### DIFF
--- a/mycli/cli_runner.py
+++ b/mycli/cli_runner.py
@@ -15,7 +15,12 @@ from mycli.main_modes.checkup import main_checkup
 from mycli.main_modes.execute import main_execute_from_cli
 from mycli.main_modes.list_dsn import main_list_dsn
 from mycli.packages.cli_utils import is_valid_connection_scheme
-from mycli.vault import DEFAULT_VAULT_EXECUTABLE, DEFAULT_VAULT_FIELD, VaultError, get_password_from_vault
+from mycli.vault import (
+    DEFAULT_VAULT_EXECUTABLE,
+    DEFAULT_VAULT_PASSWORD_FIELD,
+    VaultError,
+    get_password_from_vault,
+)
 
 if TYPE_CHECKING:
     from mycli.main import CliArgs
@@ -344,10 +349,10 @@ def run_from_cli_args(cli_args: 'CliArgs', client_factory: ClientFactory) -> Non
         reset_keyring = False
 
     if cli_args.password is None and cli_args.password_vault_secret:
-        vault_config = mycli.config.get('vault', {})
+        vault_config = mycli.config.get('vault_beta', {})
         vault_address = cli_args.password_vault_address or os.environ.get('VAULT_ADDR') or vault_config.get('address') or None
         vault_mount = cli_args.password_vault_mount or vault_config.get('default_mount') or None
-        vault_field = cli_args.password_vault_field or vault_config.get('default_field') or DEFAULT_VAULT_FIELD
+        vault_field = cli_args.password_vault_field or vault_config.get('default_password_field') or DEFAULT_VAULT_PASSWORD_FIELD
         vault_executable = vault_config.get('vault_executable') or DEFAULT_VAULT_EXECUTABLE
         try:
             vault_password: str | None = get_password_from_vault(

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -317,7 +317,7 @@ ssh_options = -a -o ServerAliveInterval=60 -o ExitOnForwardFailure=yes -o IPQoS=
 # auto means: port if on Windows, socket otherwise.
 tunnel_method = auto
 
-[vault]
+[vault_beta]
 # Path to the vault executable used for Vault integration.
 vault_executable = vault
 
@@ -328,7 +328,7 @@ address =
 default_mount =
 
 # Field/property containing the password, if --password-vault-field is not provided.
-default_field = password
+default_password_field = password
 
 # Custom colors for the completion menu, toolbar, etc, with actual support
 # depending on the terminal, and the property being set.

--- a/mycli/vault.py
+++ b/mycli/vault.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import subprocess
 
 DEFAULT_VAULT_EXECUTABLE = 'vault'
-DEFAULT_VAULT_FIELD = 'password'
+DEFAULT_VAULT_PASSWORD_FIELD = 'password'
 
 
 class VaultError(RuntimeError):
@@ -14,7 +14,7 @@ def get_password_from_vault(
     *,
     secret: str,
     executable: str = DEFAULT_VAULT_EXECUTABLE,
-    field: str = DEFAULT_VAULT_FIELD,
+    field: str = DEFAULT_VAULT_PASSWORD_FIELD,
     mount: str | None = None,
     address: str | None = None,
 ) -> str:

--- a/test/myclirc
+++ b/test/myclirc
@@ -317,7 +317,7 @@ ssh_options = -a -o ServerAliveInterval=60 -o ExitOnForwardFailure=yes -o IPQoS=
 # auto means: port if on Windows, socket otherwise.
 tunnel_method = auto
 
-[vault]
+[vault_beta]
 # Path to the vault executable used for Vault integration.
 vault_executable = vault
 
@@ -328,7 +328,7 @@ address =
 default_mount =
 
 # Field/property containing the password, if --password-vault-field is not provided.
-default_field = password
+default_password_field = password
 
 # Custom colors for the completion menu, toolbar, etc, with actual support
 # depending on the terminal, and the property being set.

--- a/test/pytests/test_cli_runner.py
+++ b/test/pytests/test_cli_runner.py
@@ -549,11 +549,11 @@ def test_run_from_cli_args_reads_password_from_vault_when_password_is_missing(
     client = DummyMyCli(
         config={
             **default_config(),
-            'vault': {
+            'vault_beta': {
                 'vault_executable': '/opt/bin/vault',
                 'address': 'https://vault.config',
                 'default_mount': 'kv',
-                'default_field': 'mysql_password',
+                'default_password_field': 'mysql_password',
             },
         }
     )
@@ -609,11 +609,11 @@ def test_run_from_cli_args_prefers_vault_cli_values_and_env_address(
     client = DummyMyCli(
         config={
             **default_config(),
-            'vault': {
+            'vault_beta': {
                 'vault_executable': '/opt/bin/vault',
                 'address': 'https://vault.config',
                 'default_mount': 'config-mount',
-                'default_field': 'config-field',
+                'default_password_field': 'config-field',
             },
         }
     )


### PR DESCRIPTION
## Description
Highlight beta nature of Vault support in configuration, and rename `default_field` config property to `default_password_field`.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
