### PR TITLE
Let Vault properties be set in DSN query parameters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features
 ---------
 * Set minimum times for transient toolbar messages.
 * `editor_command` entry in `~/.myclirc` which overrides environment.
+* Experimental: let Vault properties be set in DSNs.
 
 
 2.2.0 (2026/07/11)

--- a/mycli/cli_runner.py
+++ b/mycli/cli_runner.py
@@ -41,6 +41,11 @@ KNOWN_DSN_QUERY_PARAMS = {
     'ssl_mode',
     'ssl_verify_server_cert',
     'tls_version',
+    'vault_address',
+    'vault_mount',
+    'vault_secret',
+    'vault_password_field',
+    'vault_username_field',
 }
 
 
@@ -277,6 +282,16 @@ def run_from_cli_args(cli_args: 'CliArgs', client_factory: ClientFactory) -> Non
             cli_args.character_set = cli_args.character_set or params[0]
         if params := dsn_params.get('ssh_jump'):
             cli_args.ssh_jump = cli_args.ssh_jump or params[0]
+        if params := dsn_params.get('vault_address'):
+            cli_args.vault_address = cli_args.vault_address or params[0]
+        if params := dsn_params.get('vault_mount'):
+            cli_args.vault_mount = cli_args.vault_mount or params[0]
+        if params := dsn_params.get('vault_secret'):
+            cli_args.vault_secret = cli_args.vault_secret or params[0]
+        if params := dsn_params.get('vault_password_field'):
+            cli_args.vault_password_field = cli_args.vault_password_field or params[0]
+        if params := dsn_params.get('vault_username_field'):
+            cli_args.vault_username_field = cli_args.vault_username_field or params[0]
 
     keepalive_ticks = cli_args.keepalive_ticks if cli_args.keepalive_ticks is not None else mycli.default_keepalive_ticks
     ssl_mode = cli_args.ssl_mode or mycli.ssl_mode
@@ -388,6 +403,7 @@ def run_from_cli_args(cli_args: 'CliArgs', client_factory: ClientFactory) -> Non
             sys.exit(1)
     else:
         vault_username = None
+    vault_username_from_vault = vault_username is not None
 
     try:
         mycli.connect(
@@ -407,6 +423,12 @@ def run_from_cli_args(cli_args: 'CliArgs', client_factory: ClientFactory) -> Non
             keepalive_ticks=keepalive_ticks,
             ssh_jump=cli_args.ssh_jump,
             ssh_cli_options=cli_args.ssh_options,
+            vault_address=cli_args.vault_address,
+            vault_mount=cli_args.vault_mount,
+            vault_secret=cli_args.vault_secret,
+            vault_password_field=cli_args.vault_password_field,
+            vault_username_field=cli_args.vault_username_field,
+            vault_username_from_vault=vault_username_from_vault,
         )
 
         if combined_init_cmd:

--- a/mycli/client_connection.py
+++ b/mycli/client_connection.py
@@ -63,6 +63,12 @@ class ClientConnectionMixin:
         keepalive_ticks: int | None = None,
         ssh_jump: str | None = None,
         ssh_cli_options: str | None = None,
+        vault_address: str | None = None,
+        vault_mount: str | None = None,
+        vault_secret: str | None = None,
+        vault_password_field: str | None = None,
+        vault_username_field: str | None = None,
+        vault_username_from_vault: bool = False,
     ) -> None:
         mylogin_cnf: dict[str, Any] = self.read_mylogin_cnf(self.mylogin_cnf)
         # Fall back to .mylogin.cnf values only if user did not specify a value.
@@ -191,15 +197,36 @@ class ClientConnectionMixin:
         assert not isinstance(passwd, int)
 
         display_dsn = None
+        display_dsn_user = None if vault_username_from_vault else user
         if self.ssh_tunnel:
             display_dsn = format_connection_dsn(
-                user=user,
+                user=display_dsn_user,
                 host=remote_host,
                 port=remote_port,
                 socket=remote_socket,
                 database=database,
                 character_set=character_set,
                 ssh_jump=ssh_jump,
+                vault_address=vault_address,
+                vault_mount=vault_mount,
+                vault_secret=vault_secret,
+                vault_password_field=vault_password_field,
+                vault_username_field=vault_username_field,
+            )
+        elif vault_secret:
+            display_dsn = format_connection_dsn(
+                user=display_dsn_user,
+                host=host,
+                port=int_port,
+                socket=socket,
+                database=database,
+                character_set=character_set,
+                ssh_jump=ssh_jump,
+                vault_address=vault_address,
+                vault_mount=vault_mount,
+                vault_secret=vault_secret,
+                vault_password_field=vault_password_field,
+                vault_username_field=vault_username_field,
             )
 
         connection_info: dict[str, Any] = {

--- a/mycli/packages/special/utils.py
+++ b/mycli/packages/special/utils.py
@@ -156,13 +156,18 @@ def format_connection_dsn(
     socket: str | None,
     character_set: str | None,
     ssh_jump: str | None = None,
+    vault_address: str | None = None,
+    vault_mount: str | None = None,
+    vault_secret: str | None = None,
+    vault_password_field: str | None = None,
+    vault_username_field: str | None = None,
 ) -> str:
-    user = urlquote(user or '')
-    host = host or 'localhost'
+    if user_part := urlquote(user or ''):
+        user_part = f'{user_part}@'
+    host_part = host or 'localhost'
     port_part = f':{port}' if port is not None else ''
-    db = urlquote(database or '')
-    if db:
-        db = f'/{db}'
+    if db_part := urlquote(database or ''):
+        db_part = f'/{db_part}'
     query_part = {}
     if socket:
         query_part['socket'] = socket
@@ -171,7 +176,17 @@ def format_connection_dsn(
         query_part['character_set'] = character_set
     if ssh_jump:
         query_part['ssh_jump'] = ssh_jump
-    dsn = f'mysql://{user}@{host}{port_part}{db}'
+    if vault_address:
+        query_part['vault_address'] = vault_address
+    if vault_mount:
+        query_part['vault_mount'] = vault_mount
+    if vault_secret:
+        query_part['vault_secret'] = vault_secret
+    if vault_password_field:
+        query_part['vault_password_field'] = vault_password_field
+    if vault_username_field:
+        query_part['vault_username_field'] = vault_username_field
+    dsn = f'mysql://{user_part}{host_part}{port_part}{db_part}'
     if query_part:
         dsn += '?' + urlencode(query_part)
     return dsn

--- a/test/pytests/test_cli_runner.py
+++ b/test/pytests/test_cli_runner.py
@@ -610,6 +610,7 @@ def test_run_from_cli_args_reads_username_from_vault_when_user_is_missing(
     run_with_client(monkeypatch, cli_args, client)
 
     assert client.connect_calls[-1]['user'] == 'vault-user'
+    assert client.connect_calls[-1]['vault_username_from_vault'] is True
     assert vault_calls == [
         {
             'secret': 'database/prod',
@@ -639,6 +640,7 @@ def test_run_from_cli_args_prefers_dsn_user_over_vault_username(monkeypatch: pyt
     run_with_client(monkeypatch, cli_args, client)
 
     assert client.connect_calls[-1]['user'] == 'dsn-user'
+    assert client.connect_calls[-1]['vault_username_from_vault'] is False
     assert vault_calls == []
 
 
@@ -714,6 +716,7 @@ def test_run_from_cli_args_prefers_vault_cli_values_and_env_address(
     run_with_client(monkeypatch, cli_args, client)
 
     assert client.connect_calls[-1]['passwd'] == 'vault-secret'
+    assert client.connect_calls[-1]['vault_username_from_vault'] is False
     assert vault_calls == [
         {
             'secret': 'database/prod',
@@ -830,3 +833,201 @@ def test_run_from_cli_args_uses_auto_keyring_config(
 
     assert client.connect_calls[-1]['use_keyring'] is expected_use_keyring
     assert client.connect_calls[-1]['reset_keyring'] is False
+
+
+@pytest.mark.parametrize(
+    ('flag_name', 'expected_format'),
+    (
+        ('csv', 'csv'),
+        ('table', 'table'),
+    ),
+)
+def test_run_from_cli_args_sets_legacy_format_flags(
+    monkeypatch: pytest.MonkeyPatch,
+    flag_name: str,
+    expected_format: str,
+) -> None:
+    cli_args = make_cli_args()
+    setattr(cli_args, flag_name, True)
+    client = DummyMyCli()
+
+    run_with_client(monkeypatch, cli_args, client)
+
+    assert cli_args.format == expected_format
+
+
+def test_run_from_cli_args_list_dsn_exits_with_mode_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    cli_args = make_cli_args()
+    cli_args.list_dsn = True
+    client = DummyMyCli()
+    list_dsn_calls: list[DummyMyCli] = []
+    monkeypatch.setattr(main, 'preprocess_cli_args', lambda args, scheme_validator: 0)
+
+    def fake_main_list_dsn(value: DummyMyCli) -> int:
+        list_dsn_calls.append(value)
+        return 7
+
+    monkeypatch.setattr(cli_runner, 'main_list_dsn', fake_main_list_dsn)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_runner.run_from_cli_args(cli_args, lambda **_kwargs: client)
+
+    assert excinfo.value.code == 7
+    assert list_dsn_calls == [client]
+
+
+def test_run_from_cli_args_maps_dsn_socket_parameter(monkeypatch: pytest.MonkeyPatch) -> None:
+    cli_args = make_cli_args()
+    cli_args.dsn = 'mysql://user@host/db?socket=/tmp/mysql.sock'
+    client = DummyMyCli()
+
+    run_with_client(monkeypatch, cli_args, client)
+
+    assert client.connect_calls[-1]['socket'] == '/tmp/mysql.sock'
+
+
+def test_run_from_cli_args_maps_dsn_vault_parameters(monkeypatch: pytest.MonkeyPatch) -> None:
+    cli_args = make_cli_args()
+    cli_args.user = 'existing-user'
+    cli_args.password = 'existing-password'
+    cli_args.dsn = (
+        'mysql://host/db?vault_address=https%3A%2F%2Fvault.example.com&vault_mount=kv'
+        '&vault_secret=database%2Fprod&vault_password_field=mysql_password'
+        '&vault_username_field=mysql_username'
+    )
+    client = DummyMyCli()
+
+    run_with_client(monkeypatch, cli_args, client)
+
+    connect_call = client.connect_calls[-1]
+    assert connect_call['vault_address'] == 'https://vault.example.com'
+    assert connect_call['vault_mount'] == 'kv'
+    assert connect_call['vault_secret'] == 'database/prod'
+    assert connect_call['vault_password_field'] == 'mysql_password'
+    assert connect_call['vault_username_field'] == 'mysql_username'
+
+
+def test_run_from_cli_args_uses_no_ssl_for_auto_ssl_over_socket(monkeypatch: pytest.MonkeyPatch) -> None:
+    cli_args = make_cli_args()
+    cli_args.socket = '/tmp/mysql.sock'
+    client = DummyMyCli()
+    client.ssl_mode = 'auto'
+
+    run_with_client(monkeypatch, cli_args, client)
+
+    assert client.connect_calls[-1]['ssl'] is None
+
+
+def test_run_from_cli_args_merges_scalar_global_and_alias_list_init_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli_args = make_cli_args()
+    cli_args.dsn = 'prod'
+    client = DummyMyCli(
+        config={
+            **default_config(),
+            'alias_dsn': {'prod': 'mysql://u:p@h/db'},
+            'init-commands': {'global': 'set global=1'},
+            'alias_dsn.init-commands': {'prod': ['set alias=1', 'set alias=2']},
+        }
+    )
+
+    run_with_client(monkeypatch, cli_args, client)
+
+    assert client.connect_calls[-1]['init_command'] == 'set global=1; set alias=1; set alias=2'
+
+
+def test_run_from_cli_args_execute_mode_exits_with_mode_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    cli_args = make_cli_args()
+    cli_args.execute = 'select 1'
+    client = DummyMyCli()
+    execute_calls: list[tuple[DummyMyCli, main.CliArgs]] = []
+    monkeypatch.setattr(main, 'preprocess_cli_args', lambda args, scheme_validator: 0)
+    monkeypatch.setattr(cli_runner.sys, 'stdin', SimpleNamespace(isatty=lambda: True))
+    monkeypatch.setattr(cli_runner.sys.stderr, 'isatty', lambda: False)
+
+    def fake_main_execute_from_cli(mycli: DummyMyCli, args: main.CliArgs) -> int:
+        execute_calls.append((mycli, args))
+        return 11
+
+    monkeypatch.setattr(cli_runner, 'main_execute_from_cli', fake_main_execute_from_cli)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_runner.run_from_cli_args(cli_args, lambda **_kwargs: client)
+
+    assert excinfo.value.code == 11
+    assert execute_calls == [(client, cli_args)]
+    assert client.close_called is True
+
+
+def test_run_from_cli_args_batch_with_progress_exits_with_mode_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli_args = make_cli_args()
+    cli_args.batch = 'input.sql'
+    cli_args.progress = True
+    client = DummyMyCli()
+    batch_calls: list[tuple[DummyMyCli, main.CliArgs]] = []
+    monkeypatch.setattr(main, 'preprocess_cli_args', lambda args, scheme_validator: 0)
+    monkeypatch.setattr(cli_runner.sys, 'stdin', SimpleNamespace(isatty=lambda: True))
+    monkeypatch.setattr(cli_runner.sys.stderr, 'isatty', lambda: True)
+
+    def fake_main_batch_with_progress_bar(mycli: DummyMyCli, args: main.CliArgs) -> int:
+        batch_calls.append((mycli, args))
+        return 12
+
+    monkeypatch.setattr(cli_runner, 'main_batch_with_progress_bar', fake_main_batch_with_progress_bar)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_runner.run_from_cli_args(cli_args, lambda **_kwargs: client)
+
+    assert excinfo.value.code == 12
+    assert batch_calls == [(client, cli_args)]
+    assert client.close_called is True
+
+
+def test_run_from_cli_args_batch_without_progress_exits_with_mode_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli_args = make_cli_args()
+    cli_args.batch = 'input.sql'
+    client = DummyMyCli()
+    batch_calls: list[tuple[DummyMyCli, main.CliArgs]] = []
+    monkeypatch.setattr(main, 'preprocess_cli_args', lambda args, scheme_validator: 0)
+    monkeypatch.setattr(cli_runner.sys, 'stdin', SimpleNamespace(isatty=lambda: True))
+    monkeypatch.setattr(cli_runner.sys.stderr, 'isatty', lambda: False)
+
+    def fake_main_batch_without_progress_bar(mycli: DummyMyCli, args: main.CliArgs) -> int:
+        batch_calls.append((mycli, args))
+        return 13
+
+    monkeypatch.setattr(cli_runner, 'main_batch_without_progress_bar', fake_main_batch_without_progress_bar)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_runner.run_from_cli_args(cli_args, lambda **_kwargs: client)
+
+    assert excinfo.value.code == 13
+    assert batch_calls == [(client, cli_args)]
+    assert client.close_called is True
+
+
+def test_run_from_cli_args_stdin_batch_exits_with_mode_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    cli_args = make_cli_args()
+    client = DummyMyCli()
+    batch_calls: list[tuple[DummyMyCli, main.CliArgs]] = []
+    monkeypatch.setattr(main, 'preprocess_cli_args', lambda args, scheme_validator: 0)
+    monkeypatch.setattr(cli_runner.sys, 'stdin', SimpleNamespace(isatty=lambda: False))
+    monkeypatch.setattr(cli_runner.sys.stderr, 'isatty', lambda: False)
+
+    def fake_main_batch_from_stdin(mycli: DummyMyCli, args: main.CliArgs) -> int:
+        batch_calls.append((mycli, args))
+        return 14
+
+    monkeypatch.setattr(cli_runner, 'main_batch_from_stdin', fake_main_batch_from_stdin)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_runner.run_from_cli_args(cli_args, lambda **_kwargs: client)
+
+    assert excinfo.value.code == 14
+    assert batch_calls == [(client, cli_args)]
+    assert client.close_called is True

--- a/test/pytests/test_client_connection.py
+++ b/test/pytests/test_client_connection.py
@@ -425,6 +425,72 @@ def test_connect_uses_ssh_jump_with_local_port(monkeypatch: pytest.MonkeyPatch) 
     assert FakeSQLExecute.calls[-1]['display_dsn'] == 'mysql://alice@db.internal:3307?ssh_jump=bastion'
 
 
+def test_connect_with_vault_password_keeps_explicit_user_in_display_dsn() -> None:
+    client = DummyClient()
+
+    client.connect(user='alice', host='db.internal', port=3307, vault_secret='database/prod')
+
+    assert FakeSQLExecute.calls[-1]['display_dsn'] == 'mysql://alice@db.internal:3307?vault_secret=database%2Fprod'
+
+
+def test_connect_with_vault_username_omits_user_from_display_dsn() -> None:
+    client = DummyClient()
+
+    client.connect(
+        user='vault-user',
+        host='db.internal',
+        port=3307,
+        vault_secret='database/prod',
+        vault_username_from_vault=True,
+    )
+
+    assert FakeSQLExecute.calls[-1]['display_dsn'] == 'mysql://db.internal:3307?vault_secret=database%2Fprod'
+
+
+def test_connect_with_ssh_jump_and_vault_username_omits_user_from_display_dsn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeTunnel:
+        local_socket = None
+        local_host = '127.0.0.1'
+        local_port = 4406
+
+        @classmethod
+        def from_target(
+            cls,
+            _ssh_jump: str,
+            *,
+            remote_host: str,
+            remote_port: int,
+            remote_socket: str | None = None,
+            ssh_executable: str = 'ssh',
+            ssh_config_options: str | None = None,
+            ssh_cli_options: str | None = None,
+            tunnel_method: Literal['auto', 'socket', 'port'] = 'auto',
+        ) -> 'FakeTunnel':
+            return cls()
+
+        def start(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(client_connection, 'SshTunnel', FakeTunnel)
+    client = DummyClient()
+
+    client.connect(
+        user='vault-user',
+        host='db.internal',
+        port=3307,
+        ssh_jump='bastion',
+        vault_secret='database/prod',
+        vault_username_from_vault=True,
+    )
+
+    assert FakeSQLExecute.calls[-1]['display_dsn'] == ('mysql://db.internal:3307?ssh_jump=bastion&vault_secret=database%2Fprod')
+
+
 def test_connect_passes_config_and_cli_ssh_options(monkeypatch: pytest.MonkeyPatch) -> None:
     tunnel_calls: list[dict[str, Any]] = []
 

--- a/test/pytests/test_special_utils.py
+++ b/test/pytests/test_special_utils.py
@@ -327,6 +327,26 @@ def test_format_connection_dsn_includes_ssh_jump() -> None:
     )
 
 
+def test_format_connection_dsn_includes_vault_parameters() -> None:
+    assert format_connection_dsn(
+        user=None,
+        host='db.example.com',
+        port=3307,
+        database='prod',
+        socket=None,
+        character_set='utf8mb4',
+        vault_address='https://vault.example.com',
+        vault_mount='kv',
+        vault_secret='database/prod',
+        vault_password_field='mysql_password',
+        vault_username_field='mysql_username',
+    ) == (
+        'mysql://db.example.com:3307/prod?vault_address=https%3A%2F%2Fvault.example.com'
+        '&vault_mount=kv&vault_secret=database%2Fprod&vault_password_field=mysql_password'
+        '&vault_username_field=mysql_username'
+    )
+
+
 def test_compute_current_dsn_for_socket_connection() -> None:
     connection = SimpleNamespace(
         user='alice',


### PR DESCRIPTION
## Description
Let Vault properties be set in DSN query parameters.

It is becoming awkward to pass `compute_current_dsn()` the Cursor for computation of the DSN, because there are so many exceptions to pass forward based on SSH and Vault connections.

In a followup, we should simply compute the DSN earlier, and then pass fewer parameters to `connect()`.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
