### PR TITLE
`editor_command` config entry

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming (TBD)
 Features
 ---------
 * Set minimum times for transient toolbar messages.
+* `editor_command` entry in `~/.myclirc` which overrides environment.
 
 
 2.2.0 (2026/07/11)

--- a/mycli/TIPS
+++ b/mycli/TIPS
@@ -282,6 +282,8 @@ use "min_completion_trigger" in ~/.myclirc to defer completions!
 
 colorize search previews with "highlight_preview" in ~/.myclirc!
 
+set editor_command = "code --wait" in ~/.myclirc to edit queries using VS Code!
+
 ###
 ### redirection
 ###

--- a/mycli/main_modes/repl.py
+++ b/mycli/main_modes/repl.py
@@ -9,6 +9,7 @@ from importlib import resources
 import os
 import random
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -42,6 +43,7 @@ import mycli as mycli_package
 from mycli.clibuffer import cli_is_multiline
 from mycli.clistyle import style_factory_ptoolkit
 from mycli.clitoolbar import create_toolbar_tokens_func
+from mycli.compat import WIN
 from mycli.constants import (
     DEFAULT_HOST,
     DEFAULT_WIDTH,
@@ -854,12 +856,25 @@ def _tips_picker() -> str:
     return random.choice(tips) if tips else r'\? or "help" for help!'
 
 
+def _configure_editor(mycli: 'MyCli') -> None:
+    if configured_editor := mycli.config['editor'].get('editor_command'):
+        os.environ['VISUAL'] = configured_editor
+    elif not os.environ.get('VISUAL') and not os.environ.get('EDITOR'):
+        if shutil.which('code'):
+            os.environ['VISUAL'] = 'code --wait'
+        elif WIN:
+            os.environ['VISUAL'] = 'edit'
+        else:
+            os.environ['VISUAL'] = 'vi'
+
+
 def main_repl(mycli: 'MyCli') -> None:
     sqlexecute = mycli.sqlexecute
     assert sqlexecute is not None
     state = ReplState()
 
     mycli.configure_pager()
+    _configure_editor(mycli)
     if mycli.smart_completion and not mycli.sandbox_mode:
         mycli.refresh_completions()
 

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -216,6 +216,16 @@ pager = 'less'
 # Recommanded: auto
 use_keyring = False
 
+[editor]
+
+# Command line to invoke for /edit, instead of respecting the $VISUAL/$EDITOR
+# environment variables.  Suggestions:
+# * VS Code: code --wait
+# * Vim: vim
+# * Emacs: emacsclient
+# For emacsclient, first start the server with "M-x server-start".
+editor_command =
+
 [search]
 
 # Whether to apply syntax highlighting to the preview window in fuzzy history

--- a/test/myclirc
+++ b/test/myclirc
@@ -216,6 +216,16 @@ pager = python test/features/wrappager.py ---boundary---
 # Recommended: auto
 use_keyring = False
 
+[editor]
+
+# Command line to invoke for /edit, instead of respecting the $VISUAL/$EDITOR
+# environment variables.  Suggestions:
+# * VS Code: code --wait
+# * Vim: vim
+# * Emacs: emacsclient
+# For emacsclient, first start the server with "M-x server-start".
+editor_command =
+
 [search]
 
 # Whether to apply syntax highlighting to the preview window in fuzzy history

--- a/test/pytests/test_main_modes_repl.py
+++ b/test/pytests/test_main_modes_repl.py
@@ -158,7 +158,7 @@ def make_repl_cli(sqlexecute: Any | None = None) -> Any:
     cli.post_redirect_command = None
     cli.logfile = None
     cli.smart_completion = False
-    cli.config = {'main': {'history_file': '~/.mycli-history-testing'}}
+    cli.config = {'main': {'history_file': '~/.mycli-history-testing'}, 'editor': {'editor_command': ''}}
     cli.key_bindings = 'emacs'
     cli.wider_completion_menu = False
     cli.login_path = None
@@ -331,6 +331,51 @@ def test_repl_picker_helpers_cover_present_and_missing_resources(monkeypatch: py
     assert repl_mode._contributors_picker() == 'our contributors'
     assert repl_mode._sponsors_picker() == 'our sponsors'
     assert repl_mode._tips_picker() == r'\? or "help" for help!'
+
+
+def test_configure_editor_uses_configured_editor(monkeypatch: pytest.MonkeyPatch) -> None:
+    cli = make_repl_cli()
+    cli.config['editor']['editor_command'] = 'nano'
+    monkeypatch.delenv('VISUAL', raising=False)
+
+    repl_mode._configure_editor(cli)
+
+    assert os.environ['VISUAL'] == 'nano'
+
+
+def test_configure_editor_uses_code_when_no_editor_environment_is_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    cli = make_repl_cli()
+    monkeypatch.delenv('VISUAL', raising=False)
+    monkeypatch.delenv('EDITOR', raising=False)
+    monkeypatch.setattr(repl_mode.shutil, 'which', lambda name: '/usr/bin/code' if name == 'code' else None)
+
+    repl_mode._configure_editor(cli)
+
+    assert os.environ['VISUAL'] == 'code --wait'
+
+
+def test_configure_editor_falls_back_to_vi_when_no_editor_is_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    cli = make_repl_cli()
+    monkeypatch.delenv('VISUAL', raising=False)
+    monkeypatch.delenv('EDITOR', raising=False)
+    monkeypatch.setattr(repl_mode.shutil, 'which', lambda name: None)
+    monkeypatch.setattr(repl_mode, 'WIN', False)
+
+    repl_mode._configure_editor(cli)
+
+    assert os.environ['VISUAL'] == 'vi'
+
+
+def test_configure_editor_falls_back_to_edit_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    cli = make_repl_cli()
+    monkeypatch.delenv('VISUAL', raising=False)
+    monkeypatch.delenv('EDITOR', raising=False)
+    monkeypatch.setattr(repl_mode.shutil, 'which', lambda name: None)
+    monkeypatch.setattr(repl_mode, 'WIN', True)
+
+    repl_mode._configure_editor(cli)
+
+    assert os.environ['VISUAL'] == 'edit'
 
 
 def test_repl_show_startup_banner_and_prompt_helpers(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Description
Add `editor.editor_command` config entry in `~/.myclirc`, which overrides `$VISUAL`/`$EDITOR` environment variables if present.

Motivation: the user may want different editors for different applications.  It is also a little odd to have to switch from `~/.myclirc` for most configuration to environment variables for one little item.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
