### PR TITLE
Let `/prompt` alone return the current format string

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ Features
 * Add a `--completions` argument to emit a shell completion script.
 * Ability to set the `prompt` value as a DSN query parameter.
 * Add `--more` option to some `/dsn` subcommands, showing more DSN query parameters.
+* Let `/prompt` with no arguments display the current prompt format string.
 
 
 Bugfixes

--- a/mycli/TIPS
+++ b/mycli/TIPS
@@ -90,7 +90,7 @@ use /tee or /notee to write/stop-writing results to a output file!
 
 /P or /pager sets the pager.  Try "/pager less"!
 
-/R or /prompt changes the prompt format!
+/R or /prompt shows or changes the prompt format!
 
 /Tr or /redirectformat changes the table format for redirects!
 

--- a/mycli/client_commands.py
+++ b/mycli/client_commands.py
@@ -81,8 +81,8 @@ class ClientCommandsMixin:
         special.register_special_command(
             self.change_prompt_format,
             "prompt",
-            "/prompt <string>",
-            "Change prompt format.",
+            "/prompt [string]",
+            "Show or change prompt format.",
             case_sensitive=True,
             aliases=[SpecialCommandAlias("\\R", case_sensitive=True)],
         )
@@ -161,14 +161,13 @@ class ClientCommandsMixin:
 
     def change_prompt_format(self, arg: str, **_) -> list[SQLResult]:
         """
-        Change the prompt format.
+        Show or change the prompt format.
         """
         if not arg:
-            message = "Missing required argument, format."
-            return [SQLResult(status=message)]
+            return [SQLResult(status=f'Prompt format: "{self.prompt_format}"')]
 
         self.prompt_format = arg
-        return [SQLResult(status=f"Changed prompt format to {arg}")]
+        return [SQLResult(status=f'Changed prompt format to: "{arg}"')]
 
     def initialize_logging(self) -> None:
         log_file = os.path.expanduser(self.config["main"]["log_file"])

--- a/test/features/fixture_data/help_commands.txt
+++ b/test/features/fixture_data/help_commands.txt
@@ -23,7 +23,7 @@
 | /once           | /o       | /once [-o] <filename>             | Append next result to an output file (overwrite using -o).  |
 | /pager          | /P       | /pager [command]                  | Set pager to [command]. Print query results via pager.      |
 | /pipe_once      | /|       | /pipe_once <command>              | Send next result to a subprocess.                           |
-| /prompt         | /R       | /prompt <string>                  | Change prompt format.                                       |
+| /prompt         | /R       | /prompt [string]                  | Show or change prompt format.                               |
 | /quit           | /q       | /quit                             | Quit.                                                       |
 | /redirectformat | /Tr      | /redirectformat <format>          | Change the table format used to output redirected results.  |
 | /rehash         | /#       | /rehash                           | Refresh auto-completions.                                   |

--- a/test/pytests/test_client_commands.py
+++ b/test/pytests/test_client_commands.py
@@ -83,6 +83,7 @@ def test_register_special_commands_registers_expected_commands(monkeypatch: pyte
     assert calls[4][0] == client.change_redirect_format
     assert calls[5][0] == client.execute_from_file
     assert calls[6][0] == client.change_prompt_format
+    assert calls[6][2:4] == ('/prompt [string]', 'Show or change prompt format.')
 
 
 def test_manual_reconnect_reports_not_connected() -> None:
@@ -224,16 +225,18 @@ def test_execute_from_file_runs_file_query(tmp_path: Path) -> None:
     assert client.sqlexecute.runs == ['select 1;']
 
 
-def test_change_prompt_format_requires_argument() -> None:
+def test_change_prompt_format_without_argument_shows_current_format() -> None:
     client = DummyClient()
+    client.prompt_format = '\\u> '
 
-    assert client.change_prompt_format('') == [SQLResult(status='Missing required argument, format.')]
+    assert client.change_prompt_format('') == [SQLResult(status='Prompt format: "\\u> "')]
+    assert client.prompt_format == '\\u> '
 
 
 def test_change_prompt_format_updates_prompt_format() -> None:
     client = DummyClient()
 
-    assert client.change_prompt_format('\\u> ') == [SQLResult(status='Changed prompt format to \\u> ')]
+    assert client.change_prompt_format('\\u> ') == [SQLResult(status='Changed prompt format to: "\\u> "')]
     assert client.prompt_format == '\\u> '
 
 

--- a/test/pytests/test_main.py
+++ b/test/pytests/test_main.py
@@ -2106,14 +2106,17 @@ def test_null_string_config(monkeypatch):
         print(f'An error occurred while attempting to delete the file: {e}')
 
 
-def test_change_prompt_format_requires_argument() -> None:
+def test_change_prompt_format_without_argument_shows_current_format() -> None:
     cli = make_bare_mycli()
-    assert main.MyCli.change_prompt_format(cli, '')[0].status == 'Missing required argument, format.'
+    cli.prompt_format = '\\u> '
+
+    assert main.MyCli.change_prompt_format(cli, '')[0].status == 'Prompt format: "\\u> "'
+    assert cli.prompt_format == '\\u> '
 
 
 def test_change_prompt_format_updates_prompt() -> None:
     cli = make_bare_mycli()
-    assert main.MyCli.change_prompt_format(cli, '\\u@\\h> ')[0].status == 'Changed prompt format to \\u@\\h> '
+    assert main.MyCli.change_prompt_format(cli, '\\u@\\h> ')[0].status == 'Changed prompt format to: "\\u@\\h> "'
 
 
 def test_output_timing_logs_and_prints_with_warning_style(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Description
It might be a nicer interface to have `/prompt show` and `/prompt save`, as with `/dsn`, but that wouldn't be backward-compatible.

There are some tiny incidental changes in quoting in messages.  The prompt string is now quoted.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
