### PR TITLE
Let cursor shape respond to vi modes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming (TBD)
 Features
 ---------
 * Render tab literals as four spaces in the REPL.
+* Let cursor shape respond to vi modes: _eg_ bar for insert mode.
 
 
 2.7.0 (2026/07/25)

--- a/mycli/main_modes/repl.py
+++ b/mycli/main_modes/repl.py
@@ -23,6 +23,7 @@ import prompt_toolkit
 from prompt_toolkit.application.current import get_app
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory, ThreadedAutoSuggest
 from prompt_toolkit.completion import DynamicCompleter
+from prompt_toolkit.cursor_shapes import CursorShape, ModalCursorShapeConfig
 from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
 from prompt_toolkit.filters import Condition, has_focus, is_done
 from prompt_toolkit.formatted_text import (
@@ -605,6 +606,7 @@ def _build_prompt_session(
             enable_system_prompt=True,
             enable_suspend=True,
             editing_mode=editing_mode,
+            cursor=ModalCursorShapeConfig() if editing_mode == EditingMode.VI else CursorShape.BLOCK,
             search_ignore_case=True,
         )
 


### PR DESCRIPTION
## Description
Let cursor shape respond to vi modes,_eg_ vertical bar for insert mode.  Learned from reading the pgcli source.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
