### PR TITLE
Promote Vault integration out of beta

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Features
 ---------
 * Always clean favorite queries on save and fetch.
 * Give a clearer message on a Vault connection if the user is not logged in.
+* Promote Vault integration out of beta status.
 
 
 Bugfixes

--- a/mycli/cli_runner.py
+++ b/mycli/cli_runner.py
@@ -455,7 +455,7 @@ def run_from_cli_args(cli_args: 'CliArgs', client_factory: ClientFactory) -> Non
 
     if cli_args.vault_secret:
         vault_secret = cli_args.vault_secret
-        vault_config = mycli.config.get('vault_beta', {})
+        vault_config = mycli.config.get('vault', {})
         vault_address = cli_args.vault_address or os.environ.get('VAULT_ADDR') or vault_config.get('address') or None
         vault_mount = cli_args.vault_mount or vault_config.get('default_mount') or None
         vault_password_field = cli_args.vault_password_field or vault_config.get('default_password_field') or DEFAULT_VAULT_PASSWORD_FIELD
@@ -477,7 +477,7 @@ def run_from_cli_args(cli_args: 'CliArgs', client_factory: ClientFactory) -> Non
         password_candidates.add_loader('vault', load_vault_password)
 
     if cli_args.user is None and cli_args.vault_secret:
-        vault_config = mycli.config.get('vault_beta', {})
+        vault_config = mycli.config.get('vault', {})
         vault_address = cli_args.vault_address or os.environ.get('VAULT_ADDR') or vault_config.get('address') or None
         vault_mount = cli_args.vault_mount or vault_config.get('default_mount') or None
         vault_username_field = cli_args.vault_username_field or vault_config.get('default_username_field') or DEFAULT_VAULT_USERNAME_FIELD

--- a/mycli/main.py
+++ b/mycli/main.py
@@ -107,23 +107,23 @@ class CliArgs:
     )
     vault_address: str | None = clickdc.option(
         type=str,
-        help='EXPERIMENTAL "vault kv get" integration: value for $VAULT_ADDR if unset in the environment or ~/.myclirc.',
+        help='"vault kv get" integration: value for $VAULT_ADDR if unset in the environment or ~/.myclirc.',
     )
     vault_mount: str | None = clickdc.option(
         type=str,
-        help='EXPERIMENTAL "vault kv get" integration: value for -mount if unset in ~/.myclirc.',
+        help='"vault kv get" integration: value for -mount if unset in ~/.myclirc.',
     )
     vault_secret: str | None = clickdc.option(
         type=str,
-        help='EXPERIMENTAL "vault kv get" integration: secret name.',
+        help='"vault kv get" integration: secret name.',
     )
     vault_password_field: str | None = clickdc.option(
         type=str,
-        help='EXPERIMENTAL "vault kv get" integration: field containing the password.',
+        help='"vault kv get" integration: field containing the password.',
     )
     vault_username_field: str | None = clickdc.option(
         type=str,
-        help='EXPERIMENTAL "vault kv get" integration: field containing the username.',
+        help='"vault kv get" integration: field containing the username.',
     )
     ssl_mode: str = clickdc.option(
         type=click.Choice(['auto', 'on', 'off']),

--- a/mycli/myclirc
+++ b/mycli/myclirc
@@ -394,7 +394,7 @@ ssh_options = -a -o ServerAliveInterval=60 -o ExitOnForwardFailure=yes -o IPQoS=
 # auto means: port if on Windows, socket otherwise.
 tunnel_method = auto
 
-[vault_beta]
+[vault]
 # Path to the vault executable used for Vault integration.
 vault_executable = vault
 

--- a/mycli/packages/special/dsn_aliases.py
+++ b/mycli/packages/special/dsn_aliases.py
@@ -117,7 +117,7 @@ Examples:
 
         main_config = self.config.get('main', {})
         connection_config = self.config.get('connection', {})
-        vault_config = self.config.get('vault_beta', {})
+        vault_config = self.config.get('vault', {})
         return {
             'character_set': connection_config.get('default_character_set') or DEFAULT_CHARSET,
             'keepalive_ticks': self.mycli.default_keepalive_ticks,

--- a/test/myclirc
+++ b/test/myclirc
@@ -394,7 +394,7 @@ ssh_options = -a -o ServerAliveInterval=60 -o ExitOnForwardFailure=yes -o IPQoS=
 # auto means: port if on Windows, socket otherwise.
 tunnel_method = auto
 
-[vault_beta]
+[vault]
 # Path to the vault executable used for Vault integration.
 vault_executable = vault
 

--- a/test/pytests/test_cli_runner.py
+++ b/test/pytests/test_cli_runner.py
@@ -56,7 +56,7 @@ def default_config() -> dict[str, Any]:
     return {
         'main': {'use_keyring': 'false'},
         'connection': {'default_keepalive_ticks': 0},
-        'vault_beta': {},
+        'vault': {},
         'alias_dsn': {},
         'init-commands': {},
         'alias_dsn.init-commands': {},
@@ -964,7 +964,7 @@ def test_run_from_cli_args_reads_password_from_vault_when_password_is_missing(
     client = DummyMyCli(
         config={
             **default_config(),
-            'vault_beta': {
+            'vault': {
                 'vault_executable': '/opt/bin/vault',
                 'address': 'https://vault.config',
                 'default_mount': 'kv',
@@ -1005,7 +1005,7 @@ def test_run_from_cli_args_reads_username_from_vault_when_user_is_missing(
     client = DummyMyCli(
         config={
             **default_config(),
-            'vault_beta': {
+            'vault': {
                 'vault_executable': '/opt/bin/vault',
                 'address': 'https://vault.config',
                 'default_mount': 'kv',
@@ -1110,7 +1110,7 @@ def test_run_from_cli_args_prefers_vault_cli_values_and_env_address(
     client = DummyMyCli(
         config={
             **default_config(),
-            'vault_beta': {
+            'vault': {
                 'vault_executable': '/opt/bin/vault',
                 'address': 'https://vault.config',
                 'default_mount': 'config-mount',

--- a/test/pytests/test_dsn_aliases.py
+++ b/test/pytests/test_dsn_aliases.py
@@ -364,7 +364,7 @@ def test_dsn_more_adds_non_default_runtime_parameters_in_sorted_order() -> None:
             'default_ssl_ca': '/default-ca.pem',
             'default_ssl_verify_server_cert': 'False',
         },
-        'vault_beta': {
+        'vault': {
             'address': 'https://default-vault',
             'default_mount': 'kv',
             'default_password_field': 'password',
@@ -435,7 +435,7 @@ def test_dsn_more_omits_empty_false_and_active_default_parameters() -> None:
             'default_ssl_mode': 'on',
             'default_ssl_verify_server_cert': 'True',
         },
-        'vault_beta': {
+        'vault': {
             'address': 'https://default-vault',
             'default_mount': 'kv',
             'default_password_field': 'secret',


### PR DESCRIPTION
## Description
Promote Vault integration out of beta status.

Users may need to edit `~/.myclirc` files to change `[vault_beta]` to `[vault]`.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
