### PR TITLE
Add type-ignore for prompt-toolkit CI issue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ Documentation
 * Document shell completions in `README.md`.
 
 
+Internal
+---------
+* Typing fixes for `prompt-toolkit`.
+
+
 2.9.0 (2026/08/01)
 ==============
 

--- a/mycli/main_modes/repl.py
+++ b/mycli/main_modes/repl.py
@@ -582,7 +582,7 @@ def _build_prompt_session(
             lexer=PygmentsLexer(MyCliLexer),
             reserve_space_for_menu=mycli.get_reserved_space(),
             prompt_continuation=lambda width, two, three: _get_continuation(mycli, width, two, three),
-            bottom_toolbar=get_toolbar_tokens,
+            bottom_toolbar=get_toolbar_tokens,  # type: ignore[arg-type]
             complete_style=complete_style,
             input_processors=[
                 ConditionalProcessor(


### PR DESCRIPTION
## Description

Add type-ignore for prompt-toolkit CI issue

* https://github.com/dbcli/mycli/actions/runs/30806512791/job/91664091222?pr=2085

So far, I cannot duplicate this locally, only paper it over for the sake of CI.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
