### PR TITLE
Make some imports lazy in Python 3.15

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ Features
 * Improve acceptance of a DSN alias as a positional argument.
 * Add bash completions which can complete DSN aliases.
 * Add fish completions which can complete DSN aliases.
+* Support Python 3.15 lazy imports for startup performance.
 
 
 2.8.0 (2026/07/31)

--- a/mycli/cli_runner.py
+++ b/mycli/cli_runner.py
@@ -1,5 +1,23 @@
 from __future__ import annotations
 
+__lazy_modules__ = [
+    'io',
+    're',
+    'sys',
+    'typing',
+    'urllib.parse',
+    'click',
+    'mycli.config',
+    'mycli.constants',
+    'mycli.main_modes.batch',
+    'mycli.main_modes.checkup',
+    'mycli.main_modes.execute',
+    'mycli.main_modes.list_dsn',
+    'mycli.packages.cli_utils',
+    'mycli.password_sources',
+    'mycli.vault',
+]
+
 import os
 import re
 import sys

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -1,5 +1,20 @@
 from __future__ import annotations
 
+__lazy_modules__ = [
+    'dataclasses',
+    'io',
+    'sys',
+    'textwrap',
+    'typing',
+    'click',
+    'clickdc',
+    'mycli',
+    'mycli.cli_runner',
+    'mycli.client',
+    'mycli.constants',
+    'mycli.packages.cli_utils',
+]
+
 from dataclasses import dataclass
 from io import TextIOWrapper
 import os

--- a/mycli/packages/special/__init__.py
+++ b/mycli/packages/special/__init__.py
@@ -1,3 +1,10 @@
+__lazy_modules__ = [
+    'mycli.packages.special.dbcommands',
+    'mycli.packages.special.iocommands',
+    'mycli.packages.special.llm',
+    'mycli.packages.special.main',
+]
+
 import os
 
 from mycli.packages.special.dbcommands import (

--- a/mycli/packages/special/llm.py
+++ b/mycli/packages/special/llm.py
@@ -1,3 +1,7 @@
+__lazy_modules__ = [
+    'llm',
+]
+
 import contextlib
 import functools
 import io


### PR DESCRIPTION
## Description
Using the backward-compatible `__lazy_modules__` array, mark some imports as lazy, focusing on the main entrypoint, special commands, and LLM support.

Testing with a prerelease of Python 3.15, a simple `mycli --help` is more than 10x faster with these changes.  This will also be a great benefit to dynamic shell completions.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
