### PR TITLE
Don't let the `behave` suite modify checked-in files

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ Features
 * Configurable sources of credentials to save to the keyring.
 
 
+Internal
+---------
+* Don't modify checked-in `test/myclirc` in the behave test suite.
+
+
 2.4.0 (2026/07/18)
 ==============
 

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import sys
+import tempfile
 
 import db_utils as dbutils
 import fixture_utils as fixutils
@@ -64,7 +65,11 @@ def before_all(context):
     os.environ['PAGER'] = (
         f'{sys.executable} {os.path.join(context.package_root, "test/features/wrappager.py")} {context.conf["pager_boundary"]}'
     )
-    context.conf["myclirc"] = os.path.join(context.package_root, "test", "myclirc")
+    source_myclirc = os.path.join(context.package_root, 'test', 'myclirc')
+    fd, context.myclirc_copy = tempfile.mkstemp(prefix='mycli-behave-', suffix='.myclirc')
+    os.close(fd)
+    shutil.copyfile(source_myclirc, context.myclirc_copy)
+    context.conf['myclirc'] = context.myclirc_copy
 
     context.cn = dbutils.create_db(
         context.conf["host"], context.conf["port"], context.conf["user"], context.conf["pass"], context.conf["dbname"]
@@ -81,6 +86,10 @@ def after_all(context):
         if os.path.exists(context.conf["defaults-file"]):
             os.remove(context.conf["defaults-file"])
     except Exception:
+        pass
+    try:
+        os.remove(context.myclirc_copy)
+    except FileNotFoundError:
         pass
 
     # Restore env vars.


### PR DESCRIPTION
## Description
Make a copy of `test/myclirc` to be used by the behave suite, because the behave suite saves a favorite query, causing the config file to be modified, and therefore "dirty" from the point-of-view of git.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
