### PR TITLE
Remove duplication in dev dependency group

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,7 @@ Internal
 * Exclude `cli_helpers` and `openai` from cooldown
 * Update `sqlglot`/`sqlglotc` to v30.12.0
 * Update `wcwidth` to v0.8.2
+* Remove duplication in dev dependencies.
 
 
 2.6.1 (2026/07/24)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,13 +66,7 @@ dev = [
     "pytest-random-order ~= 1.2.0",
     "tox ~= 4.35.0",
     "pdbpp ~= 0.11.7",
-    "llm ~= 0.31.1",
-    "setuptools == 83.*",                   # Required by llm commands to install models
-    "pip ~= 26.1.2",
     "ruff ~= 0.15.0",
-    "polars ~= 1.42.1",
-    "altair ~= 6.2.2",
-    "vl-convert-python ~= 1.9.0",
 ]
 
 [project.scripts]
@@ -142,7 +136,7 @@ passenv = ['PYTEST_HOST',
            'PYTEST_PORT',
            'PYTEST_CHARSET',
            'GITHUB_ACTION']
-commands = [['uv', 'pip', 'install', '-e', '.[dev,llm]'],
+commands = [['uv', 'pip', 'install', '-e', '.[dev,llm,dataframe]'],
             ['coverage', 'run', '-m', 'pytest', '-v', 'test'],
             ['coverage', 'report', '-m', '--sort=Miss'],
             ['behave', 'test/features']]


### PR DESCRIPTION
## Description
Remove duplication in dev dependency group, depending on `tox` to install from the `llm` and `dataframe` groups for the relevant tests.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
