### PR TITLE
Disallow DSN aliases starting with dash

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,11 @@ Features
 * Add `--more` option to some `/dsn` subcommands, showing more DSN query parameters.
 
 
+Bugfixes
+---------
+* Disallow DSN aliases starting with `-`, because of ambiguity.
+
+
 Documentation
 ---------
 * Add license badge to `README.md`.

--- a/mycli/cli_runner.py
+++ b/mycli/cli_runner.py
@@ -15,6 +15,7 @@ __lazy_modules__ = [
     'mycli.main_modes.execute',
     'mycli.main_modes.list_dsn',
     'mycli.packages.cli_utils',
+    'mycli.packages.special.dsn_aliases',
     'mycli.password_sources',
     'mycli.vault',
 ]
@@ -35,6 +36,7 @@ from mycli.main_modes.completions import main_completions
 from mycli.main_modes.execute import main_execute_from_cli
 from mycli.main_modes.list_dsn import main_list_dsn
 from mycli.packages.cli_utils import is_valid_connection_scheme
+from mycli.packages.special.dsn_aliases import INVALID_DSN_ALIAS_ERROR, is_valid_dsn_alias
 from mycli.password_sources import PasswordCandidates
 from mycli.vault import (
     DEFAULT_VAULT_EXECUTABLE,
@@ -189,12 +191,18 @@ def run_from_cli_args(cli_args: 'CliArgs', client_factory: ClientFactory) -> Non
                     fg='yellow',
                 )
         else:
+            if not is_valid_dsn_alias(database):
+                click.secho(INVALID_DSN_ALIAS_ERROR, err=True, fg='red')
+                sys.exit(1)
             cli_args.dsn, database = database, ""
 
     if database and "://" in database:
         dsn_uri, database = database, ""
 
     if cli_args.dsn:
+        if not is_valid_dsn_alias(cli_args.dsn):
+            click.secho(INVALID_DSN_ALIAS_ERROR, err=True, fg='red')
+            sys.exit(1)
         try:
             dsn_uri = mycli.config["alias_dsn"][cli_args.dsn]
         except KeyError:

--- a/mycli/main_modes/list_dsn.py
+++ b/mycli/main_modes/list_dsn.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 import click
 
+from mycli.packages.special.dsn_aliases import is_valid_dsn_alias
+
 if TYPE_CHECKING:
     from mycli.client import MyCli
 
@@ -18,6 +20,8 @@ def main_list_dsn(mycli: 'MyCli') -> int:
         click.secho(str(e), err=True, fg='red')
         return 1
     for alias, value in alias_dsn.items():
+        if not is_valid_dsn_alias(alias):
+            continue
         if mycli.verbosity >= 1:
             click.secho(f'{alias} : {value}')
         else:

--- a/mycli/packages/special/dsn_aliases.py
+++ b/mycli/packages/special/dsn_aliases.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from mycli.client import MyCli
 
 DSN_SUBCOMMANDS = {'help', 'list', 'show', 'save', 'delete'}
+INVALID_DSN_ALIAS_ERROR = 'Error: DSN aliases cannot start with a dash.'
 
 SSL_QUERY_PARAMS = {
     'ssl_ca': 'ca',
@@ -21,6 +22,10 @@ SSL_QUERY_PARAMS = {
     'ssl_verify_server_cert': 'check_hostname',
     'tls_version': 'tls_version',
 }
+
+
+def is_valid_dsn_alias(alias: str) -> bool:
+    return not alias.startswith('-')
 
 
 def _config_bool(value: Any) -> bool:
@@ -140,12 +145,16 @@ Examples:
         return urlunsplit(parsed._replace(query=urlencode(more_params)))
 
     def list(self) -> list[str]:
-        return list(self.config.get(self.section_name, {}))
+        return [alias for alias in self.config.get(self.section_name, {}) if is_valid_dsn_alias(alias)]
 
     def get(self, alias: str) -> str | None:
+        if not is_valid_dsn_alias(alias):
+            return None
         return self.config.get(self.section_name, {}).get(alias, None)
 
     def save(self, alias: str, dsn: str) -> str:
+        if not is_valid_dsn_alias(alias):
+            return INVALID_DSN_ALIAS_ERROR
         self.config.encoding = 'utf-8'
         if self.section_name not in self.config:
             self.config[self.section_name] = {}
@@ -154,6 +163,8 @@ Examples:
         return f'Saved: {alias}'
 
     def delete(self, alias: str) -> str:
+        if not is_valid_dsn_alias(alias):
+            return INVALID_DSN_ALIAS_ERROR
         try:
             del self.config[self.section_name][alias]
         except KeyError:

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -19,7 +19,7 @@ import sqlparse
 from mycli.compat import WIN
 from mycli.packages.interactive_utils import confirm_destructive_query
 from mycli.packages.special.delimitercommand import DelimiterCommand
-from mycli.packages.special.dsn_aliases import DsnAliases
+from mycli.packages.special.dsn_aliases import INVALID_DSN_ALIAS_ERROR, DsnAliases, is_valid_dsn_alias
 from mycli.packages.special.favoritequeries import FavoriteQueries
 from mycli.packages.special.main import COMMANDS as SPECIAL_COMMANDS
 from mycli.packages.special.main import ArgType, SpecialCommandAlias, special_command
@@ -476,16 +476,20 @@ def dsn(
         include_more = len(args) == 3 and args[1] == '--more'
         if not (len(args) == 2 and args[1] != '--more') and not include_more:
             return [SQLResult(status='Error: a single alias-name argument is required to save.')]
+        alias = args[2] if include_more else args[1]
+        if not is_valid_dsn_alias(alias):
+            return [SQLResult(status=INVALID_DSN_ALIAS_ERROR)]
         dsn = compute_current_dsn(cur)
         if include_more:
             dsn = DsnAliases.instance.dsn_more(dsn)
-        alias = args[2] if include_more else args[1]
         status = DsnAliases.instance.save(alias, dsn)
         return [SQLResult(status=status)]
     elif args and args[0].lower() == 'delete':
         if len(args) != 2:
             return [SQLResult(status='Error: a single alias-name argument is required to delete.')]
         alias = args[1]
+        if not is_valid_dsn_alias(alias):
+            return [SQLResult(status=INVALID_DSN_ALIAS_ERROR)]
         status = DsnAliases.instance.delete(alias)
         return [SQLResult(status=status)]
     elif len(args) == 1 and args[0].lower() == 'list':

--- a/test/pytests/test_cli_runner.py
+++ b/test/pytests/test_cli_runner.py
@@ -177,6 +177,32 @@ def test_run_from_cli_args_treats_database_as_dsn_alias(monkeypatch: pytest.Monk
     assert connect_call['database'] == 'db'
 
 
+@pytest.mark.parametrize('argument', ['dsn', 'database'])
+def test_run_from_cli_args_rejects_dash_prefixed_dsn_alias(
+    monkeypatch: pytest.MonkeyPatch,
+    argument: str,
+) -> None:
+    cli_args = make_cli_args()
+    setattr(cli_args, argument, '-prod')
+    client = DummyMyCli(
+        config={
+            **default_config(),
+            'alias_dsn': {'-prod': 'mysql://u:p@h/db'},
+        }
+    )
+    secho_calls: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(cli_runner.click, 'secho', lambda text, **kwargs: secho_calls.append((text, kwargs)))
+
+    with pytest.raises(SystemExit) as excinfo:
+        run_with_client(monkeypatch, cli_args, client)
+
+    assert excinfo.value.code == 1
+    assert secho_calls == [
+        ('Error: DSN aliases cannot start with a dash.', {'err': True, 'fg': 'red'}),
+    ]
+    assert client.connect_calls == []
+
+
 def test_run_from_cli_args_reports_ambiguous_database_alias_with_connection_options(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -202,6 +228,25 @@ def test_run_from_cli_args_reports_ambiguous_database_alias_with_connection_opti
     ]
     assert client.dsn_alias is None
     assert client.connect_calls[-1]['database'] == 'prod'
+
+
+def test_run_from_cli_args_allows_dash_prefixed_database_with_connection_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli_args = make_cli_args()
+    cli_args.database = '-prod'
+    cli_args.user = 'alice'
+    client = DummyMyCli(
+        config={
+            **default_config(),
+            'alias_dsn': {'-prod': 'mysql://u:p@h/alias-db'},
+        }
+    )
+
+    run_with_client(monkeypatch, cli_args, client)
+
+    assert client.dsn_alias is None
+    assert client.connect_calls[-1]['database'] == '-prod'
 
 
 def test_run_from_cli_args_loads_password_from_file(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/test/pytests/test_dsn_aliases.py
+++ b/test/pytests/test_dsn_aliases.py
@@ -4,7 +4,7 @@ from typing import Any
 from urllib.parse import parse_qsl, urlsplit
 
 from mycli.constants import KNOWN_DSN_QUERY_PARAMS
-from mycli.packages.special.dsn_aliases import DsnAliases
+from mycli.packages.special.dsn_aliases import INVALID_DSN_ALIAS_ERROR, DsnAliases, is_valid_dsn_alias
 
 
 class DummyConfig(dict):
@@ -15,6 +15,11 @@ class DummyConfig(dict):
 
     def write(self) -> None:
         self.write_calls += 1
+
+
+def test_is_valid_dsn_alias_rejects_dash_prefix() -> None:
+    assert is_valid_dsn_alias('prod') is True
+    assert is_valid_dsn_alias('-prod') is False
 
 
 def test_from_config_returns_instance_with_same_config() -> None:
@@ -56,6 +61,7 @@ def test_list_and_get_use_alias_dsn_section() -> None:
         'alias_dsn': {
             'prod': 'mysql://prod/db',
             'staging': 'mysql://staging/db',
+            '-hidden': 'mysql://hidden/db',
         },
     })
     aliases = DsnAliases(config)
@@ -63,6 +69,7 @@ def test_list_and_get_use_alias_dsn_section() -> None:
     assert aliases.list() == ['prod', 'staging']
     assert aliases.get('prod') == 'mysql://prod/db'
     assert aliases.get('missing') is None
+    assert aliases.get('-hidden') is None
 
 
 def test_list_returns_empty_list_when_section_is_missing() -> None:
@@ -98,6 +105,18 @@ def test_save_updates_existing_section_and_writes_config() -> None:
     assert config.write_calls == 1
 
 
+def test_save_rejects_dash_prefixed_alias_without_writing_config() -> None:
+    config = DummyConfig()
+    aliases = DsnAliases(config)
+
+    result = aliases.save('-prod', 'mysql://prod/db')
+
+    assert result == INVALID_DSN_ALIAS_ERROR
+    assert config.encoding is None
+    assert config == {}
+    assert config.write_calls == 0
+
+
 def test_delete_removes_existing_alias_and_writes_config() -> None:
     config = DummyConfig({'alias_dsn': {'prod': 'mysql://prod/db'}})
     aliases = DsnAliases(config)
@@ -107,6 +126,17 @@ def test_delete_removes_existing_alias_and_writes_config() -> None:
     assert result == 'Deleted: prod'
     assert config['alias_dsn'] == {}
     assert config.write_calls == 1
+
+
+def test_delete_rejects_dash_prefixed_alias_without_writing_config() -> None:
+    config = DummyConfig({'alias_dsn': {'-prod': 'mysql://prod/db'}})
+    aliases = DsnAliases(config)
+
+    result = aliases.delete('-prod')
+
+    assert result == INVALID_DSN_ALIAS_ERROR
+    assert config['alias_dsn'] == {'-prod': 'mysql://prod/db'}
+    assert config.write_calls == 0
 
 
 def test_delete_returns_not_found_without_writing_config() -> None:

--- a/test/pytests/test_main_modes_list_dsn.py
+++ b/test/pytests/test_main_modes_list_dsn.py
@@ -34,7 +34,13 @@ def main_list_dsn(mycli: DummyMyCli) -> int:
 
 def test_main_list_dsn_lists_aliases_without_values(monkeypatch) -> None:
     secho_calls: list[tuple[str, bool | None, str | None]] = []
-    mycli = DummyMyCli(DummyConfig({'prod': 'mysql://u:p@h/db', 'staging': 'mysql://u2:p2@h2/db2'}))
+    mycli = DummyMyCli(
+        DummyConfig({
+            'prod': 'mysql://u:p@h/db',
+            '-hidden': 'mysql://hidden/db',
+            'staging': 'mysql://u2:p2@h2/db2',
+        })
+    )
 
     monkeypatch.setattr(
         list_dsn_mode.click,
@@ -53,7 +59,7 @@ def test_main_list_dsn_lists_aliases_without_values(monkeypatch) -> None:
 
 def test_main_list_dsn_lists_aliases_with_values_in_verbose_mode(monkeypatch) -> None:
     secho_calls: list[tuple[str, bool | None, str | None]] = []
-    mycli = DummyMyCli(DummyConfig({'prod': 'mysql://u:p@h/db'}))
+    mycli = DummyMyCli(DummyConfig({'prod': 'mysql://u:p@h/db', '-hidden': 'mysql://hidden/db'}))
     mycli.verbosity = 1
 
     monkeypatch.setattr(

--- a/test/pytests/test_special_iocommands.py
+++ b/test/pytests/test_special_iocommands.py
@@ -782,6 +782,23 @@ def test_dsn_command_saves_more_current_connection_settings(monkeypatch) -> None
     assert aliases.saved == [('prod', 'mysql://user@host/db?prompt=prod%3E+')]
 
 
+@pytest.mark.parametrize('arg', ['save -prod', 'save --more -prod'])
+def test_dsn_command_rejects_dash_prefixed_alias_before_computing_dsn(monkeypatch, arg: str) -> None:
+    aliases = FakeDsnAliases()
+    monkeypatch.setattr(
+        iocommands,
+        'compute_current_dsn',
+        lambda cur: pytest.fail('The DSN should not be computed for an invalid alias.'),
+    )
+    monkeypatch.setattr(iocommands.DsnAliases, 'instance', aliases, raising=False)
+
+    result = iocommands.dsn(cur=FakeCursor(), arg=arg)[0]
+
+    assert result.status == 'Error: DSN aliases cannot start with a dash.'
+    assert aliases.saved == []
+    assert aliases.completed == []
+
+
 def test_dsn_command_rejects_save_without_single_alias(monkeypatch) -> None:
     monkeypatch.setattr(iocommands.DsnAliases, 'instance', FakeDsnAliases(), raising=False)
 
@@ -798,6 +815,16 @@ def test_dsn_command_deletes_alias(monkeypatch) -> None:
 
     assert result.status == 'Deleted: prod'
     assert aliases.deleted == ['prod']
+
+
+def test_dsn_command_rejects_legacy_dash_prefixed_alias(monkeypatch) -> None:
+    aliases = FakeDsnAliases({'-legacy': 'mysql://legacy/db'})
+    monkeypatch.setattr(iocommands.DsnAliases, 'instance', aliases, raising=False)
+
+    result = iocommands.dsn(cur=FakeCursor(), arg='delete -legacy')[0]
+
+    assert result.status == 'Error: DSN aliases cannot start with a dash.'
+    assert aliases.deleted == []
 
 
 def test_dsn_command_rejects_delete_without_single_alias(monkeypatch) -> None:


### PR DESCRIPTION
## Description
A DSN alias starting with dash can create an ambiguity both on the shell command line, and after the `/dsn` special command.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
