### PR TITLE
Don't treat dot as separating punctuation in `/config get` completions

### DIFF
--- a/mycli/main_modes/repl.py
+++ b/mycli/main_modes/repl.py
@@ -119,6 +119,7 @@ def complete_while_typing_filter() -> bool:
     text = app.current_buffer.text.lstrip()
     if text.startswith('/') and not text.startswith('/*') and ' ' not in text:
         return True
+    completing_config_property = bool(re.match(r'^(?:/|\\)config\s+get\s+', text, re.IGNORECASE))
     text_len = len(text)
     if text_len < MIN_COMPLETION_TRIGGER:
         return False
@@ -137,7 +138,8 @@ def complete_while_typing_filter() -> bool:
         # limit. We would have to parse the statement, or at least go back more
         # characters, costing performance. This still works within a backtick! So
         # long as there are three trailing non-punctuation characters.
-        return not bool(re.search(r'[\s!-/:-@\[-^\{-~]', last_word))
+        punctuation_check = last_word.replace('.', '') if completing_config_property else last_word
+        return not bool(re.search(r'[\s!-/:-@\[-^\{-~]', punctuation_check))
 
 
 def _create_history(mycli: 'MyCli') -> FileHistoryWithTimestamp | None:

--- a/test/pytests/test_main_modes_repl.py
+++ b/test/pytests/test_main_modes_repl.py
@@ -311,6 +311,31 @@ def test_complete_while_typing_filter_bypasses_threshold_for_initial_slash_comma
     assert repl_mode.complete_while_typing_filter() is expected
 
 
+@pytest.mark.parametrize(
+    ('text', 'expected'),
+    [
+        ('/config get ma', False),
+        ('/config get mai', True),
+        ('/config get main.', True),
+        ('/config get main.s', True),
+        (r'\config get main.', True),
+        ('/CONFIG GET main.', True),
+        ('/config get main.-', False),
+        ('/config search main.', False),
+        ('select main.', False),
+    ],
+)
+def test_complete_while_typing_filter_treats_periods_as_config_property_characters(
+    monkeypatch: pytest.MonkeyPatch,
+    text: str,
+    expected: bool,
+) -> None:
+    monkeypatch.setattr(repl_mode, 'MIN_COMPLETION_TRIGGER', 3)
+    monkeypatch.setattr(repl_mode, 'get_app', lambda: SimpleNamespace(current_buffer=SimpleNamespace(text=text)))
+
+    assert repl_mode.complete_while_typing_filter() is expected
+
+
 def test_complete_while_typing_filter_does_not_treat_block_comments_as_slash_commands(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Description
Unlike the form table.column, `min_completion_trigger` should not reapply in main.property after the period.  Instead, all completions should be offered throughout the string.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
