### PR TITLE
Ensure user is logged in to Vault

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming (TBD)
 Features
 ---------
 * Always clean favorite queries on save and fetch.
+* Give a clearer message on a Vault connection if the user is not logged in.
 
 
 Bugfixes

--- a/mycli/vault.py
+++ b/mycli/vault.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import subprocess
 
 DEFAULT_VAULT_EXECUTABLE = 'vault'
@@ -11,6 +12,40 @@ class VaultError(RuntimeError):
     pass
 
 
+@functools.lru_cache(maxsize=32)
+def _ensure_vault_user_logged_in(
+    executable: str = DEFAULT_VAULT_EXECUTABLE,
+    address: str | None = None,
+) -> None:
+    command = [
+        executable,
+        'token',
+        'lookup',
+        '-format=json',
+    ]
+    if address:
+        command.append(f'-address={address}')
+
+    try:
+        completed_process = subprocess.run(
+            command,
+            check=False,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise VaultError(f'Vault executable not found: {executable}') from exc
+    except OSError as exc:
+        raise VaultError(f'Unable to run Vault executable {executable}: {exc}') from exc
+
+    if completed_process.returncode:
+        # maybe could display something from the JSON output
+        # maybe only with --verbose
+        raise VaultError('Not logged in to Vault. You may need to run "vault login".')
+
+
 def get_field_from_vault(
     field: str,
     secret: str,
@@ -18,6 +53,12 @@ def get_field_from_vault(
     mount: str | None = None,
     address: str | None = None,
 ) -> str:
+
+    _ensure_vault_user_logged_in(
+        executable=executable,
+        address=address,
+    )
+
     command = [
         executable,
         'kv',

--- a/test/pytests/test_vault.py
+++ b/test/pytests/test_vault.py
@@ -9,6 +9,11 @@ import pytest
 from mycli import vault
 
 
+@pytest.fixture(autouse=True)
+def clear_vault_login_cache() -> None:
+    vault._ensure_vault_user_logged_in.cache_clear()
+
+
 def test_get_field_from_vault_runs_kv_get_with_field_mount_and_address(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -33,6 +38,20 @@ def test_get_field_from_vault_runs_kv_get_with_field_mount_and_address(
         {
             'command': [
                 '/opt/bin/vault',
+                'token',
+                'lookup',
+                '-format=json',
+                '-address=https://vault.example.com',
+            ],
+            'check': False,
+            'stdin': -3,
+            'stdout': -1,
+            'stderr': -1,
+            'text': True,
+        },
+        {
+            'command': [
+                '/opt/bin/vault',
                 'kv',
                 'get',
                 '-field=mysql_password',
@@ -45,7 +64,7 @@ def test_get_field_from_vault_runs_kv_get_with_field_mount_and_address(
             'stdout': subprocess.PIPE,
             'stderr': subprocess.PIPE,
             'text': True,
-        }
+        },
     ]
 
 
@@ -72,7 +91,9 @@ def test_get_field_from_vault_reports_oserror(monkeypatch: pytest.MonkeyPatch) -
 def test_get_field_from_vault_reports_nonzero_exit_without_stdout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def fake_run(*_args: Any, **_kwargs: Any) -> SimpleNamespace:
+    def fake_run(command: list[str], **_kwargs: Any) -> SimpleNamespace:
+        if command[1:3] == ['token', 'lookup']:
+            return SimpleNamespace(returncode=0, stdout='token metadata\n', stderr='')
         return SimpleNamespace(returncode=2, stdout='secret\n', stderr='permission denied\n')
 
     monkeypatch.setattr(vault.subprocess, 'run', fake_run)
@@ -84,6 +105,43 @@ def test_get_field_from_vault_reports_nonzero_exit_without_stdout(
     assert 'secret' not in str(excinfo.value)
 
 
+@pytest.mark.parametrize(
+    ('error', 'message'),
+    (
+        (FileNotFoundError(), 'Vault executable not found: custom-vault'),
+        (OSError('boom'), 'Unable to run Vault executable custom-vault: boom'),
+    ),
+)
+def test_get_field_from_vault_reports_kv_get_start_error(
+    monkeypatch: pytest.MonkeyPatch,
+    error: OSError,
+    message: str,
+) -> None:
+    def fake_run(command: list[str], **_kwargs: Any) -> SimpleNamespace:
+        if command[1:3] == ['token', 'lookup']:
+            return SimpleNamespace(returncode=0, stdout='token metadata\n', stderr='')
+        raise error
+
+    monkeypatch.setattr(vault.subprocess, 'run', fake_run)
+
+    with pytest.raises(vault.VaultError, match=message):
+        vault.get_field_from_vault('password', 'database/prod', executable='custom-vault')
+
+
+def test_get_field_from_vault_reports_kv_get_nonzero_exit_without_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(command: list[str], **_kwargs: Any) -> SimpleNamespace:
+        if command[1:3] == ['token', 'lookup']:
+            return SimpleNamespace(returncode=0, stdout='token metadata\n', stderr='')
+        return SimpleNamespace(returncode=2, stdout='', stderr='')
+
+    monkeypatch.setattr(vault.subprocess, 'run', fake_run)
+
+    with pytest.raises(vault.VaultError, match='Vault command failed.*Exit code 2'):
+        vault.get_field_from_vault('password', 'database/prod')
+
+
 def test_get_field_from_vault_reports_nonzero_exit_without_stderr(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -92,5 +150,5 @@ def test_get_field_from_vault_reports_nonzero_exit_without_stderr(
 
     monkeypatch.setattr(vault.subprocess, 'run', fake_run)
 
-    with pytest.raises(vault.VaultError, match='Vault command failed\\. You may need to run "vault login"\\. Exit code 2\\.'):
+    with pytest.raises(vault.VaultError, match='Not logged in to Vault. You may need to run "vault login".'):
         vault.get_field_from_vault('password', 'database/prod')


### PR DESCRIPTION
## Description
Ensure user is logged in to Vault before trying to read credentials from Vault, and raise with a specific error message if not.

This could probably be refined for more cases, such as the lack of a connection.

We assume that all exit codes represent an error, though Vault has a habit of encoding information into different exit codes.

The test command is

```bash
vault taken lookup -format=json
```

though any JSON output is currently not parsed.

We use `functools` to ensure that the check is only performed once, though `vault kv` could be run twice: once for the username and once for the password.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
