### PR TITLE
Add a `--completions` argument to emit shell completion scripts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ Features
 * Add bash completions which can complete DSN aliases.
 * Add fish completions which can complete DSN aliases.
 * Support Python 3.15 lazy imports for startup performance.
+* Add a `--completions` argument to emit a shell completion script.
 
 
 2.8.0 (2026/07/31)

--- a/mycli/cli_runner.py
+++ b/mycli/cli_runner.py
@@ -11,6 +11,7 @@ __lazy_modules__ = [
     'mycli.constants',
     'mycli.main_modes.batch',
     'mycli.main_modes.checkup',
+    'mycli.main_modes.completions',
     'mycli.main_modes.execute',
     'mycli.main_modes.list_dsn',
     'mycli.packages.cli_utils',
@@ -30,6 +31,7 @@ from mycli.config import str_to_bool
 from mycli.constants import EMPTY_PASSWORD_FLAG_SENTINEL
 from mycli.main_modes.batch import main_batch_from_stdin, main_batch_with_progress_bar, main_batch_without_progress_bar
 from mycli.main_modes.checkup import main_checkup
+from mycli.main_modes.completions import main_completions
 from mycli.main_modes.execute import main_execute_from_cli
 from mycli.main_modes.list_dsn import main_list_dsn
 from mycli.packages.cli_utils import is_valid_connection_scheme
@@ -141,6 +143,10 @@ def expand_dsn_alias_env_vars(
 
 def run_from_cli_args(cli_args: 'CliArgs', client_factory: ClientFactory) -> None:
     from mycli import main as main_module
+
+    if cli_args.completions:
+        main_completions(cli_args.completions)
+        return
 
     cli_verbosity = main_module.preprocess_cli_args(cli_args, is_valid_connection_scheme)
 

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -185,6 +185,10 @@ class CliArgs:
         is_flag=True,
         help='Show list of DSN aliases configured in the [alias_dsn] section of ~/.myclirc.',
     )
+    completions: str | None = clickdc.option(
+        type=click.Choice(['bash', 'zsh', 'fish']),
+        help='Print a completion script for the selected shell.',
+    )
     prompt: str | None = clickdc.option(
         '-R',
         type=str,

--- a/mycli/main_modes/completions.py
+++ b/mycli/main_modes/completions.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from importlib import resources
+
+import mycli as mycli_package
+
+COMPLETION_PATHS = {
+    'bash': ('resources', 'completions', 'bash', 'mycli'),
+    'zsh': ('resources', 'completions', 'zsh', '_mycli'),
+    'fish': ('resources', 'completions', 'fish', 'mycli.fish'),
+}
+
+
+def main_completions(shell: str) -> None:
+    completion_path = resources.files(mycli_package).joinpath(*COMPLETION_PATHS[shell])
+    print(completion_path.read_text(), end='')

--- a/mycli/resources/completions/bash/mycli
+++ b/mycli/resources/completions/bash/mycli
@@ -37,7 +37,7 @@ _mycli_is_positional_db_arg() {
                 ;;
             --*=*)
                 ;;
-            --host|--hostname|--port|--user|--username|--socket|--pass|--password|--password-file|--vault-address|--vault-mount|--vault-secret|--vault-password-field|--vault-username-field|--ssl-mode|--ssl-ca|--ssl-capath|--ssl-cert|--ssl-key|--ssl-cipher|--tls-version|--database|--dsn|--prompt|--toolbar|--logfile|--checkpoint|--myclirc|--local-infile|--login-path|--execute|--init-command|--charset|--character-set|--batch|--format|--throttle|--use-keyring|--keepalive-ticks|--ssh-jump|--ssh-options)
+            --host|--hostname|--port|--user|--username|--socket|--pass|--password|--password-file|--vault-address|--vault-mount|--vault-secret|--vault-password-field|--vault-username-field|--ssl-mode|--ssl-ca|--ssl-capath|--ssl-cert|--ssl-key|--ssl-cipher|--tls-version|--database|--dsn|--completions|--prompt|--toolbar|--logfile|--checkpoint|--myclirc|--local-infile|--login-path|--execute|--init-command|--charset|--character-set|--batch|--format|--throttle|--use-keyring|--keepalive-ticks|--ssh-jump|--ssh-options)
                 expects_value=1
                 ;;
             -?*)

--- a/mycli/resources/completions/fish/mycli.fish
+++ b/mycli/resources/completions/fish/mycli.fish
@@ -28,7 +28,7 @@ function _mycli_is_positional_db_arg
             case --
                 set options_ended 1
             case '--*=*'
-            case --host --hostname --port --user --username --socket --pass --password --password-file --vault-address --vault-mount --vault-secret --vault-password-field --vault-username-field --ssl-mode --ssl-ca --ssl-capath --ssl-cert --ssl-key --ssl-cipher --tls-version --database --dsn --prompt --toolbar --logfile --checkpoint --myclirc --local-infile --login-path --execute --init-command --charset --character-set --batch --format --throttle --use-keyring --keepalive-ticks --ssh-jump --ssh-options
+            case --host --hostname --port --user --username --socket --pass --password --password-file --vault-address --vault-mount --vault-secret --vault-password-field --vault-username-field --ssl-mode --ssl-ca --ssl-capath --ssl-cert --ssl-key --ssl-cipher --tls-version --database --dsn --completions --prompt --toolbar --logfile --checkpoint --myclirc --local-infile --login-path --execute --init-command --charset --character-set --batch --format --throttle --use-keyring --keepalive-ticks --ssh-jump --ssh-options
                 set expects_value 1
             case '-*'
                 set -l option_length (string length -- "$word")

--- a/mycli/resources/completions/zsh/_mycli
+++ b/mycli/resources/completions/zsh/_mycli
@@ -35,7 +35,7 @@ _mycli_is_positional_db_arg() {
                 ;;
             --*=*)
                 ;;
-            --host|--hostname|--port|--user|--username|--socket|--pass|--password|--password-file|--vault-address|--vault-mount|--vault-secret|--vault-password-field|--vault-username-field|--ssl-mode|--ssl-ca|--ssl-capath|--ssl-cert|--ssl-key|--ssl-cipher|--tls-version|--database|--dsn|--prompt|--toolbar|--logfile|--checkpoint|--myclirc|--local-infile|--login-path|--execute|--init-command|--charset|--character-set|--batch|--format|--throttle|--use-keyring|--keepalive-ticks|--ssh-jump|--ssh-options)
+            --host|--hostname|--port|--user|--username|--socket|--pass|--password|--password-file|--vault-address|--vault-mount|--vault-secret|--vault-password-field|--vault-username-field|--ssl-mode|--ssl-ca|--ssl-capath|--ssl-cert|--ssl-key|--ssl-cipher|--tls-version|--database|--dsn|--completions|--prompt|--toolbar|--logfile|--checkpoint|--myclirc|--local-infile|--login-path|--execute|--init-command|--charset|--character-set|--batch|--format|--throttle|--use-keyring|--keepalive-ticks|--ssh-jump|--ssh-options)
                 expects_value=1
                 ;;
             -?*)

--- a/test/pytests/test_bash_completion.py
+++ b/test/pytests/test_bash_completion.py
@@ -46,6 +46,8 @@ if [ "${_MYCLI_COMPLETE:-}" = 'bash_complete' ]; then
     printf 'click\\n' >> "$MYCLI_LOG"
     if [ "$COMP_WORDS" = 'mycli --s' ]; then
         printf 'plain,--socket\\nplain,--ssl-mode\\n'
+    elif [ "$COMP_WORDS" = 'mycli --completions ba' ]; then
+        printf 'plain,bash\\n'
     fi
     exit 0
 fi
@@ -80,6 +82,7 @@ fi
     assert result.stdout.splitlines() == [
         'complete -F _mycli_completion mycli',
         'generic|reply<--socket><--ssl-mode>|compopt',
+        'completions|reply<bash>|compopt',
         'bare|reply<prod>|compopt',
         'dsn-separate|reply<prod><staging>|compopt',
         'dsn-attached|reply<-dprod>|compopt',
@@ -129,6 +132,7 @@ run_completion() {
 }
 
 run_completion generic mycli --s
+run_completion completions mycli --completions ba
 run_completion bare mycli pro
 run_completion dsn-separate mycli -d ''
 run_completion dsn-attached mycli -dpro

--- a/test/pytests/test_fish_completion.py
+++ b/test/pytests/test_fish_completion.py
@@ -22,6 +22,8 @@ if [ "${_MYCLI_COMPLETE:-}" = 'fish_complete' ]; then
     printf 'click\n' >> "$MYCLI_LOG"
     if [ "$COMP_CWORD" = '--s' ]; then
         printf 'plain,--socket\tSocket file\nplain,--ssl-mode\tTLS mode\n'
+    elif [ "$COMP_CWORD" = 'ba' ]; then
+        printf 'plain,bash\n'
     fi
     exit 0
 fi
@@ -55,6 +57,7 @@ fi
 
     assert result.stdout.splitlines() == [
         'generic|--socket\tSocket file|--ssl-mode\tTLS mode',
+        'completions|bash',
         'bare|prod',
         'dsn-separate|prod|staging',
         'dsn-long-separate|prod',
@@ -94,6 +97,7 @@ function run_completion --argument-names label command
 end
 
 run_completion generic 'mycli --s'
+run_completion completions 'mycli --completions ba'
 run_completion bare 'mycli pro'
 run_completion dsn-separate 'mycli -d '
 run_completion dsn-long-separate 'mycli --dsn pro'

--- a/test/pytests/test_main.py
+++ b/test/pytests/test_main.py
@@ -895,6 +895,40 @@ def test_list_dsn(monkeypatch):
         print(f"An error occurred while attempting to delete the file: {e}")
 
 
+@pytest.mark.parametrize(
+    ('shell', 'relative_path'),
+    (
+        ('bash', ('bash', 'mycli')),
+        ('zsh', ('zsh', '_mycli')),
+        ('fish', ('fish', 'mycli.fish')),
+    ),
+)
+def test_completions_prints_packaged_script_without_initializing_client(
+    monkeypatch: pytest.MonkeyPatch,
+    shell: str,
+    relative_path: tuple[str, str],
+) -> None:
+    def fail(*args: Any, **kwargs: Any) -> None:
+        pytest.fail('Completion output must not initialize the client or preprocess connection arguments.')
+
+    monkeypatch.setattr(main, 'MyCli', fail)
+    monkeypatch.setattr(main, 'preprocess_cli_args', fail)
+    completion_path = Path(project_root_dir, 'mycli', 'resources', 'completions', *relative_path)
+
+    result = CliRunner().invoke(click_entrypoint, args=['--completions', shell])
+
+    assert result.exit_code == 0
+    assert result.output == completion_path.read_text(encoding='utf-8')
+
+
+@pytest.mark.parametrize('args', (['--completions'], ['--completions', 'powershell']))
+def test_completions_rejects_missing_or_unknown_shell(args: list[str]) -> None:
+    result = CliRunner().invoke(click_entrypoint, args=args)
+
+    assert result.exit_code == 2
+    assert 'Error:' in result.output
+
+
 def test_dsn(monkeypatch):
     # Setup classes to mock mycli.main.MyCli
     class Formatter:

--- a/test/pytests/test_zsh_completion.py
+++ b/test/pytests/test_zsh_completion.py
@@ -20,6 +20,9 @@ def test_zsh_completion_lists_dsn_aliases_in_supported_contexts(tmp_path: Path) 
         '''#!/bin/sh
 if [ "${_MYCLI_COMPLETE:-}" = 'zsh_complete' ]; then
     printf 'click\\n' >> "$MYCLI_LOG"
+    if [ "$COMP_WORDS" = 'mycli --completions ba' ]; then
+        printf 'plain\\nbash\\n_\\n'
+    fi
     exit 0
 fi
 if [ "$1" = '--list-dsn' ]; then
@@ -49,6 +52,7 @@ fi
     assert result.stdout.splitlines() == [
         'prod,staging||0|',
         'prod||0|',
+        'bash||1|',
         'prod,staging||0|',
         'prod,staging||0|',
         '-dprod|-P -d|0|',
@@ -127,6 +131,7 @@ run_completion() {
 
 run_completion mycli ''
 run_completion mycli pro
+run_completion mycli --completions ba
 run_completion mycli -d ''
 run_completion mycli --dsn ''
 run_completion mycli -dpro


### PR DESCRIPTION
## Description
`--completions` uses `importlib` to find the appropriate shell completion script in the package resources.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
