### PR TITLE
Remove "2" from Jinja branding in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Features
     - `SELECT * FROM <tab>` will only show table names.
     - `SELECT * FROM users WHERE <tab>` will only show column names.
 * Support for multiline queries.
-* Favorite queries with positional or named parameters using [Jinja2](https://jinja.palletsprojects.com/en/stable/). Save a query using
+* Favorite queries with positional or named parameters using [Jinja](https://jinja.palletsprojects.com/en/stable/). Save a query using
   `/fs <alias> <query>` and execute it with `/f <alias>` or `/f <alias> --key=value`.
 * Timing of sql statements and table rendering.
 * Log every query and its results to a file (disabled by default).

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@ Upcoming (TBD)
 
 Features
 ---------
-* Let favorite queries use Jinja2 templates, allowing optional arguments.
+* Let favorite queries use Jinja templates, allowing optional arguments.
 
 
 Bugfixes

--- a/mycli/TIPS
+++ b/mycli/TIPS
@@ -62,7 +62,7 @@ edit a query in an external editor using /edit <filename>!
 
 /fd <name> deletes a saved favorite query!
 
-Favorite queries support Jinja2 templates and named arguments!
+Favorite queries support Jinja templates and named arguments!
 
 /l lists databases!
 

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -499,13 +499,13 @@ matching-bracket.other = '#000000 bg:#aacccc'
 [favorite_queries]
 # example = "SELECT * FROM example_table WHERE id = 1"
 #
-# Favorite queries can use the Jinja2 templating language. Named argument
+# Favorite queries can use the Jinja templating language. Named argument
 # values are available as keys in a dictionary named "kv".
 # Run this example templated query with: /f find_user --name=henry
 # Any keys refereed to by name will be available as completions.
 # find_user = "SELECT * FROM users WHERE name = '{{ kv.name }}'"
 #
-# Jinja2 parameters are optional.
+# Jinja parameters are optional.
 # Run this example templated query with: /f recent_user --name=henry
 # or alternatively, with different behavior: /f recent_user
 # recent_user = "SELECT * FROM users WHERE create_date >= NOW() - INTERVAL 1 DAY {% if kv.name %} AND name = '{{ kv.name }}' {% endif %}"

--- a/test/myclirc
+++ b/test/myclirc
@@ -499,13 +499,13 @@ matching-bracket.other = '#000000 bg:#aacccc'
 [favorite_queries]
 # example = "SELECT * FROM example_table WHERE id = 1"
 #
-# Favorite queries can use the Jinja2 templating language. Named argument
+# Favorite queries can use the Jinja templating language. Named argument
 # values are available as keys in a dictionary named "kv".
 # Run this example templated query with: /f find_user --name=henry
 # Any keys refereed to by name will be available as completions.
 # find_user = "SELECT * FROM users WHERE name = '{{ kv.name }}'"
 #
-# Jinja2 parameters are optional.
+# Jinja parameters are optional.
 # Run this example templated query with: /f recent_user --name=henry
 # or alternatively, with different behavior: /f recent_user
 # recent_user = "SELECT * FROM users WHERE create_date >= NOW() - INTERVAL 1 DAY {% if kv.name %} AND name = '{{ kv.name }}' {% endif %}"


### PR DESCRIPTION
## Description
Remove "2" from Jinja branding in docs, since that's how the project brands itself.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
