### PR TITLE
Add Trove classifiers for PyPi

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ Features
 * Render tab literals as four spaces in the REPL.
 
 
+Internal
+---------
+* Add Trove classifiers for PyPi.
+
+
 2.7.0 (2026/07/25)
 ==============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,23 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "BSD-3-Clause"
 authors = [{ name = "Mycli Core Team" }]
+classifiers = [
+    'Environment :: Console',
+    'Intended Audience :: Developers',
+    'Intended Audience :: Science/Research',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
+    'Programming Language :: SQL',
+    'Topic :: Database',
+    'Topic :: Database :: Front-Ends',
+    'Topic :: Software Development',
+]
 
 dependencies = [
     "click ~= 8.4.2",


### PR DESCRIPTION
## Description
Add Trove classifiers for PyPi.  These may have been lost in the transition to `pyproject.toml`.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
