### PR TITLE
Document that ssh jump works best noninteractively

### DIFF
--- a/mycli/main.py
+++ b/mycli/main.py
@@ -311,7 +311,11 @@ class CliArgs:
     )
     ssh_jump: str | None = clickdc.option(
         type=str,
-        help='Open an SSH tunnel via [user@]host[:port] and connect to MySQL through it.',
+        help=dedent(
+            """Open an SSH tunnel via [user@]host[:port] and connect to MySQL through it.
+            Works best if SSH is configured not to prompt for a password interactively.
+            """
+        ),
     )
     ssh_options: str | None = clickdc.option(
         type=str,


### PR DESCRIPTION
## Description
Since in the interactive case, we cannot call `setsid()` in the tunnel process, `--ssh-jump` works best when SSH is set up to make the connection entirely interactively.

xref #2104

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
