### PR TITLE
Add zsh completions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE.txt *.md *.rst doc/screenshots/*
+recursive-include mycli/resources/completions *
 recursive-include test *.cnf
 recursive-include test *.feature
 recursive-include test *.py

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features
 ---------
 * Render tab literals as four spaces in the REPL.
 * Let cursor shape respond to vi modes: _eg_ bar for insert mode.
+* Add zsh completions which can complete DSN aliases.
 
 
 Internal

--- a/mycli/resources/completions/zsh/_mycli
+++ b/mycli/resources/completions/zsh/_mycli
@@ -1,0 +1,66 @@
+#compdef mycli
+
+_mycli_dsn_aliases() {
+    local -a dsn_aliases
+
+    dsn_aliases=("${(@f)$(env MYCLI_LLM_OFF=1 command mycli --list-dsn 2>/dev/null)}")
+    if (( $#dsn_aliases )); then
+        compadd -V unsorted -a dsn_aliases
+    fi
+}
+
+_mycli_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[mycli] )) && return 1
+
+    case "${words[CURRENT]}" in
+        --dsn=*)
+            compset -P '--dsn='
+            _mycli_dsn_aliases
+            return
+            ;;
+        -d*)
+            compset -P '-d'
+            _mycli_dsn_aliases
+            return
+            ;;
+    esac
+
+    response=("${(@f)$(env MYCLI_LLM_OFF=1 COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _MYCLI_COMPLETE=zsh_complete command mycli)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+
+    if (( CURRENT == 2 )) && [[ "${words[CURRENT]}" != -* ]]; then
+        _mycli_dsn_aliases
+    elif [[ "${words[CURRENT - 1]}" == '-d' || "${words[CURRENT - 1]}" == '--dsn' ]]; then
+        _mycli_dsn_aliases
+    fi
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    _mycli_completion "$@"
+else
+    compdef _mycli_completion mycli
+fi

--- a/test/pytests/test_zsh_completion.py
+++ b/test/pytests/test_zsh_completion.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+
+import pytest
+
+ZSH = shutil.which('zsh')
+COMPLETION_SCRIPT = Path(__file__).parents[2] / 'mycli' / 'resources' / 'completions' / 'zsh' / '_mycli'
+
+
+@pytest.mark.skipif(ZSH is None, reason='zsh is not installed')
+def test_zsh_completion_lists_dsn_aliases_in_supported_contexts(tmp_path: Path) -> None:
+    assert ZSH is not None
+    executable = tmp_path / 'mycli'
+    executable.write_text(
+        '''#!/bin/sh
+if [ "${_MYCLI_COMPLETE:-}" = 'zsh_complete' ]; then
+    printf 'click\\n' >> "$MYCLI_LOG"
+    exit 0
+fi
+if [ "$1" = '--list-dsn' ]; then
+    printf 'list-dsn\\n' >> "$MYCLI_LOG"
+    printf 'prod\\nstaging\\n'
+fi
+''',
+        encoding='utf-8',
+    )
+    executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+    log_path = tmp_path / 'calls.log'
+    environment = {
+        **os.environ,
+        'COMPLETION_SCRIPT': str(COMPLETION_SCRIPT),
+        'MYCLI_LOG': str(log_path),
+        'PATH': f'{tmp_path}{os.pathsep}{os.environ["PATH"]}',
+    }
+
+    result = subprocess.run(
+        [ZSH, '-fc', ZSH_COMPLETION_HARNESS],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    assert result.stdout.splitlines() == [
+        'prod,staging||0',
+        'prod||0',
+        'prod,staging||0',
+        'prod,staging||0',
+        '-dprod|-P -d|0',
+        '--dsn=prod|-P --dsn=|0',
+        '||0',
+        '||0',
+    ]
+    assert log_path.read_text(encoding='utf-8').splitlines().count('list-dsn') == 6
+
+
+ZSH_COMPLETION_HARNESS = r'''
+compdef() { :; }
+_describe() { :; }
+_path_files() { :; }
+
+typeset -a captured compset_calls
+typeset PREFIX IPREFIX used_unambiguous
+compadd() {
+    local array_name=''
+    local candidate
+
+    while (( $# )); do
+        case "$1" in
+            -U)
+                used_unambiguous=1
+                ;;
+            -a)
+                array_name="$2"
+                shift
+                ;;
+        esac
+        shift
+    done
+
+    for candidate in "${(@P)array_name}"; do
+        [[ "$candidate" == "$PREFIX"* ]] && captured+=("$IPREFIX$candidate")
+    done
+}
+compset() {
+    compset_calls+=("$*")
+    IPREFIX="$2"
+    PREFIX="${PREFIX#$IPREFIX}"
+}
+
+source "$COMPLETION_SCRIPT"
+
+run_completion() {
+    captured=()
+    compset_calls=()
+    words=("$@")
+    CURRENT=$#
+    PREFIX="${words[CURRENT]}"
+    IPREFIX=''
+    used_unambiguous=0
+    _mycli_completion
+    print -r -- "${(j:,:)captured}|${(j:,:)compset_calls}|$used_unambiguous"
+}
+
+run_completion mycli ''
+run_completion mycli pro
+run_completion mycli -d ''
+run_completion mycli --dsn ''
+run_completion mycli -dpro
+run_completion mycli --dsn=pro
+run_completion mycli --host ''
+run_completion mycli --host
+'''


### PR DESCRIPTION
## Description

These completions are forked from what `click` generates automatically, with two advantages:

 * LLM support is turned off when dynamically completing, for a huge performance improvement (reduction in lag while typing)
 * DSN aliases can be completed, either in the first position, or after `--dsn` or `-d`

Followups to consider:

 * custom completion on filenames for files typed as strings within our `click` spec, such as `--socket`
 * completing on DSN aliases in any position
 * similar bash and fish completions

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
