### PR TITLE
Improved filename completions for zsh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ A command line client for MySQL with auto-completion and syntax highlighting.
 ├── mycli/packages/string_utils.py        # generic string utilities
 ├── mycli/packages/tabular_output/        # extends cli_helper with additional output formats
 ├── mycli/password_sources.py             # password sources and precedence
+├── mycli/resources/completions/          # shell completions for CLI interface
 ├── mycli/ssh_tunnel.py                   # connecting over a tunnel with `--ssh-jump`
 ├── mycli/schema_prefetcher.py            # background prefetcher for multi-schema auto-completion
 ├── mycli/sqlcompleter.py                 # offers SQL completions

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Features
+---------
+* Improved filename completions for zsh.
+
+
 2.8.0 (2026/07/31)
 ==============
 

--- a/mycli/resources/completions/zsh/_mycli
+++ b/mycli/resources/completions/zsh/_mycli
@@ -16,6 +16,7 @@ _mycli_completion() {
     (( ! $+commands[mycli] )) && return 1
 
     case "${words[CURRENT]}" in
+        # special cases for DSN aliases
         --dsn=*)
             compset -P '--dsn='
             _mycli_dsn_aliases
@@ -24,6 +25,28 @@ _mycli_completion() {
         -d*)
             compset -P '-d'
             _mycli_dsn_aliases
+            return
+            ;;
+        # special cases for files denoted as str types in click
+        # alternatively: make these file types in click
+        --socket=*)
+            compset -P '--socket='
+            _path_files -f
+            return
+            ;;
+        -S*)
+            compset -P '-S'
+            _path_files -f
+            return
+            ;;
+        --checkpoint=*)
+            compset -P '--checkpoint='
+            _path_files -f
+            return
+            ;;
+        --batch=*)
+            compset -P '--batch='
+            _path_files -f
             return
             ;;
     esac
@@ -52,10 +75,18 @@ _mycli_completion() {
         compadd -U -V unsorted -a completions
     fi
 
+    # special cases for DSN aliases
     if (( CURRENT == 2 )) && [[ "${words[CURRENT]}" != -* ]]; then
         _mycli_dsn_aliases
     elif [[ "${words[CURRENT - 1]}" == '-d' || "${words[CURRENT - 1]}" == '--dsn' ]]; then
         _mycli_dsn_aliases
+    # special cases for files denoted as str types in click
+    elif [[ "${words[CURRENT - 1]}" == '-S' || "${words[CURRENT - 1]}" == '--socket' ]]; then
+        _path_files -f
+    elif [[ "${words[CURRENT - 1]}" == '--checkpoint' ]]; then
+        _path_files -f
+    elif [[ "${words[CURRENT - 1]}" == '--batch' ]]; then
+        _path_files -f
     fi
 }
 

--- a/test/pytests/test_zsh_completion.py
+++ b/test/pytests/test_zsh_completion.py
@@ -47,14 +47,18 @@ fi
     )
 
     assert result.stdout.splitlines() == [
-        'prod,staging||0',
-        'prod||0',
-        'prod,staging||0',
-        'prod,staging||0',
-        '-dprod|-P -d|0',
-        '--dsn=prod|-P --dsn=|0',
-        '||0',
-        '||0',
+        'prod,staging||0|',
+        'prod||0|',
+        'prod,staging||0|',
+        'prod,staging||0|',
+        '-dprod|-P -d|0|',
+        '--dsn=prod|-P --dsn=|0|',
+        '||0|',
+        '||0|',
+        '||0|-f',
+        '||0|-f',
+        '|-P --socket=|0|-f',
+        '|-P -S|0|-f',
     ]
     assert log_path.read_text(encoding='utf-8').splitlines().count('list-dsn') == 6
 
@@ -62,9 +66,11 @@ fi
 ZSH_COMPLETION_HARNESS = r'''
 compdef() { :; }
 _describe() { :; }
-_path_files() { :; }
+_path_files() {
+    path_file_calls+=("$*")
+}
 
-typeset -a captured compset_calls
+typeset -a captured compset_calls path_file_calls
 typeset PREFIX IPREFIX used_unambiguous
 compadd() {
     local array_name=''
@@ -98,13 +104,14 @@ source "$COMPLETION_SCRIPT"
 run_completion() {
     captured=()
     compset_calls=()
+    path_file_calls=()
     words=("$@")
     CURRENT=$#
     PREFIX="${words[CURRENT]}"
     IPREFIX=''
     used_unambiguous=0
     _mycli_completion
-    print -r -- "${(j:,:)captured}|${(j:,:)compset_calls}|$used_unambiguous"
+    print -r -- "${(j:,:)captured}|${(j:,:)compset_calls}|$used_unambiguous|${(j:,:)path_file_calls}"
 }
 
 run_completion mycli ''
@@ -115,4 +122,8 @@ run_completion mycli -dpro
 run_completion mycli --dsn=pro
 run_completion mycli --host ''
 run_completion mycli --host
+run_completion mycli --socket ''
+run_completion mycli -S ''
+run_completion mycli --socket=/tmp/mysql
+run_completion mycli -S/tmp/mysql
 '''


### PR DESCRIPTION
## Description

Special-case values which are typed as `str` in `click`, but actually hold files, allowing the values to complete as files at the shell CLI.

Incidentally update `AGENTS.md` with completion resources.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
