### PR TITLE
Only ignore min completion trigger for `/command` term itself

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,11 @@ Features
 * Highlight indexed columns in completions with a suffix and/or a text style.
 
 
+Bugfixes
+---------
+* Ignoring `min_completion_trigger` only applies to first token after `/`.
+
+
 Documentation
 ---------
 * Add `.|` and `.>` to TIPS.

--- a/mycli/main_modes/repl.py
+++ b/mycli/main_modes/repl.py
@@ -112,7 +112,7 @@ def complete_while_typing_filter() -> bool:
         return True
     app = get_app()
     text = app.current_buffer.text.lstrip()
-    if text.startswith('/') and not text.startswith('/*'):
+    if text.startswith('/') and not text.startswith('/*') and ' ' not in text:
         return True
     text_len = len(text)
     if text_len < MIN_COMPLETION_TRIGGER:

--- a/test/pytests/test_main_modes_repl.py
+++ b/test/pytests/test_main_modes_repl.py
@@ -288,13 +288,27 @@ def test_complete_while_typing_filter_covers_threshold_and_word_rules(monkeypatc
     assert repl_mode.complete_while_typing_filter() is True
 
 
-def test_complete_while_typing_filter_always_completes_slash_commands(
+@pytest.mark.parametrize(
+    ('text', 'expected'),
+    [
+        ('/', True),
+        ('/d', True),
+        ('/dsn', True),
+        ('  /d', True),
+        ('/dsn ', False),
+        ('/dsn d', False),
+        ('/dsn del', True),
+    ],
+)
+def test_complete_while_typing_filter_bypasses_threshold_for_initial_slash_command_only(
     monkeypatch: pytest.MonkeyPatch,
+    text: str,
+    expected: bool,
 ) -> None:
     monkeypatch.setattr(repl_mode, 'MIN_COMPLETION_TRIGGER', 3)
-    monkeypatch.setattr(repl_mode, 'get_app', lambda: SimpleNamespace(current_buffer=SimpleNamespace(text='/')))
+    monkeypatch.setattr(repl_mode, 'get_app', lambda: SimpleNamespace(current_buffer=SimpleNamespace(text=text)))
 
-    assert repl_mode.complete_while_typing_filter() is True
+    assert repl_mode.complete_while_typing_filter() is expected
 
 
 def test_complete_while_typing_filter_does_not_treat_block_comments_as_slash_commands(


### PR DESCRIPTION
## Description
Ignoring `min_completion_trigger` when the line starts with forward slash helps prompt for possible commands, but the previous implementation suppressed the setting throughout the entire line, applying also to the subcommands and further arguments of `/command`.

Instead, the user's setting should be generally respected, and ignored _only_ for the first term, when `/command` is typed.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
