### PR TITLE
Add fish completions which complete DSN aliases

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Features
 * Improve filename completions for zsh.
 * Improve acceptance of a DSN alias as a positional argument.
 * Add bash completions which can complete DSN aliases.
+* Add fish completions which can complete DSN aliases.
 
 
 2.8.0 (2026/07/31)

--- a/mycli/resources/completions/fish/mycli.fish
+++ b/mycli/resources/completions/fish/mycli.fish
@@ -1,0 +1,132 @@
+function _mycli_dsn_aliases --argument-names insert_prefix incomplete
+    env MYCLI_LLM_OFF=1 mycli --list-dsn 2>/dev/null | while read -l alias
+        if test -n "$alias"; and test (string sub -s 1 -l (string length -- "$incomplete") -- "$alias") = "$incomplete"
+            printf '%s%s\n' "$insert_prefix" "$alias"
+        end
+    end
+end
+
+# Spelling out the args here is much faster than invoking mycli with _MYCLI_COMPLETE.
+function _mycli_is_positional_db_arg
+    set -l words (commandline -opc)
+    set -l current (commandline -ct)
+    set -l positional_count 0
+    set -l options_ended 0
+    set -l expects_value 0
+
+    for word in $words[2..-1]
+        if test $expects_value -eq 1
+            set expects_value 0
+            continue
+        end
+        if test $options_ended -eq 1
+            set positional_count (math $positional_count + 1)
+            continue
+        end
+
+        switch "$word"
+            case --
+                set options_ended 1
+            case '--*=*'
+            case --host --hostname --port --user --username --socket --pass --password --password-file --vault-address --vault-mount --vault-secret --vault-password-field --vault-username-field --ssl-mode --ssl-ca --ssl-capath --ssl-cert --ssl-key --ssl-cipher --tls-version --database --dsn --prompt --toolbar --logfile --checkpoint --myclirc --local-infile --login-path --execute --init-command --charset --character-set --batch --format --throttle --use-keyring --keepalive-ticks --ssh-jump --ssh-options
+                set expects_value 1
+            case '-*'
+                set -l option_length (string length -- "$word")
+                if test $option_length -eq 1
+                    set positional_count (math $positional_count + 1)
+                    continue
+                end
+                for short_index in (seq 2 $option_length)
+                    set -l short_option (string sub -s $short_index -l 1 -- "$word")
+                    if contains -- "$short_option" h P u S p g e R l D d
+                        if test $short_index -eq $option_length
+                            set expects_value 1
+                        end
+                        break
+                    end
+                end
+            case '*'
+                set positional_count (math $positional_count + 1)
+        end
+    end
+
+    test $expects_value -eq 0; and test $positional_count -eq 0; and not string match -q -- '-*' "$current"
+end
+
+function _mycli_complete_paths --argument-names insert_prefix incomplete
+    __fish_complete_path "$incomplete" | while read -l candidate
+        printf '%s%s\n' "$insert_prefix" "$candidate"
+    end
+end
+
+function _mycli_click_completions
+    set -l response (env MYCLI_LLM_OFF=1 _MYCLI_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -ct) mycli)
+
+    for completion in $response
+        set -l metadata (string split -m 1 ',' -- "$completion")
+        switch "$metadata[1]"
+            case dir
+                __fish_complete_directories "$metadata[2]"
+            case file
+                __fish_complete_path "$metadata[2]"
+            case plain
+                echo "$metadata[2]"
+        end
+    end
+end
+
+function _mycli_completion
+    command -q mycli; or return 1
+
+    set -l current (commandline -ct)
+    set -l words (commandline -opc)
+    set -l previous ''
+    if test (count $words) -gt 1
+        set previous "$words[-1]"
+    end
+
+    switch "$current"
+        case '--dsn=*'
+            _mycli_dsn_aliases '--dsn=' (string replace -- '--dsn=' '' "$current")
+            return
+        case '-d*'
+            _mycli_dsn_aliases '-d' (string sub -s 3 -- "$current")
+            return
+        case '--database=*'
+            _mycli_dsn_aliases '--database=' (string replace -- '--database=' '' "$current")
+            return
+        case '-D*'
+            _mycli_dsn_aliases '-D' (string sub -s 3 -- "$current")
+            return
+        case '--socket=*'
+            _mycli_complete_paths '--socket=' (string replace -- '--socket=' '' "$current")
+            return
+        case '-S*'
+            _mycli_complete_paths '-S' (string sub -s 3 -- "$current")
+            return
+        case '--checkpoint=*'
+            _mycli_complete_paths '--checkpoint=' (string replace -- '--checkpoint=' '' "$current")
+            return
+        case '--batch=*'
+            _mycli_complete_paths '--batch=' (string replace -- '--batch=' '' "$current")
+            return
+    end
+
+    _mycli_click_completions
+
+    switch "$previous"
+        case -d --dsn -D --database
+            _mycli_dsn_aliases '' "$current"
+        case -S --socket --checkpoint --batch
+            _mycli_complete_paths '' "$current"
+        case '*'
+            if _mycli_is_positional_db_arg
+                _mycli_dsn_aliases '' "$current"
+            end
+    end
+end
+
+# erase supplied completions which only work for --dsn
+complete --erase --command mycli
+
+complete --no-files --keep-order --command mycli --arguments '(_mycli_completion)'

--- a/test/pytests/test_fish_completion.py
+++ b/test/pytests/test_fish_completion.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+
+import pytest
+
+FISH = shutil.which('fish')
+COMPLETION_SCRIPT = Path(__file__).parents[2] / 'mycli' / 'resources' / 'completions' / 'fish' / 'mycli.fish'
+
+
+@pytest.mark.skipif(FISH is None, reason='Fish is not installed')
+def test_fish_completion_matches_mycli_completion_behavior(tmp_path: Path) -> None:
+    assert FISH is not None
+    executable = tmp_path / 'mycli'
+    executable.write_text(
+        '''#!/bin/sh
+if [ "${_MYCLI_COMPLETE:-}" = 'fish_complete' ]; then
+    printf 'click\n' >> "$MYCLI_LOG"
+    if [ "$COMP_CWORD" = '--s' ]; then
+        printf 'plain,--socket\tSocket file\nplain,--ssl-mode\tTLS mode\n'
+    fi
+    exit 0
+fi
+if [ "$1" = '--list-dsn' ]; then
+    printf 'list-dsn\n' >> "$MYCLI_LOG"
+    printf 'prod\nstaging\n'
+fi
+''',
+        encoding='utf-8',
+    )
+    executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+    (tmp_path / 'mysql.sock').touch()
+    (tmp_path / 'space socket.sock').touch()
+    (tmp_path / 'batch.sql').touch()
+    log_path = tmp_path / 'calls.log'
+    environment = {
+        **os.environ,
+        'COMPLETION_SCRIPT': str(COMPLETION_SCRIPT),
+        'MYCLI_LOG': str(log_path),
+        'PATH': f'{tmp_path}{os.pathsep}{os.environ.get("PATH", "")}',
+    }
+
+    result = subprocess.run(
+        [FISH, '--no-config', '-c', FISH_COMPLETION_HARNESS],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env=environment,
+    )
+
+    assert result.stdout.splitlines() == [
+        'generic|--socket\tSocket file|--ssl-mode\tTLS mode',
+        'bare|prod',
+        'dsn-separate|prod|staging',
+        'dsn-long-separate|prod',
+        'dsn-attached|-dprod',
+        'dsn-long-attached|--dsn=prod',
+        'database-separate|staging',
+        'database-short-separate|staging',
+        'database-short-attached|-Dprod',
+        'database-attached|--database=prod',
+        'after-host|prod',
+        'host-value',
+        'after-double-dash|staging',
+        'after-positional',
+        'clustered-option|prod',
+        'socket-separate|mysql.sock',
+        'socket-attached|--socket=space socket.sock',
+        'socket-short-separate|space socket.sock',
+        'socket-short-attached|-Smysql.sock',
+        'checkpoint-separate|batch.sql',
+        'checkpoint-attached|--checkpoint=batch.sql',
+        'batch-separate|batch.sql',
+        'batch-attached|--batch=batch.sql',
+    ]
+    assert log_path.read_text(encoding='utf-8').splitlines().count('list-dsn') == 12
+
+
+FISH_COMPLETION_HARNESS = r'''
+complete --erase --command mycli
+source "$COMPLETION_SCRIPT"
+
+function run_completion --argument-names label command
+    printf '%s' "$label"
+    for candidate in (complete -C "$command")
+        printf '|%s' "$candidate"
+    end
+    printf '\n'
+end
+
+run_completion generic 'mycli --s'
+run_completion bare 'mycli pro'
+run_completion dsn-separate 'mycli -d '
+run_completion dsn-long-separate 'mycli --dsn pro'
+run_completion dsn-attached 'mycli -dpro'
+run_completion dsn-long-attached 'mycli --dsn=pro'
+run_completion database-separate 'mycli --database sta'
+run_completion database-short-separate 'mycli -D sta'
+run_completion database-short-attached 'mycli -Dpro'
+run_completion database-attached 'mycli --database=pro'
+run_completion after-host 'mycli --host db pro'
+run_completion host-value 'mycli --host pro'
+run_completion after-double-dash 'mycli -- sta'
+run_completion after-positional 'mycli prod --host db other'
+run_completion clustered-option 'mycli -vP 3306 pro'
+run_completion socket-separate 'mycli --socket mysql'
+run_completion socket-attached 'mycli --socket=space'
+run_completion socket-short-separate 'mycli -S space'
+run_completion socket-short-attached 'mycli -Smysql'
+run_completion checkpoint-separate 'mycli --checkpoint batch'
+run_completion checkpoint-attached 'mycli --checkpoint=bat'
+run_completion batch-separate 'mycli --batch batch'
+run_completion batch-attached 'mycli --batch=bat'
+'''


### PR DESCRIPTION
## Description
Ported from the zsh completions, these fish completions are much more performant than the default which would be generated from `click`, due to turning off LLM support.

These completions also can complete dynamically on the user's saved DSN aliases.

Existing mycli completions are deleted since fish apparently supplies a minimal mycli completion function which only completes `--dsn`.


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
