### PR TITLE
Add `\e` prompt/toolbar format string for edit mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features
 ---------
 * Make password sources and precedence configurable.
 * Ability to deselect fallback interactive password prompt.
+* Add `\e` prompt/toolbar format string for edit mode.
 
 
 Bug Fixes

--- a/mycli/clitoolbar.py
+++ b/mycli/clitoolbar.py
@@ -8,6 +8,17 @@ from prompt_toolkit.key_binding.vi_state import InputMode
 from mycli.packages import special
 
 
+def get_vi_mode() -> str:
+    """Get the current vi mode for display."""
+    return {
+        InputMode.INSERT: "I",
+        InputMode.NAVIGATION: "N",
+        InputMode.REPLACE: "R",
+        InputMode.REPLACE_SINGLE: "R",
+        InputMode.INSERT_MULTIPLE: "M",
+    }[get_app().vi_state.input_mode]
+
+
 def create_toolbar_tokens_func(
     mycli,
     show_initial_toolbar_help: Callable[[], bool],
@@ -45,8 +56,8 @@ def create_toolbar_tokens_func(
 
         if mycli.prompt_session.editing_mode == EditingMode.VI:
             result.append(divider)
-            result.append(("class:bottom-toolbar", "Vi:"))
-            result.append(("class:bottom-toolbar.on", _get_vi_mode()))
+            result.append(("class:bottom-toolbar", "vi:"))
+            result.append(("class:bottom-toolbar.on", get_vi_mode()))
 
         if mycli.toolbar_error_message:
             dynamic.append(divider)
@@ -92,14 +103,3 @@ def create_toolbar_tokens_func(
         return result
 
     return get_toolbar_tokens
-
-
-def _get_vi_mode() -> str:
-    """Get the current vi mode for display."""
-    return {
-        InputMode.INSERT: "I",
-        InputMode.NAVIGATION: "N",
-        InputMode.REPLACE: "R",
-        InputMode.REPLACE_SINGLE: "R",
-        InputMode.INSERT_MULTIPLE: "M",
-    }[get_app().vi_state.input_mode]

--- a/mycli/main_modes/repl.py
+++ b/mycli/main_modes/repl.py
@@ -42,7 +42,7 @@ from pymysql.cursors import Cursor
 import mycli as mycli_package
 from mycli.clibuffer import cli_is_multiline
 from mycli.clistyle import style_factory_ptoolkit
-from mycli.clitoolbar import create_toolbar_tokens_func
+from mycli.clitoolbar import create_toolbar_tokens_func, get_vi_mode
 from mycli.compat import WIN
 from mycli.constants import (
     DEFAULT_HOST,
@@ -321,6 +321,14 @@ def render_prompt_string(
     strings = [x.replace('\\_', ' ') for x in strings]
 
     checker_string = ' '.join(strings)
+    if r'\e' in checker_string:
+        if mycli.prompt_session:
+            edit_mode = mycli.prompt_session.editing_mode.value.lower()
+            if edit_mode == 'vi':
+                edit_mode += ':' + get_vi_mode()
+        else:
+            edit_mode = mycli.key_bindings.lower()
+        strings = [x.replace(r'\e', maybe_html_escape(edit_mode, is_html)) for x in strings]
     if hasattr(sqlexecute, 'conn') and sqlexecute.conn is not None:
         if '\\y' in checker_string:
             with sqlexecute.conn.cursor() as cur:

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -122,6 +122,7 @@ wider_completion_menu = False
 # * \s - seconds of the current time
 # * \P - AM/PM
 # * \d - selected database/schema
+# * \e - current edit mode (emacs or vi)
 # * \h - hostname of the server
 # * \H - shortened hostname of the server
 # * \p - connection port

--- a/test/myclirc
+++ b/test/myclirc
@@ -122,6 +122,7 @@ wider_completion_menu = False
 # * \s - seconds of the current time
 # * \P - AM/PM
 # * \d - selected database/schema
+# * \e - current edit mode (emacs or vi)
 # * \h - hostname of the server
 # * \H - shortened hostname of the server
 # * \p - connection port

--- a/test/pytests/test_clitoolbar.py
+++ b/test/pytests/test_clitoolbar.py
@@ -73,7 +73,7 @@ def test_create_toolbar_tokens_func_shows_multiline_vi_and_refreshing(monkeypatc
         refreshing=True,
     )
     monkeypatch.setattr(clitoolbar.special, 'get_current_delimiter', lambda: '$$')
-    monkeypatch.setattr(clitoolbar, '_get_vi_mode', lambda: 'N')
+    monkeypatch.setattr(clitoolbar, 'get_vi_mode', lambda: 'N')
 
     toolbar = clitoolbar.create_toolbar_tokens_func(mycli, lambda: False, None, mycli.get_custom_toolbar)
     result = toolbar()
@@ -81,7 +81,7 @@ def test_create_toolbar_tokens_func_shows_multiline_vi_and_refreshing(monkeypatc
     assert ("class:bottom-toolbar.off", "OFF") in result
     assert ("class:bottom-toolbar", "[F3] Multiline:") in result
     assert ("class:bottom-toolbar.on", "ON ") in result
-    assert ("class:bottom-toolbar", "Vi:") in result
+    assert ("class:bottom-toolbar", "vi:") in result
     assert ("class:bottom-toolbar.on", "N") in result
     assert ('class:bottom-toolbar.on', '$$') in result
     assert ("class:bottom-toolbar", "Refreshing completions…") in result
@@ -140,4 +140,4 @@ def test_get_vi_mode(monkeypatch, input_mode: InputMode, expected: str) -> None:
     app = SimpleNamespace(vi_state=SimpleNamespace(input_mode=input_mode))
     monkeypatch.setattr(clitoolbar, 'get_app', lambda: app)
 
-    assert clitoolbar._get_vi_mode() == expected
+    assert clitoolbar.get_vi_mode() == expected

--- a/test/pytests/test_main_modes_repl.py
+++ b/test/pytests/test_main_modes_repl.py
@@ -604,6 +604,30 @@ def test_maybe_html_escape() -> None:
     assert repl_mode.maybe_html_escape('a&b<1>', True) == 'a&amp;b&lt;1&gt;'
 
 
+def test_render_prompt_string_includes_current_edit_mode() -> None:
+    cli = make_repl_cli(
+        SimpleNamespace(
+            user='alice',
+            host='db.example.com',
+            dbname='nameprod',
+            port=3306,
+            socket=None,
+            server_info=SimpleNamespace(species=SimpleNamespace(name='MySQL')),
+            conn=None,
+        )
+    )
+    cli.prompt_session = SimpleNamespace(editing_mode=repl_mode.EditingMode.VI)
+
+    assert to_plain_text(repl_mode.render_prompt_string(cli, r'\e', 0)) == 'vi:I'
+
+    cli.prompt_session.editing_mode = repl_mode.EditingMode.EMACS
+    assert to_plain_text(repl_mode.render_prompt_string(cli, r'\e', 1)) == 'emacs'
+
+    cli.prompt_session = None
+    cli.key_bindings = 'vi'
+    assert to_plain_text(repl_mode.render_prompt_string(cli, r'\e', 2)) == 'vi'
+
+
 def test_render_prompt_string_html() -> None:
     repl_mode.render_prompt_string.cache_clear()
 


### PR DESCRIPTION
## Description

This is so that users can show the current edit mode in the bottom toolbar to taste.  The edit mode could otherwise only be shown in the toolbar with the default group of items using `\B`.

It is unlikely that anyone wants this value to be shown in the prompt, but it is equally possible.

The edit mode name is also lowercased, for consistency.

For vi-mode, the string `vi` is followed by a colon and the current vi input mode.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
