### PR TITLE
Allow the argument to `/prompt` to be quoted

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ Features
 * Ability to set the `prompt` value as a DSN query parameter.
 * Add `--more` option to some `/dsn` subcommands, showing more DSN query parameters.
 * Let `/prompt` with no arguments display the current prompt format string.
+* Allow the `/prompt` argument to be quoted.
 
 
 Bugfixes

--- a/mycli/client_commands.py
+++ b/mycli/client_commands.py
@@ -166,6 +166,9 @@ class ClientCommandsMixin:
         if not arg:
             return [SQLResult(status=f'Prompt format: "{self.prompt_format}"')]
 
+        if len(arg) >= 2 and arg[0] == arg[-1] and arg[0] in {'\'', '"'}:
+            arg = arg[1:-1]
+
         self.prompt_format = arg
         return [SQLResult(status=f'Changed prompt format to: "{arg}"')]
 

--- a/test/pytests/test_client_commands.py
+++ b/test/pytests/test_client_commands.py
@@ -8,6 +8,8 @@ import pytest
 
 from mycli import client_commands
 from mycli.client_commands import ClientCommandsMixin
+from mycli.packages import special
+from mycli.packages.special import main as special_main
 from mycli.packages.sqlresult import SQLResult
 
 
@@ -238,6 +240,51 @@ def test_change_prompt_format_updates_prompt_format() -> None:
 
     assert client.change_prompt_format('\\u> ') == [SQLResult(status='Changed prompt format to: "\\u> "')]
     assert client.prompt_format == '\\u> '
+
+
+@pytest.mark.parametrize(
+    ('command', 'quote'),
+    [
+        ('/prompt', '"'),
+        (r'\R', "'"),
+    ],
+)
+def test_change_prompt_format_accepts_quoted_value(
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    quote: str,
+) -> None:
+    monkeypatch.setattr(special_main, 'COMMANDS', {})
+    monkeypatch.setattr(special_main, 'CASE_SENSITIVE_COMMANDS', set())
+    monkeypatch.setattr(special_main, 'CASE_INSENSITIVE_COMMANDS', set())
+    client = DummyClient()
+    client.prompt_format = 'old> '
+    client.register_special_commands()
+
+    result = special.execute(None, f'{command} {quote} \\u> {quote}')
+
+    assert result == [SQLResult(status='Changed prompt format to: " \\u> "')]
+    assert client.prompt_format == ' \\u> '
+
+
+@pytest.mark.parametrize('arg', ["''", '""'])
+def test_change_prompt_format_accepts_quoted_empty_value(arg: str) -> None:
+    client = DummyClient()
+    client.prompt_format = 'old> '
+
+    result = client.change_prompt_format(arg)
+
+    assert result == [SQLResult(status='Changed prompt format to: ""')]
+    assert client.prompt_format == ''
+
+
+@pytest.mark.parametrize('arg', ["'unmatched", '"unmatched'])
+def test_change_prompt_format_keeps_unmatched_quote(arg: str) -> None:
+    client = DummyClient()
+
+    client.change_prompt_format(arg)
+
+    assert client.prompt_format == arg
 
 
 def test_initialize_logging_uses_null_handler_for_none_level(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Description
With this change, the special command for setting the prompt behaves the same way as the configuration file.


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
