### PR TITLE
Refine password-source names

### DIFF
--- a/mycli/cli_runner.py
+++ b/mycli/cli_runner.py
@@ -371,9 +371,9 @@ def run_from_cli_args(cli_args: 'CliArgs', client_factory: ClientFactory) -> Non
     if cli_args.password == EMPTY_PASSWORD_FLAG_SENTINEL:
         password_candidates.add_value('prompt', cli_args.password)
     elif cli_args.password is not None:
-        password_candidates.add_value('cli_literal', cli_args.password)
+        password_candidates.add_value('literal', cli_args.password)
     if cli_args.password_file:
-        password_candidates.add_loader('cli_file', lambda: main_module.get_password_from_file(cli_args.password_file))
+        password_candidates.add_loader('file', lambda: main_module.get_password_from_file(cli_args.password_file))
     if os.environ.get('MYSQL_PWD') is not None:
         password_candidates.add_value('environment', os.environ.get('MYSQL_PWD'))
     if dsn_password is not None:

--- a/mycli/client_connection.py
+++ b/mycli/client_connection.py
@@ -181,7 +181,7 @@ class ClientConnectionMixin:
         keyring_domain = 'mycli.net'
         keyring_retrieved_cleanly = False
 
-        password_candidates.add_value('mylogin_cnf', mylogin_cnf['password'])
+        password_candidates.add_value('login_path', mylogin_cnf['password'])
         if use_keyring and not reset_keyring:
             password_candidates.add_loader('keyring', lambda: keyring.get_password(keyring_domain, keyring_identifier))
 

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -205,17 +205,17 @@ enable_pager = True
 # Choose a specific pager
 pager = 'less'
 
-# Comma-separated sources to respect for a password, in order of precendence.
+# Comma-separated sources to respect for a password, in order of precedence.
 # Valid choices:
-# * prompt
-# * cli_literal
-# * cli_file
-# * environment
-# * dsn
-# * vault
-# * mylogin_cnf
-# * keyring
-password_sources = prompt, cli_literal, cli_file, environment, dsn, vault, mylogin_cnf, keyring
+# * prompt         # interactive fallback, or plain trailing --password at the CLI
+# * literal        # --password=<literal> at the CLI
+# * file           # --password-file=<file> at the CLI
+# * environment    # $MYSQL_PWD environment variable
+# * dsn            # mysql://user:password@ field in a DSN
+# * vault          # value retrieved from "vault kv get"
+# * login_path     # --login-path=<path> at the CLI
+# * keyring        # value retrieved from system keyring
+password_sources = prompt, literal, file, environment, dsn, vault, login_path, keyring
 
 # Whether to store and retrieve passwords from the system keyring.
 # * False - never use keyring

--- a/mycli/password_sources.py
+++ b/mycli/password_sources.py
@@ -8,12 +8,12 @@ import click
 
 PasswordSource = Literal[
     'prompt',
-    'cli_literal',
-    'cli_file',
+    'literal',
+    'file',
     'environment',
     'dsn',
     'vault',
-    'mylogin_cnf',
+    'login_path',
     'keyring',
 ]
 PasswordValue = str | int
@@ -21,12 +21,12 @@ PasswordLoader = Callable[[], PasswordValue | None]
 
 KNOWN_PASSWORD_SOURCES: list[PasswordSource] = [
     'prompt',
-    'cli_literal',
-    'cli_file',
+    'literal',
+    'file',
     'environment',
     'dsn',
     'vault',
-    'mylogin_cnf',
+    'login_path',
     'keyring',
 ]
 

--- a/test/myclirc
+++ b/test/myclirc
@@ -205,17 +205,17 @@ enable_pager = True
 # Choose a specific pager
 pager = python test/features/wrappager.py ---boundary---
 
-# Comma-separated sources to respect for a password, in order of precendence.
+# Comma-separated sources to respect for a password, in order of precedence.
 # Valid choices:
-# * prompt
-# * cli_literal
-# * cli_file
-# * environment
-# * dsn
-# * vault
-# * mylogin_cnf
-# * keyring
-password_sources = prompt, cli_literal, cli_file, environment, dsn, vault, mylogin_cnf, keyring
+# * prompt         # interactive fallback, or plain trailing --password at the CLI
+# * literal        # --password=<literal> at the CLI
+# * file           # --password-file=<file> at the CLI
+# * environment    # $MYSQL_PWD environment variable
+# * dsn            # mysql://user:password@ field in a DSN
+# * vault          # value retrieved from "vault kv get"
+# * login_path     # --login-path=<path> at the CLI
+# * keyring        # value retrieved from system keyring
+password_sources = prompt, literal, file, environment, dsn, vault, login_path, keyring
 
 # Whether to store and retrieve passwords from the system keyring.
 # * False - never use keyring

--- a/test/pytests/test_cli_runner.py
+++ b/test/pytests/test_cli_runner.py
@@ -201,7 +201,7 @@ def test_run_from_cli_args_password_file_prevents_positional_dsn_alias(
     connect_call = client.connect_calls[-1]
     assert client.dsn_alias is None
     assert connect_call['database'] == 'prod'
-    assert resolve_connect_password(connect_call) == ('cli_file', 'file-secret')
+    assert resolve_connect_password(connect_call) == ('file', 'file-secret')
     assert password_file_calls == ['secret.txt']
 
 
@@ -234,7 +234,7 @@ def test_run_from_cli_args_keeps_empty_cli_password_over_dsn(monkeypatch: pytest
 
     run_with_client(monkeypatch, cli_args, client)
 
-    assert resolve_connect_password(client.connect_calls[-1]) == ('cli_literal', '')
+    assert resolve_connect_password(client.connect_calls[-1]) == ('literal', '')
 
 
 def test_run_from_cli_args_preserves_cli_password_prompt(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/test/pytests/test_main.py
+++ b/test/pytests/test_main.py
@@ -974,7 +974,7 @@ def test_dsn(monkeypatch):
     assert result.exit_code == 0, result.output + " " + str(result.exception)
     assert (
         MockMyCli.connect_args["user"] == "arg_user"
-        and resolve_connect_password(MockMyCli.connect_args) == ('cli_literal', 'arg_password')
+        and resolve_connect_password(MockMyCli.connect_args) == ('literal', 'arg_password')
         and MockMyCli.connect_args["host"] == "arg_host"
         and MockMyCli.connect_args["port"] == 3
         and MockMyCli.connect_args["database"] == "arg_database"
@@ -1033,7 +1033,7 @@ def test_dsn(monkeypatch):
     assert result.exit_code == 0, result.output + " " + str(result.exception)
     assert (
         MockMyCli.connect_args["user"] == "arg_user"
-        and resolve_connect_password(MockMyCli.connect_args) == ('cli_literal', 'arg_password')
+        and resolve_connect_password(MockMyCli.connect_args) == ('literal', 'arg_password')
         and MockMyCli.connect_args["host"] == "arg_host"
         and MockMyCli.connect_args["port"] == 5
         and MockMyCli.connect_args["database"] == "arg_database"
@@ -1271,7 +1271,7 @@ def test_password_option_uses_cleartext_value(monkeypatch):
         ],
     )
     assert result.exit_code == 0, result.output + ' ' + str(result.exception)
-    assert resolve_connect_password(MockMyCli.connect_args) == ('cli_literal', 'cleartext_password')
+    assert resolve_connect_password(MockMyCli.connect_args) == ('literal', 'cleartext_password')
 
 
 def test_password_option_overrides_password_file_and_mysql_pwd(monkeypatch):
@@ -1340,7 +1340,7 @@ def test_password_option_overrides_password_file_and_mysql_pwd(monkeypatch):
             ],
         )
         assert result.exit_code == 0, result.output + ' ' + str(result.exception)
-        assert resolve_connect_password(MockMyCli.connect_args) == ('cli_literal', 'option_password')
+        assert resolve_connect_password(MockMyCli.connect_args) == ('literal', 'option_password')
     finally:
         os.remove(password_file.name)
 
@@ -1408,7 +1408,7 @@ def test_password_file_option_reads_password(monkeypatch):
             ],
         )
         assert result.exit_code == 0, result.output + ' ' + str(result.exception)
-        assert resolve_connect_password(MockMyCli.connect_args) == ('cli_file', 'file_password')
+        assert resolve_connect_password(MockMyCli.connect_args) == ('file', 'file_password')
     finally:
         os.remove(password_file.name)
 

--- a/test/pytests/test_password_sources.py
+++ b/test/pytests/test_password_sources.py
@@ -12,24 +12,24 @@ def test_resolve_uses_fixed_precedence_instead_of_registration_order() -> None:
     candidates = PasswordCandidates()
     candidates.add_value('keyring', 'keyring-secret')
     candidates.add_value('dsn', 'dsn-secret')
-    candidates.add_value('cli_literal', 'cli-secret')
+    candidates.add_value('literal', 'cli-secret')
 
     selected = candidates.resolve(KNOWN_PASSWORD_SOURCES)
 
     assert selected is not None
-    assert selected.source == 'cli_literal'
+    assert selected.source == 'literal'
     assert selected.value == 'cli-secret'
 
 
 def test_resolve_treats_empty_string_as_password() -> None:
     candidates = PasswordCandidates()
-    candidates.add_value('cli_literal', '')
-    candidates.add_value('cli_file', 'file-secret')
+    candidates.add_value('literal', '')
+    candidates.add_value('file', 'file-secret')
 
     selected = candidates.resolve(KNOWN_PASSWORD_SOURCES)
 
     assert selected is not None
-    assert selected.source == 'cli_literal'
+    assert selected.source == 'literal'
     assert selected.value == ''
 
 
@@ -54,12 +54,12 @@ def test_resolve_skips_lower_priority_lazy_loader() -> None:
 def test_resolve_falls_back_when_a_loader_returns_none() -> None:
     candidates = PasswordCandidates()
     candidates.add_loader('vault', lambda: None)
-    candidates.add_value('mylogin_cnf', 'mylogin-secret')
+    candidates.add_value('login_path', 'mylogin-secret')
 
     selected = candidates.resolve(KNOWN_PASSWORD_SOURCES)
 
     assert selected is not None
-    assert selected.source == 'mylogin_cnf'
+    assert selected.source == 'login_path'
     assert selected.value == 'mylogin-secret'
 
 

--- a/test/pytests/test_tabular_output.py
+++ b/test/pytests/test_tabular_output.py
@@ -21,7 +21,7 @@ default_config_file = os.path.join(os.path.dirname(__file__), "../myclirc")
 def mycli():
     cli = MyCli()
     pc = PasswordCandidates()
-    pc.add_value('cli_literal', PASSWORD)
+    pc.add_value('literal', PASSWORD)
     cli.connect(None, USER, pc, HOST, PORT, None, init_command=None)
     yield cli
     cli.sqlexecute.conn.close()


### PR DESCRIPTION
## Description
 * refine password-source names, prior to release, making them correspond more directly to the UI
 * add commentary in `~/.myclirc`
 * fix typo in `~/.myclirc`

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
