### PR TITLE
Render tab literals as four spaces in the REPL

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Features
+---------
+* Render tab literals as four spaces in the REPL.
+
+
 2.7.0 (2026/07/25)
 ==============
 

--- a/mycli/main_modes/repl.py
+++ b/mycli/main_modes/repl.py
@@ -33,7 +33,11 @@ from prompt_toolkit.formatted_text import (
     to_plain_text,
 )
 from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.layout.processors import ConditionalProcessor, HighlightMatchingBracketProcessor
+from prompt_toolkit.layout.processors import (
+    ConditionalProcessor,
+    HighlightMatchingBracketProcessor,
+    TabsProcessor,
+)
 from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.output import ColorDepth
 from prompt_toolkit.shortcuts import CompleteStyle, PromptSession
@@ -583,7 +587,9 @@ def _build_prompt_session(
                 ConditionalProcessor(
                     processor=HighlightMatchingBracketProcessor(chars='[](){}'),
                     filter=has_focus(DEFAULT_BUFFER) & ~is_done,
-                )
+                ),
+                # renders tab as four spaces rather than ^I control character
+                TabsProcessor(char1=' ', char2=' '),
             ],
             tempfile_suffix='.sql',
             completer=DynamicCompleter(lambda: mycli.completer),


### PR DESCRIPTION
## Description
Render tab literals as four spaces in the REPL, rather than the `^I` control sequence.  Learned from reading the pgcli source.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
