### PR TITLE
Separate Homepage/Documentation lines in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 A command line client for MySQL with auto-completion and syntax highlighting.
 
 Homepage: [https://mycli.net](https://mycli.net)
+
 Documentation: [https://mycli.net/docs](https://mycli.net/docs)
 
 ![Completion](https://raw.githubusercontent.com/dbcli/mycli/main/doc/screenshots/tables.png)

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,11 @@ Bug Fixes
 * Keep Vault username and password fields from being confused.
 
 
+Documentation
+---------
+* `README.md` formatting.
+
+
 Internal
 ---------
 * Sync test myclirc file closer to package myclirc file.


### PR DESCRIPTION
## Description
Separate Homepage/Documentation lines in `README.md`, so that they appear as separate lines, not one after the other.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
