### PR TITLE
Downgrade `click` to v8.3.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@ Features
 * Add a `/config` command to inspect configuration values from the REPL.
 
 
+Bugfixes
+---------
+* Downgrade `click` to v8.3.3, since v8.4.2 broke the pager on Windows.
+
+
 2.11.0 (2026/08/07)
 ==============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,9 @@ classifiers = [
 ]
 
 dependencies = [
-    "click ~= 8.4.2",
+    # click 8.4.2 breaks the pager on Windows; check the next
+    # version for https://github.com/pallets/click/pull/3739
+    "click ~= 8.3.3",
     "clickdc ~= 0.1.1",
     "cryptography ~= 50.0.0",
     "Pygments ~= 2.20.0",


### PR DESCRIPTION
## Description

Downgrade `click` to v8.3.3, since v8.4.2 broke the pager on Windows.

Fixes #2100.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
