### PR TITLE
Better ordering for `/help` table

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ Features
 Documentation
 ---------
 * Spellcheck myclirc commentary.
+* Better ordering for `/help` table.
 
 
 2.2.0 (2026/07/11)

--- a/mycli/packages/special/main.py
+++ b/mycli/packages/special/main.py
@@ -226,7 +226,7 @@ def show_help(*_args) -> list[SQLResult]:
     header = ["Command", "Shortcut", "Usage", "Description"]
     result = []
 
-    for _, value in sorted(COMMANDS.items(), key=lambda x: str.casefold(x[0])):
+    for _, value in sorted(COMMANDS.items(), key=lambda x: str.casefold(x[0].removeprefix('\\').removeprefix('/'))):
         if value.hidden:
             continue
         if value.aliases:

--- a/test/features/fixture_data/help_commands.txt
+++ b/test/features/fixture_data/help_commands.txt
@@ -3,27 +3,26 @@
 +-----------------+----------+-----------------------------------+-------------------------------------------------------------+
 | /bug            | <null>   | /bug                              | File a bug on GitHub.                                       |
 | /clip           | <null>   | /clip | <query>\clip              | Copy query to the system clipboard.                         |
+| /connect        | /r       | /connect [database]               | Reconnect to the server, optionally switching databases.    |
+| /delimiter      | <null>   | /delimiter <string>               | Change end-of-statement delimiter.                          |
 | /dsn            | <null>   | /dsn <help|list|show|save|delete> | Manage saved DSNs.                                          |
 | /dt             | <null>   | /dt[+] [table]                    | List or describe tables.                                    |
 | /edit           | /e       | /edit <filename> | <query>\edit   | Edit query with editor (uses $VISUAL or $EDITOR).           |
+| /exit           | /q       | /exit                             | Exit.                                                       |
 | /f              | <null>   | /f [name [args..]]                | List or execute favorite queries.                           |
 | /fd             | <null>   | /fd <name>                        | Delete a favorite query.                                    |
 | /fs             | <null>   | /fs <name> <query>                | Save a favorite query.                                      |
 | \g              | <null>   | <query>\g                         | Display query results (mnemonic: go).                       |
 | \G              | <null>   | <query>\G                         | Display query results vertically.                           |
+| /help           | /?       | /help [term]                      | Show this table, or search for help on a term.              |
 | /l              | <null>   | /l                                | List databases.                                             |
 | /llm            | /ai      | /llm [arguments]                  | Interrogate an LLM.  See "/llm help".                       |
-| /once           | /o       | /once [-o] <filename>             | Append next result to an output file (overwrite using -o).  |
-| /pipe_once      | /|       | /pipe_once <command>              | Send next result to a subprocess.                           |
-| /timing         | /t       | /timing                           | Toggle timing of queries.                                   |
-| /connect        | /r       | /connect [database]               | Reconnect to the server, optionally switching databases.    |
-| /delimiter      | <null>   | /delimiter <string>               | Change end-of-statement delimiter.                          |
-| /exit           | /q       | /exit                             | Exit.                                                       |
-| /help           | /?       | /help [term]                      | Show this table, or search for help on a term.              |
 | /nopager        | /n       | /nopager                          | Disable pager; print to stdout.                             |
 | /notee          | <null>   | /notee                            | Stop writing results to an output file.                     |
 | /nowarnings     | /w       | /nowarnings                       | Disable automatic warnings display.                         |
+| /once           | /o       | /once [-o] <filename>             | Append next result to an output file (overwrite using -o).  |
 | /pager          | /P       | /pager [command]                  | Set pager to [command]. Print query results via pager.      |
+| /pipe_once      | /|       | /pipe_once <command>              | Send next result to a subprocess.                           |
 | /prompt         | /R       | /prompt <string>                  | Change prompt format.                                       |
 | /quit           | /q       | /quit                             | Quit.                                                       |
 | /redirectformat | /Tr      | /redirectformat <format>          | Change the table format used to output redirected results.  |
@@ -33,6 +32,7 @@
 | /system         | <null>   | /system [-r] <command>            | Execute a system shell command (raw mode with -r).          |
 | /tableformat    | /T       | /tableformat <format>             | Change the table format used to output interactive results. |
 | /tee            | <null>   | /tee [-o] <filename>              | Append all results to an output file (overwrite using -o).  |
+| /timing         | /t       | /timing                           | Toggle timing of queries.                                   |
 | /use            | /u       | /use <database>                   | Change to a new database.                                   |
 | /warnings       | /W       | /warnings                         | Enable automatic warnings display.                          |
 | /watch          | <null>   | /watch [seconds] [-c] <query>     | Execute query every [seconds] seconds (5 by default).       |


### PR DESCRIPTION
## Description
Better ordering for `/help` table: lexicographic by first alphabetical letter, ignoring leading punctuation.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
