### PR TITLE
Improve acceptance of a DSN as a positional argument

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,8 @@ Upcoming (TBD)
 
 Features
 ---------
-* Improved filename completions for zsh.
+* Improve filename completions for zsh.
+* Improve acceptance of a DSN alias as a positional argument.
 
 
 2.8.0 (2026/07/31)

--- a/mycli/cli_runner.py
+++ b/mycli/cli_runner.py
@@ -168,26 +168,23 @@ def run_from_cli_args(cli_args: 'CliArgs', client_factory: ClientFactory) -> Non
     dsn_uri = None
     dsn_password: str | None = None
 
-    # Treat the database argument as a DSN alias only if it matches a configured alias
     # todo why is port tested but not socket?
-    truthy_password = (
-        cli_args.password not in (None, EMPTY_PASSWORD_FLAG_SENTINEL)
-        or cli_args.password_file is not None
-        or os.environ.get('MYSQL_PWD') is not None
-    )
-    if (
-        database
-        and "://" not in database
-        and not any([
+    if database and "://" not in database and database in mycli.config.get("alias_dsn", {}):
+        if any([
             cli_args.user,
-            truthy_password,
             cli_args.host,
             cli_args.port,
+            cli_args.socket,
             cli_args.login_path,
-        ])
-        and database in mycli.config.get("alias_dsn", {})
-    ):
-        cli_args.dsn, database = database, ""
+        ]):
+            if cli_verbosity:
+                click.secho(
+                    f'Interpreting ambiguous database/DSN-alias argument "{database}" as a database name.',
+                    err=True,
+                    fg='yellow',
+                )
+        else:
+            cli_args.dsn, database = database, ""
 
     if database and "://" in database:
         dsn_uri, database = database, ""

--- a/mycli/resources/completions/zsh/_mycli
+++ b/mycli/resources/completions/zsh/_mycli
@@ -9,6 +9,56 @@ _mycli_dsn_aliases() {
     fi
 }
 
+# spelling out the args here is much faster than invoking mycli with _MYCLI_COMPLETE
+_mycli_is_positional_db_arg() {
+    local word
+    local index
+    local short_index
+    local positional_count=0
+    local options_ended=0
+    local expects_value=0
+
+    for (( index = 2; index < CURRENT; index++ )); do
+        word="${words[index]}"
+        if (( expects_value )); then
+            expects_value=0
+            continue
+        fi
+        if (( options_ended )); then
+            (( positional_count++ ))
+            continue
+        fi
+
+        case "$word" in
+            --)
+                options_ended=1
+                ;;
+            --*=*)
+                ;;
+            --host|--hostname|--port|--user|--username|--socket|--pass|--password|--password-file|--vault-address|--vault-mount|--vault-secret|--vault-password-field|--vault-username-field|--ssl-mode|--ssl-ca|--ssl-capath|--ssl-cert|--ssl-key|--ssl-cipher|--tls-version|--database|--dsn|--prompt|--toolbar|--logfile|--checkpoint|--myclirc|--local-infile|--login-path|--execute|--init-command|--charset|--character-set|--batch|--format|--throttle|--use-keyring|--keepalive-ticks|--ssh-jump|--ssh-options)
+                expects_value=1
+                ;;
+            -?*)
+                for (( short_index = 2; short_index <= ${#word}; short_index++ )); do
+                    case "${word[short_index]}" in
+                        h|P|u|S|p|g|e|R|l|D|d)
+                            if (( short_index == ${#word} )); then
+                                expects_value=1
+                            fi
+                            break
+                            ;;
+                    esac
+                done
+                ;;
+            *)
+                (( positional_count++ ))
+                ;;
+        esac
+    done
+
+    (( ! expects_value && positional_count == 0 )) && [[ "${words[CURRENT]}" != -* ]]
+}
+
 _mycli_completion() {
     local -a completions
     local -a completions_with_descriptions
@@ -24,6 +74,17 @@ _mycli_completion() {
             ;;
         -d*)
             compset -P '-d'
+            _mycli_dsn_aliases
+            return
+            ;;
+        # odd feature, but we do accept DSNs in the place of a database name
+        --database=*)
+            compset -P '--database='
+            _mycli_dsn_aliases
+            return
+            ;;
+        -D*)
+            compset -P '-D'
             _mycli_dsn_aliases
             return
             ;;
@@ -76,9 +137,12 @@ _mycli_completion() {
     fi
 
     # special cases for DSN aliases
-    if (( CURRENT == 2 )) && [[ "${words[CURRENT]}" != -* ]]; then
+    if [[ "${words[CURRENT - 1]}" == '-d' || "${words[CURRENT - 1]}" == '--dsn' ]]; then
         _mycli_dsn_aliases
-    elif [[ "${words[CURRENT - 1]}" == '-d' || "${words[CURRENT - 1]}" == '--dsn' ]]; then
+    elif [[ "${words[CURRENT - 1]}" == '-D' || "${words[CURRENT - 1]}" == '--database' ]]; then
+        # odd feature, but we do accept DSNs in the place of a database name
+        _mycli_dsn_aliases
+    elif _mycli_is_positional_db_arg; then
         _mycli_dsn_aliases
     # special cases for files denoted as str types in click
     elif [[ "${words[CURRENT - 1]}" == '-S' || "${words[CURRENT - 1]}" == '--socket' ]]; then

--- a/test/pytests/test_cli_runner.py
+++ b/test/pytests/test_cli_runner.py
@@ -176,54 +176,59 @@ def test_run_from_cli_args_treats_database_as_dsn_alias(monkeypatch: pytest.Monk
     assert connect_call['database'] == 'db'
 
 
-def test_run_from_cli_args_password_file_prevents_positional_dsn_alias(
+def test_run_from_cli_args_reports_ambiguous_database_alias_with_connection_options(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cli_args = make_cli_args()
     cli_args.database = 'prod'
-    cli_args.password_file = 'secret.txt'
+    cli_args.user = 'alice'
     client = DummyMyCli(
         config={
             **default_config(),
             'alias_dsn': {'prod': 'mysql://u:p@h/db'},
         }
     )
-    password_file_calls: list[str | None] = []
-
-    def read_password_file(password_file: str | None) -> str:
-        password_file_calls.append(password_file)
-        return 'file-secret'
-
-    monkeypatch.setattr(main, 'get_password_from_file', read_password_file)
+    secho_calls: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(cli_runner.click, 'secho', lambda text, **kwargs: secho_calls.append((text, kwargs)))
 
     run_with_client(monkeypatch, cli_args, client)
 
-    connect_call = client.connect_calls[-1]
+    assert secho_calls == [
+        (
+            'Interpreting ambiguous database/DSN-alias argument "prod" as a database name.',
+            {'err': True, 'fg': 'yellow'},
+        )
+    ]
     assert client.dsn_alias is None
-    assert connect_call['database'] == 'prod'
-    assert resolve_connect_password(connect_call) == ('file', 'file-secret')
-    assert password_file_calls == ['secret.txt']
+    assert client.connect_calls[-1]['database'] == 'prod'
 
 
-def test_run_from_cli_args_mysql_pwd_prevents_positional_dsn_alias(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_run_from_cli_args_loads_password_from_file(monkeypatch: pytest.MonkeyPatch) -> None:
     cli_args = make_cli_args()
-    cli_args.database = 'prod'
-    client = DummyMyCli(
-        config={
-            **default_config(),
-            'alias_dsn': {'prod': 'mysql://u:p@h/db'},
-        }
-    )
+    cli_args.password_file = 'password.txt'
+    client = DummyMyCli()
+    password_file_calls: list[str] = []
+
+    def get_password_from_file(path: str) -> str:
+        password_file_calls.append(path)
+        return 'file-secret'
+
+    monkeypatch.setattr(main, 'get_password_from_file', get_password_from_file)
+
+    run_with_client(monkeypatch, cli_args, client)
+
+    assert resolve_connect_password(client.connect_calls[-1]) == ('file', 'file-secret')
+    assert password_file_calls == ['password.txt']
+
+
+def test_run_from_cli_args_uses_mysql_pwd_password(monkeypatch: pytest.MonkeyPatch) -> None:
+    cli_args = make_cli_args()
+    client = DummyMyCli()
     monkeypatch.setenv('MYSQL_PWD', 'environment-secret')
 
     run_with_client(monkeypatch, cli_args, client)
 
-    connect_call = client.connect_calls[-1]
-    assert client.dsn_alias is None
-    assert connect_call['database'] == 'prod'
-    assert resolve_connect_password(connect_call) == ('environment', 'environment-secret')
+    assert resolve_connect_password(client.connect_calls[-1]) == ('environment', 'environment-secret')
 
 
 def test_run_from_cli_args_keeps_empty_cli_password_over_dsn(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/test/pytests/test_zsh_completion.py
+++ b/test/pytests/test_zsh_completion.py
@@ -59,8 +59,19 @@ fi
         '||0|-f',
         '|-P --socket=|0|-f',
         '|-P -S|0|-f',
+        'prod,staging||0|',
+        'prod,staging||0|',
+        '-Dprod|-P -D|0|',
+        '--database=prod|-P --database=|0|',
+        'prod||0|',
+        'staging||0|',
+        'prod||0|',
+        '||0|',
+        '||0|',
+        'prod||0|',
+        '||0|',
     ]
-    assert log_path.read_text(encoding='utf-8').splitlines().count('list-dsn') == 6
+    assert log_path.read_text(encoding='utf-8').splitlines().count('list-dsn') == 14
 
 
 ZSH_COMPLETION_HARNESS = r'''
@@ -126,4 +137,15 @@ run_completion mycli --socket ''
 run_completion mycli -S ''
 run_completion mycli --socket=/tmp/mysql
 run_completion mycli -S/tmp/mysql
+run_completion mycli -D ''
+run_completion mycli --database ''
+run_completion mycli -Dpro
+run_completion mycli --database=pro
+run_completion mycli --host db pro
+run_completion mycli --ssl-mode auto sta
+run_completion mycli -- prod
+run_completion mycli --host pro
+run_completion mycli --ssl-mode sta
+run_completion mycli -vP 3306 pro
+run_completion mycli prod --host db other
 '''


### PR DESCRIPTION
## Description
 * Don't let a `--password` argument indicate that an ambiguous DSN alias is a database name.  We generally expect passwords to be given separately from a DSN.
 * Do let an explicit `--socket` argument suggest that an ambiguous argument is a database name rather than a DSN alias.
 * Emit a warning on taking an ambiguous argument to be a database name, when it also exists as a DSN alias.
 * Complete DSN aliases as positional arguments outside of the first position in zsh.
 * Accept DSN aliases as zsh completions after `--database` or `-D`.  This is weird, but we do accept DSNs there, so we might as well offer the completions.

There is some effect on non-positional DSN values, but the changes mostly concern positional arguments.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
