### PR TITLE
Constrain the size of an image in transforms.md

### DIFF
--- a/doc/transforms.md
+++ b/doc/transforms.md
@@ -75,7 +75,8 @@ Example:
 ```sql
 SELECT * FROM orders .| df['total'].plot.hist();
 ```
-![histogram](https://raw.githubusercontent.com/dbcli/mycli/main/doc/screenshots/total_histogram.png)
+
+<img src="https://raw.githubusercontent.com/dbcli/mycli/main/doc/screenshots/total_histogram.png", height=400>
 
 Image size, display protocol, and other properties can be configured in
 the `[dataframe]` section of `~/.myclirc`.


### PR DESCRIPTION
## Description
Constrain the size of an image in transforms.md.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
