### PR TITLE
Complete all Jinja2 keys after `--<tab>` in `/f`

### DIFF
--- a/mycli/packages/completion_engine.py
+++ b/mycli/packages/completion_engine.py
@@ -894,6 +894,8 @@ def suggest_favorite_query_with_template(text: str, arg: str) -> list[dict[str, 
         is_current = index == len(arguments) - 1 and not trailing_space
 
         if argument == '--':
+            if is_current:
+                break
             return []
         if argument.startswith('--'):
             option = argument[2:]

--- a/test/pytests/test_completion_engine.py
+++ b/test/pytests/test_completion_engine.py
@@ -863,6 +863,8 @@ def test_suggest_type_handles_parser_results_shorter_than_cursor(monkeypatch):
         ('/f report ', [{'type': 'favoritequery_template_key', 'name': 'report', 'used_keys': set()}]),
         ('\\f report --u', [{'type': 'favoritequery_template_key', 'name': 'report', 'used_keys': set()}]),
         ('/f report -', [{'type': 'favoritequery_template_key', 'name': 'report', 'used_keys': set()}]),
+        ('/f report --', [{'type': 'favoritequery_template_key', 'name': 'report', 'used_keys': set()}]),
+        ('/f report -- ', []),
         ('/f report positional', []),
         ('/f report positional ', [{'type': 'favoritequery_template_key', 'name': 'report', 'used_keys': set()}]),
         ('/f report --user=', []),

--- a/test/pytests/test_sqlcompleter.py
+++ b/test/pytests/test_sqlcompleter.py
@@ -525,6 +525,8 @@ def test_get_completions_favorite_query_template_keys(monkeypatch) -> None:
 
     blank_text = '/f report '
     blank = list(completer.get_completions(Document(text=blank_text, cursor_position=len(blank_text)), None))
+    option_prefix_text = '/f report --'
+    option_prefix = list(completer.get_completions(Document(text=option_prefix_text, cursor_position=len(option_prefix_text)), None))
     partial_text = '/f report --u'
     partial = list(completer.get_completions(Document(text=partial_text, cursor_position=len(partial_text)), None))
     dashed_text = '/f report --start-'
@@ -535,6 +537,8 @@ def test_get_completions_favorite_query_template_keys(monkeypatch) -> None:
     used_dashed = list(completer.get_completions(Document(text=used_dashed_text, cursor_position=len(used_dashed_text)), None))
 
     assert [completion.text for completion in blank] == ['--range=', '--start-date=', '--start_date=', '--user=']
+    assert {completion.text for completion in option_prefix} == {'--range=', '--start-date=', '--start_date=', '--user='}
+    assert {completion.start_position for completion in option_prefix} == {-2}
     assert [(completion.text, completion.start_position) for completion in partial] == [('--user=', -3)]
     assert [(completion.text, completion.start_position) for completion in dashed] == [('--start-date=', -8)]
     assert [completion.text for completion in used] == ['--range=', '--start-date=', '--start_date=']


### PR DESCRIPTION
## Description

Because `--` means "end of options", there was a slight ambiguity for favorite completions if `<tab>` was pressed immediately after `--`.  We should see all possible key names, as scraped from the Jinja2 template for the favorite query.

Whereas if there is an intervening space: `-- <tab>`, no key-name completions should be offered.

This fixes favorite parameter completion so that completions are equally visible after `-<tab>`, `--<tab>`, and `--<partial><tab>`.

The change can be included under a pending changelog entry.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
