### PR TITLE
Add bash completions which complete DSN aliases

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features
 ---------
 * Improve filename completions for zsh.
 * Improve acceptance of a DSN alias as a positional argument.
+* Add bash completions which can complete DSN aliases.
 
 
 2.8.0 (2026/07/31)

--- a/mycli/resources/completions/bash/mycli
+++ b/mycli/resources/completions/bash/mycli
@@ -1,0 +1,169 @@
+_mycli_append_dsn_aliases() {
+    local insert_prefix="$1"
+    local incomplete="$2"
+    local alias
+
+    while IFS= read -r alias; do
+        if [[ -n "$alias" && "$alias" == "$incomplete"* ]]; then
+            COMPREPLY+=("${insert_prefix}${alias}")
+        fi
+    done < <(env MYCLI_LLM_OFF=1 mycli --list-dsn 2>/dev/null)
+}
+
+# Spelling out the args here is much faster than invoking mycli with _MYCLI_COMPLETE.
+_mycli_is_positional_db_arg() {
+    local word
+    local index
+    local short_index
+    local short_option
+    local positional_count=0
+    local options_ended=0
+    local expects_value=0
+
+    for (( index = 1; index < COMP_CWORD; index++ )); do
+        word="${COMP_WORDS[index]}"
+        if (( expects_value )); then
+            expects_value=0
+            continue
+        fi
+        if (( options_ended )); then
+            (( positional_count += 1 ))
+            continue
+        fi
+
+        case "$word" in
+            --)
+                options_ended=1
+                ;;
+            --*=*)
+                ;;
+            --host|--hostname|--port|--user|--username|--socket|--pass|--password|--password-file|--vault-address|--vault-mount|--vault-secret|--vault-password-field|--vault-username-field|--ssl-mode|--ssl-ca|--ssl-capath|--ssl-cert|--ssl-key|--ssl-cipher|--tls-version|--database|--dsn|--prompt|--toolbar|--logfile|--checkpoint|--myclirc|--local-infile|--login-path|--execute|--init-command|--charset|--character-set|--batch|--format|--throttle|--use-keyring|--keepalive-ticks|--ssh-jump|--ssh-options)
+                expects_value=1
+                ;;
+            -?*)
+                for (( short_index = 1; short_index < ${#word}; short_index++ )); do
+                    short_option="${word:short_index:1}"
+                    case "$short_option" in
+                        h|P|u|S|p|g|e|R|l|D|d)
+                            if (( short_index == ${#word} - 1 )); then
+                                expects_value=1
+                            fi
+                            break
+                            ;;
+                    esac
+                done
+                ;;
+            *)
+                (( positional_count += 1 ))
+                ;;
+        esac
+    done
+
+    (( ! expects_value && positional_count == 0 )) && [[ "${COMP_WORDS[COMP_CWORD]}" != -* ]]
+}
+
+_mycli_complete_paths() {
+    local insert_prefix="$1"
+    local incomplete="$2"
+    local path
+    local -a paths=()
+
+    mapfile -t paths < <(compgen -f -- "$incomplete")
+    for path in "${paths[@]}"; do
+        COMPREPLY+=("${insert_prefix}${path}")
+    done
+    compopt -o filenames 2>/dev/null || true
+}
+
+_mycli_add_click_completions() {
+    local response
+    local type
+    local value
+
+    response=$(env MYCLI_LLM_OFF=1 COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD="$COMP_CWORD" _MYCLI_COMPLETE=bash_complete mycli)
+    while IFS=, read -r type value; do
+        case "$type" in
+            dir)
+                COMPREPLY=()
+                compopt -o dirnames
+                ;;
+            file)
+                COMPREPLY=()
+                compopt -o default
+                ;;
+            plain)
+                COMPREPLY+=("$value")
+                ;;
+        esac
+    done <<< "$response"
+}
+
+_mycli_completion() {
+    local current="${COMP_WORDS[COMP_CWORD]}"
+    local previous=''
+    COMPREPLY=()
+
+    command -v mycli >/dev/null 2>&1 || return 1
+    if (( COMP_CWORD > 0 )); then
+        previous="${COMP_WORDS[COMP_CWORD - 1]}"
+    fi
+
+    case "$current" in
+        --dsn=*)
+            _mycli_append_dsn_aliases '--dsn=' "${current#--dsn=}"
+            return
+            ;;
+        -d*)
+            _mycli_append_dsn_aliases '-d' "${current#-d}"
+            return
+            ;;
+        --database=*)
+            _mycli_append_dsn_aliases '--database=' "${current#--database=}"
+            return
+            ;;
+        -D*)
+            _mycli_append_dsn_aliases '-D' "${current#-D}"
+            return
+            ;;
+        --socket=*)
+            _mycli_complete_paths '--socket=' "${current#--socket=}"
+            return
+            ;;
+        -S*)
+            _mycli_complete_paths '-S' "${current#-S}"
+            return
+            ;;
+        --checkpoint=*)
+            _mycli_complete_paths '--checkpoint=' "${current#--checkpoint=}"
+            return
+            ;;
+        --batch=*)
+            _mycli_complete_paths '--batch=' "${current#--batch=}"
+            return
+            ;;
+    esac
+
+    _mycli_add_click_completions
+
+    case "$previous" in
+        -d|--dsn|-D|--database)
+            _mycli_append_dsn_aliases '' "$current"
+            ;;
+        -S|--socket|--checkpoint|--batch)
+            _mycli_complete_paths '' "$current"
+            ;;
+        *)
+            if _mycli_is_positional_db_arg; then
+                _mycli_append_dsn_aliases '' "$current"
+            fi
+            ;;
+    esac
+
+    return 0
+}
+
+_mycli_completion_setup() {
+    complete -F _mycli_completion mycli
+}
+
+_mycli_completion_setup;

--- a/test/pytests/test_bash_completion.py
+++ b/test/pytests/test_bash_completion.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+
+import pytest
+
+
+def find_supported_bash() -> str | None:
+    candidates = [
+        os.environ.get('MYCLI_TEST_BASH'),
+        '/opt/homebrew/bin/bash',
+        '/opt/local/bin/bash',
+        '/usr/local/bin/bash',
+        shutil.which('bash5'),
+        shutil.which('bash4'),
+        shutil.which('bash'),
+    ]
+    for candidate in dict.fromkeys(candidates):
+        if candidate is None or not Path(candidate).is_file():
+            continue
+        version_check = subprocess.run(
+            # completions mostly work with bash 3 but some tests would fail to match
+            [candidate, '-c', '(( BASH_VERSINFO[0] > 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 4) ))'],
+            check=False,
+        )
+        if version_check.returncode == 0:
+            return candidate
+    return None
+
+
+BASH = find_supported_bash()
+COMPLETION_SCRIPT = Path(__file__).parents[2] / 'mycli' / 'resources' / 'completions' / 'bash' / 'mycli'
+
+
+@pytest.mark.skipif(BASH is None, reason='Bash 4.4 or newer is not installed')
+def test_bash_completion_matches_mycli_completion_behavior(tmp_path: Path) -> None:
+    assert BASH is not None
+    executable = tmp_path / 'mycli'
+    executable.write_text(
+        '''#!/bin/sh
+if [ "${_MYCLI_COMPLETE:-}" = 'bash_complete' ]; then
+    printf 'click\\n' >> "$MYCLI_LOG"
+    if [ "$COMP_WORDS" = 'mycli --s' ]; then
+        printf 'plain,--socket\\nplain,--ssl-mode\\n'
+    fi
+    exit 0
+fi
+if [ "$1" = '--list-dsn' ]; then
+    printf 'list-dsn\\n' >> "$MYCLI_LOG"
+    printf 'prod\\nstaging\\n'
+fi
+''',
+        encoding='utf-8',
+    )
+    executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+    (tmp_path / 'mysql.sock').touch()
+    (tmp_path / 'space socket.sock').touch()
+    (tmp_path / 'batch.sql').touch()
+    log_path = tmp_path / 'calls.log'
+    environment = {
+        **os.environ,
+        'COMPLETION_SCRIPT': str(COMPLETION_SCRIPT),
+        'MYCLI_LOG': str(log_path),
+        'PATH': f'{tmp_path}{os.pathsep}{os.environ.get("PATH", "")}',
+    }
+
+    result = subprocess.run(
+        [BASH, '--noprofile', '--norc', '-c', BASH_COMPLETION_HARNESS],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env=environment,
+    )
+
+    assert result.stdout.splitlines() == [
+        'complete -F _mycli_completion mycli',
+        'generic|reply<--socket><--ssl-mode>|compopt',
+        'bare|reply<prod>|compopt',
+        'dsn-separate|reply<prod><staging>|compopt',
+        'dsn-attached|reply<-dprod>|compopt',
+        'database-separate|reply<staging>|compopt',
+        'database-attached|reply<--database=prod>|compopt',
+        'after-host|reply<prod>|compopt',
+        'host-value|reply|compopt',
+        'after-double-dash|reply<staging>|compopt',
+        'after-positional|reply|compopt',
+        'clustered-option|reply<prod>|compopt',
+        'socket-separate|reply<mysql.sock>|compopt<-o filenames>',
+        'socket-attached|reply<--socket=space socket.sock>|compopt<-o filenames>',
+        'socket-short-attached|reply<-Smysql.sock>|compopt<-o filenames>',
+        'checkpoint-separate|reply<batch.sql>|compopt<-o filenames>',
+        'batch-attached|reply<--batch=batch.sql>|compopt<-o filenames>',
+    ]
+    assert log_path.read_text(encoding='utf-8').splitlines().count('list-dsn') == 8
+
+
+BASH_COMPLETION_HARNESS = r'''
+compopt() {
+    compopt_calls+=("$*")
+}
+
+source "$COMPLETION_SCRIPT"
+complete -p mycli
+
+run_completion() {
+    local label="$1"
+    local reply
+    local call
+    shift
+    COMP_WORDS=("$@")
+    COMP_CWORD=$((${#COMP_WORDS[@]} - 1))
+    compopt_calls=()
+    _mycli_completion
+
+    printf '%s|reply' "$label"
+    for reply in "${COMPREPLY[@]}"; do
+        printf '<%s>' "$reply"
+    done
+    printf '|compopt'
+    for call in "${compopt_calls[@]}"; do
+        printf '<%s>' "$call"
+    done
+    printf '\n'
+}
+
+run_completion generic mycli --s
+run_completion bare mycli pro
+run_completion dsn-separate mycli -d ''
+run_completion dsn-attached mycli -dpro
+run_completion database-separate mycli --database sta
+run_completion database-attached mycli --database=pro
+run_completion after-host mycli --host db pro
+run_completion host-value mycli --host pro
+run_completion after-double-dash mycli -- sta
+run_completion after-positional mycli prod --host db other
+run_completion clustered-option mycli -vP 3306 pro
+run_completion socket-separate mycli --socket mysql
+run_completion socket-attached mycli '--socket=space'
+run_completion socket-short-attached mycli -Smysql
+run_completion checkpoint-separate mycli --checkpoint batch
+run_completion batch-attached mycli --batch=bat
+'''


### PR DESCRIPTION
## Description
Ported from the zsh completions, these bash completions are much more performant than the default due to turning off LLM support.

These completions also can complete dynamically on the user's saved DSN aliases.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
