### PR TITLE
Allow entering an SSH password interactively

### DIFF
--- a/mycli/ssh_tunnel.py
+++ b/mycli/ssh_tunnel.py
@@ -187,6 +187,8 @@ class SshTunnel:
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                # better insulate the thread from signals, but interactivity
+                # is disabled
                 start_new_session=True,
             )
         except OSError as exc:
@@ -195,7 +197,23 @@ class SshTunnel:
             return
         return_code = self.process.wait()
         if return_code != 0 and not self._ready.is_set():
-            self._failed.set()
+            # in case the user needed to enter an SSH password, try again with
+            # start_new_session=False
+            try:
+                self.process = subprocess.Popen(
+                    self.command(),
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    start_new_session=False,
+                )
+            except OSError as exc:
+                self._startup_error = exc
+                self._failed.set()
+                return
+            return_code = self.process.wait()
+            if return_code != 0 and not self._ready.is_set():
+                self._failed.set()
 
     def _is_listening(self) -> bool:
         try:

--- a/test/pytests/test_ssh_tunnel.py
+++ b/test/pytests/test_ssh_tunnel.py
@@ -292,6 +292,38 @@ def test_ssh_tunnel_start_reports_process_start_error(monkeypatch: pytest.Monkey
     assert isinstance(excinfo.value.__cause__, FileNotFoundError)
 
 
+def test_ssh_tunnel_start_reports_interactive_retry_start_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    start_new_session_calls: list[bool] = []
+
+    class FakeProcess:
+        def wait(self, timeout: float | None = None) -> int:
+            return 255
+
+        def poll(self) -> int:
+            return 255
+
+    def fake_popen(*_args: Any, start_new_session: bool, **_kwargs: Any) -> FakeProcess:
+        start_new_session_calls.append(start_new_session)
+        if start_new_session:
+            return FakeProcess()
+        raise FileNotFoundError('missing interactive ssh')
+
+    monkeypatch.setattr(ssh_tunnel.subprocess, 'Popen', fake_popen)
+    monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: '/tmp/mycli-ssh.sock')
+    tunnel = SshTunnel(
+        ssh_target='bastion',
+        remote_host='db.internal',
+        remote_port=3306,
+    )
+    monkeypatch.setattr(tunnel, '_is_listening', lambda: False)
+
+    with pytest.raises(SshTunnelError, match='Unable to start SSH tunnel process: missing interactive ssh') as excinfo:
+        tunnel.start()
+
+    assert start_new_session_calls == [True, False]
+    assert isinstance(excinfo.value.__cause__, FileNotFoundError)
+
+
 def test_ssh_tunnel_start_reports_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ssh_tunnel, '_make_local_socket_path', lambda: '/tmp/mycli-ssh.sock')
     tunnel = SshTunnel(


### PR DESCRIPTION
## Description
Allow entering an SSH password interactively, falling back to `start_new_session=False`, losing `setsid()` for the tunnel process, a compromise.

xref #2103

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
