### PR TITLE
Update dependencies to satisfy `uv audit` recommendations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,15 @@ Documentation
 Internal
 ---------
 * Update `cli_helpers` dependency to v2.15.1
+* Update `click` to v8.4.2
+* Update `cryptography` to v49.0.0
+* Update `pygments` to v2.20.0
+* Update `llm` to v0.31.1
+* Update `setuptools` to v83.x
+* Update `pip` to v26.1.2
+* Update `pytest` to v9.1.1
+* Add dependency cooldown period
+* Exclude `cli_helpers` and `openai` from cooldown
 
 
 2.6.1 (2026/07/24)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,13 @@ license = "BSD-3-Clause"
 authors = [{ name = "Mycli Core Team" }]
 
 dependencies = [
-    "click ~= 8.3.1",
+    "click ~= 8.4.2",
     "clickdc ~= 0.1.1",
-    "cryptography ~= 46.0.5",
-    "Pygments ~= 2.19.2",
-    "prompt_toolkit>=3.0.41,<4.0.0",
+    "cryptography ~= 49.0.0",
+    "Pygments ~= 2.20.0",
+    "prompt_toolkit >= 3.0.41,<4.0.0",
     "PyMySQL ~= 1.1.2",
-    "sqlparse>=0.3.0,<0.6.0",
+    "sqlparse >= 0.3.0,<0.6.0",
     "sqlglot ~= 30.8.0",
     "sqlglotc ~= 30.8.0",
     "configobj ~= 5.0.9",
@@ -44,10 +44,9 @@ build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
 llm = [
-    "llm ~= 0.30.0",
-    "pydantic_core ~= 2.41.5",              # Required by llm; force a newer version
-    "setuptools == 82.*",                   # Required by llm commands to install models
-    "pip == 26.*",
+    "llm ~= 0.31.1",
+    "setuptools == 83.*",                   # Required by llm commands to install models
+    "pip ~= 26.1.2",
 ]
 dataframe = [
     "polars ~= 1.42.1",
@@ -62,15 +61,14 @@ dev = [
     "coverage ~= 7.13.4",
     "mypy ~= 1.19.1",
     "pexpect ~= 4.9.0",
-    "pytest ~= 9.0.2",
+    "pytest ~= 9.1.1",
     "pytest-cov ~= 7.0.0",
     "pytest-random-order ~= 1.2.0",
     "tox ~= 4.35.0",
     "pdbpp ~= 0.11.7",
-    "llm ~= 0.30.0",
-    "pydantic_core ~= 2.41.5",              # Required by llm; force a newer version
-    "setuptools == 82.*",                   # Required by llm commands to install models
-    "pip == 26.*",
+    "llm ~= 0.31.1",
+    "setuptools == 83.*",                   # Required by llm commands to install models
+    "pip ~= 26.1.2",
     "ruff ~= 0.15.0",
     "polars ~= 1.42.1",
     "altair ~= 6.2.2",
@@ -85,6 +83,10 @@ mycli = ["myclirc", "AUTHORS", "SPONSORS", "TIPS"]
 
 [tool.setuptools.packages.find]
 include = ["mycli*"]
+
+[tool.uv]
+exclude-newer = '1 week'
+exclude-newer-package = { cli_helpers = false, openai = false }
 
 [tool.ruff]
 target-version = 'py310'


### PR DESCRIPTION
## Description
Update dependencies to satisfy `uv audit` recommendations, and add a dependency cooldown of one week.

 * update `click` to v8.4.2
 * update `cryptography` to v49.0.0
 * update `pygments` to v2.20.0
 * update `llm` to v0.31.1
 * update `setuptools` to v83.x
 * update `pip` to v26.1.2
 * update `pytest` to v9.1.1
 * add dependency cooldown period
 * exclude `cli_helpers` and `openai` from cooldown

The `click` update contains some breaking changes, but seems to work well.

The `pygments` update changes the list of known MySQL keywords for syntax highlighting, which we already supplement with additional keywords.  It does not yet solve the highlighting bug with terms starting with the string "set", expected in the following release.

The `llm` update was not directly recommended by `uv audit`, but pulls in a more recent version if `idna`.  In addition, we can remove an explicit dependency on `pydantic_core` which was needed to force a newer version and thus a binary wheel, for some platforms.

The dependency cooldown is a defense against supply-chain attacks.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
