### PR TITLE
start_new_session when creating SSH tunnels

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ Features
 * Always clean favorite queries on save and fetch.
 
 
+Bugfixes
+---------
+* Call `setsid()` to keep SSH tunnels from receiving Ctrl-C interrupts.
+
+
 Documentation
 ---------
 * Document double-return requirement after `/fs` in multi-line mode.

--- a/mycli/ssh_tunnel.py
+++ b/mycli/ssh_tunnel.py
@@ -187,6 +187,7 @@ class SshTunnel:
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                start_new_session=True,
             )
         except OSError as exc:
             self._startup_error = exc


### PR DESCRIPTION
## Description

According to

 * https://docs.python.org/3/library/subprocess.html#popen-constructor

> If start_new_session is true the `setsid()` system call will be made in the child process prior to the execution of the subprocess.

The hope is that `setsid()` keeps the tunnel process from receiving ctrl-c interrupts from the REPL.

Intended to address #2102.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
