### PR TITLE
Document double-return requirement for `/fs`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Documentation
+---------
+* Document double-return requirement after `/fs` in multi-line mode.
+
+
 2.10.0 (2026/08/05)
 ==============
 

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -37,7 +37,8 @@ expand_dsn_alias_env_vars = False
 # Multi-line mode allows breaking up the sql statements into multiple lines. If
 # this is set to True, then the end of the statements must have a semi-colon.
 # If this is set to False then sql statements can't be split into multiple
-# lines. End of line (return) is considered as the end of the statement.
+# lines. End of line (Return) is considered as the end of the statement.
+# When True, saving a favorite query requires pressing Return twice.
 multi_line = False
 
 # Destructive warning mode will alert you before executing a sql statement

--- a/mycli/packages/special/favoritequeries.py
+++ b/mycli/packages/special/favoritequeries.py
@@ -75,14 +75,17 @@ with a short name.
 Examples:
 
     # Save a new favorite query.
-    > /fs simple select * from abc where a is not Null;
+    > /fs simple SELECT * FROM abc WHERE a IS NOT NULL;
+
+    # When multi-line mode is on, pressing Return twice is needed to save.
+    # This supports multi-statement favorites.
 
     # List all favorite queries.
     > /f
     ╒═══════════╤══════════════════════════════════════════════════╕
     │ Name      │ Query                                            │
     ╞═══════════╪══════════════════════════════════════════════════╡
-    │ simple    │ SELECT * FROM abc where a is not NULL            │
+    │ simple    │ SELECT * FROM abc WHERE a IS NOT NULL            │
     │ find_user │ SELECT * FROM users WHERE name = '{{ kv.name }}' │
     ╘═══════════╧══════════════════════════════════════════════════╛
 
@@ -94,15 +97,16 @@ Examples:
     │ 日本語 │ 日本語 │
     ╘════════╧════════╛
 
-    # Run a favorite query containing {{ kv.name }} in the template:
+    # Run a favorite query containing {{ kv.name }} in the template.
     > /f find_user --name=henry
     > /f find_user --name henry
 
-    # Run a favorite query containing $1 in the template:
+    # Run a favorite query containing positional parameter $1 in the
+    # template.
     > /f find_user henry
 
-    # Use -- to disambiguate positional parameters, especially if
-    # the positional value starts with a dash.
+    # Use -- to disambiguate positional parameters such as $1, especially
+    # if the positional value starts with a dash.
     > /f query --key=value -- positional-value
     > /f query -- --positional-value-which-looks-like-a-flag--
 

--- a/test/myclirc
+++ b/test/myclirc
@@ -37,7 +37,8 @@ expand_dsn_alias_env_vars = False
 # Multi-line mode allows breaking up the sql statements into multiple lines. If
 # this is set to True, then the end of the statements must have a semi-colon.
 # If this is set to False then sql statements can't be split into multiple
-# lines. End of line (return) is considered as the end of the statement.
+# lines. End of line (Return) is considered as the end of the statement.
+# When True, saving a favorite query requires pressing Return twice.
 multi_line = False
 
 # Destructive warning mode will alert you before executing a sql statement


### PR DESCRIPTION
## Description
In multi-line mode, we have always required two returns to save a favorite query with `/fs`, but that was undocumented.  The purpose is to support multi-statement favorites.

Document this both in the config file with the `multi_line` setting, and in the `/f` internal helpdoc.

Incidentally make some clarifications and punctuation fixes in the `/f` internal helpdoc.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
