### PR TITLE
Update `cryptography` to v50.0.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@ Documentation
 Internal
 ---------
 * Typing fixes for `prompt-toolkit`.
+* Update `cryptography` to v50.0.0.
 
 
 2.9.0 (2026/08/01)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "click ~= 8.4.2",
     "clickdc ~= 0.1.1",
-    "cryptography ~= 49.0.0",
+    "cryptography ~= 50.0.0",
     "Pygments ~= 2.20.0",
     "prompt_toolkit >= 3.0.41,<4.0.0",
     "PyMySQL ~= 1.1.2",
@@ -98,7 +98,7 @@ include = ["mycli*"]
 
 [tool.uv]
 exclude-newer = '1 week'
-exclude-newer-package = { cli_helpers = false, openai = false }
+exclude-newer-package = { cli_helpers = false, openai = false, cryptography = false }
 
 [tool.ruff]
 target-version = 'py310'


### PR DESCRIPTION
## Description
Update `cryptography` to v50.0.0, to quiet a warning from `uv audit`.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
