### PR TITLE
Attempt to make `README.md` images display on PyPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A command line client for MySQL with auto-completion and syntax highlighting.
 Homepage: [https://mycli.net](https://mycli.net)
 Documentation: [https://mycli.net/docs](https://mycli.net/docs)
 
-![Completion](doc/screenshots/tables.png)
-![CompletionGif](doc/screenshots/main.gif)
+![Completion](https://raw.githubusercontent.com/dbcli/mycli/main/doc/screenshots/tables.png)
+![CompletionGif](https://raw.githubusercontent.com/dbcli/mycli/main/doc/screenshots/main.gif)
 
 Mycli is compatible with MySQL, MariaDB, Percona, TiDB, and Apache Doris.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+2.5.1 (2026/07/22)
+==============
+
+Documentation
+---------
+* Attempt to make `README.md` images display on PyPi.
+
+
 2.5.0 (2026/07/22)
 ==============
 


### PR DESCRIPTION
## Description
Attempt to make `README.md` images display on PyPi, by giving the full URL.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
