### PR TITLE
Remove redundant Homebrew dependency in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ You might need `sudo` on Linux.
 pip install --upgrade 'mycli[all]'
 ```
 
-or, only on macOS (`fzf` and `pygments` are optional but recommended):
+or, only on macOS (`pygments` is optional but recommended):
 
 ```bash
-brew update && brew install mycli fzf pygments
+brew update && brew install mycli pygments
 ```
 
 or, only on Debian or Ubuntu (`fzf` and `pygments` are optional but recommended):

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ Documentation
 ---------
 * Document shell completions in `README.md`.
 * Fix table alignment in favorite-queries example.
+* Remove redundant Homebrew dependency in `README.md`
 
 
 Internal


### PR DESCRIPTION
## Description
`fzf` is now a declared dependency of the mycli Homebrew Formula, so it is implicitly installed.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
