### PR TITLE
Fix spelling error in comment

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,11 @@ Features
 * Experimental: let Vault properties be set in DSNs.
 
 
+Documentation
+---------
+* Spellcheck myclirc commentary.
+
+
 2.2.0 (2026/07/11)
 ==============
 

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -213,7 +213,7 @@ pager = 'less'
 # Note that the hostname is considered to be different if short or qualified.
 # This can be overridden with --use-keyring= at the CLI.
 # A password can be reset with --use-keyring=reset at the CLI.
-# Recommanded: auto
+# Recommended: auto
 use_keyring = False
 
 [editor]


### PR DESCRIPTION
## Description

Fix spelling error in comment.


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
