### PR TITLE
Allow `\g` to terminate `.>` expressions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ Features
 Bug Fixes
 ---------
 * Keep Vault username and password fields from being confused.
+* Allow `\g` to terminate `.>` expressions.
 
 
 Documentation

--- a/doc/transforms.md
+++ b/doc/transforms.md
@@ -100,7 +100,7 @@ reports its destination and row count.
 When `post_redirect_command` is set in `~/.myclirc`, the given command runs
 after a successful Parquet save.
 
-`.>` cannot be combined with `\x`, `\G`, or `\g` special display terminators.
+`.>` cannot be combined with the `\x` or `\G` special display terminators.
 
 ## Combining
 

--- a/mycli/packages/polars_transform.py
+++ b/mycli/packages/polars_transform.py
@@ -86,8 +86,9 @@ def parse_polars_transform(command: str) -> PolarsPipeline | None:
         parquet_operator = tokens[parquet_index + 1]
         parquet_path = command[parquet_operator.end + 1 :].strip()
         parquet_path = parquet_path.removesuffix(delimiter_command.current).rstrip()
+        parquet_path = parquet_path.removesuffix(r'\g').rstrip()
 
-    has_display_terminator = any(value is not None and value.endswith((r'\x', r'\G', r'\g')) for value in (sql, expression, parquet_path))
+    has_display_terminator = any(value is not None and value.endswith((r'\x', r'\G')) for value in (sql, expression, parquet_path))
     if parquet_path is not None and has_display_terminator:
         raise PolarsTransformError('Parquet saves cannot use special display terminators.')
     if sql.endswith(r'\x') or expression is not None and expression.endswith(r'\x'):

--- a/test/pytests/test_polars_transform.py
+++ b/test/pytests/test_polars_transform.py
@@ -158,6 +158,7 @@ def test_parse_polars_transform_returns_output_mode(command: str, output_mode: O
     [
         ('SELECT * FROM orders .> orders.parquet', None, 'orders.parquet'),
         ('SELECT * FROM orders .> orders.parquet;', None, 'orders.parquet'),
+        (r'SELECT * FROM orders .> orders.parquet \g', None, 'orders.parquet'),
         ("SELECT * FROM orders .> 'order exports.parquet'", None, 'order exports.parquet'),
         ('SELECT * FROM orders .| df.head(10) .> orders.parquet', 'df.head(10)', 'orders.parquet'),
     ],
@@ -202,6 +203,7 @@ def test_parse_polars_transform_ignores_non_suffix_markers(command: str) -> None
         ('SELECT 1 .> export file.parquet', 'must be quoted'),
         ('SELECT 1 .> export.parquet .| df', 'must follow'),
         ('SELECT 1 .| df .> export.parquet \\x', 'cannot use special display terminators'),
+        ('SELECT 1 .| df .> export.parquet \\G', 'cannot use special display terminators'),
         ('SELECT 1 .| df .| df', 'only one ".|"'),
         ('SELECT 1 .> first.parquet .> second.parquet', 'only one ".>"'),
         ('SELECT 1 .> ;', 'require a destination path'),


### PR DESCRIPTION
## Description
There is no reason to exclude `\g` from terminating `.>` expressions, since it doesn't modify the expectations of output.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
