### PR TITLE
Center images in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ Homepage: [https://mycli.net](https://mycli.net)
 
 Documentation: [https://mycli.net/docs](https://mycli.net/docs)
 
-![Completion](https://raw.githubusercontent.com/dbcli/mycli/main/doc/screenshots/tables.png)
-![CompletionGif](https://raw.githubusercontent.com/dbcli/mycli/main/doc/screenshots/main.gif)
+<div align="center">
+  <img alt="Completion" src="https://raw.githubusercontent.com/dbcli/mycli/main/doc/screenshots/tables.png">
+  <img alt="CompletionGif" src="https://raw.githubusercontent.com/dbcli/mycli/main/doc/screenshots/main.gif">
+</div>
 
 Mycli is compatible with MySQL, MariaDB, Percona, TiDB, and Apache Doris.
 

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ Features
 Documentation
 ---------
 * Add license badge to `README.md`.
+* Center images in `README.md`.
 
 
 2.8.0 (2026/07/31)


### PR DESCRIPTION
## Description
Because one image has a drop shadow, and one does not, left alignment doesn't line up.  Centering isn't perfect either, but adding a drop shadow to the animated GIF to align the images would increase the image size.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
