### PR TITLE
Don't create `~/.myclirc` if user adopted the XDG config layout

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Bug Fixes
+---------
+* Don't create `~/.myclirc` if the user adopted the XDG layout for myclirc.
+
+
 2.3.0 (2026/07/16)
 ==============
 

--- a/mycli/client.py
+++ b/mycli/client.py
@@ -58,9 +58,9 @@ class MyCli(AppStateMixin, OutputMixin, ClientCommandsMixin, ClientConnectionMix
 
     # check XDG_CONFIG_HOME exists and not an empty string
     xdg_config_home = os.environ.get("XDG_CONFIG_HOME", "~/.config")
+    xdg_config_file = os.path.join(os.path.expanduser(xdg_config_home), "mycli", "myclirc")
     system_config_files: list[str | IO[str]] = [
         "/etc/myclirc",
-        os.path.join(os.path.expanduser(xdg_config_home), "mycli", "myclirc"),
     ]
 
     def __init__(
@@ -72,7 +72,7 @@ class MyCli(AppStateMixin, OutputMixin, ClientCommandsMixin, ClientConnectionMix
         login_path: str | None = None,
         auto_vertical_output: bool = False,
         warn: bool | None = None,
-        myclirc: str = "~/.myclirc",
+        myclirc: str | None = None,
         show_warnings: bool | None = None,
         cli_verbosity: int = 0,
     ) -> None:
@@ -86,6 +86,12 @@ class MyCli(AppStateMixin, OutputMixin, ClientCommandsMixin, ClientConnectionMix
         self.keepalive_ticks: int | None = 0
         self.sandbox_mode: bool = False
         self.checkpoint: IO | None = None
+
+        if myclirc is None:
+            if os.path.exists(self.xdg_config_file):
+                myclirc = self.xdg_config_file
+            else:
+                myclirc = '~/.myclirc'
 
         # Load config.
         config_files: list[str | IO[str]] = self.system_config_files + [myclirc]

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -195,7 +195,6 @@ class CliArgs:
     )
     myclirc: str = clickdc.option(
         type=click.Path(),
-        default='~/.myclirc',
         help='Location of myclirc file.',
     )
     auto_vertical_output: bool = clickdc.option(

--- a/test/pytests/test_client.py
+++ b/test/pytests/test_client.py
@@ -62,6 +62,38 @@ def test_init_uses_cli_verbosity_override(monkeypatch: pytest.MonkeyPatch, tmp_p
     assert cli.verbosity == 2
 
 
+def test_init_uses_existing_xdg_config_when_myclirc_is_not_given(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    patch_constructor_side_effects(monkeypatch)
+    xdg_config = tmp_path / 'xdg' / 'mycli' / 'myclirc'
+    xdg_config.parent.mkdir(parents=True)
+    xdg_config.write_text('', encoding='utf-8')
+    monkeypatch.setattr(MyCli, 'xdg_config_file', str(xdg_config))
+
+    cli = MyCli(myclirc=None)
+
+    assert cli.config.filename == str(xdg_config)
+
+
+def test_init_uses_default_myclirc_when_xdg_config_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    patch_constructor_side_effects(monkeypatch)
+    config_file_args: list[list[str | Any]] = []
+    monkeypatch.setattr(MyCli, 'xdg_config_file', '/missing/xdg/myclirc')
+    monkeypatch.setattr(client_module.os.path, 'exists', lambda path: False)
+    monkeypatch.setattr(client_module, 'write_default_config', lambda destination: None)
+
+    original_read_config_files = client_module.read_config_files
+
+    def read_config_files(files: list[str | Any], *args: Any, **kwargs: Any) -> Any:
+        config_file_args.append(files)
+        return original_read_config_files(files, *args, **kwargs)
+
+    monkeypatch.setattr(client_module, 'read_config_files', read_config_files)
+
+    MyCli(myclirc=None)
+
+    assert config_file_args[0] == ['~/.myclirc']
+
+
 def test_init_writes_default_config_when_user_config_is_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     patch_constructor_side_effects(monkeypatch)
     write_calls: list[str] = []


### PR DESCRIPTION
## Description
If the user moved the `~/.myclirc` file to `~/.config/mycli/myclirc`, then mycli was reading the moved file correctly, but continuing to create a fresh `~/.myclirc`.

The internal logic was confusing, terming the user's XDG location as a `system_config_file`.

Simplify, and solve the `~/.myclirc` creation bug.


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
