### PR TITLE
Make links in `README.md` absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ Features
 * Pretty print tabular data (with colors!).
 * Support for SSL connections
 * Shell-style trailing redirects with `$>`, `$>>` and `$|` operators.
-* [Polars](https://pola.rs) dataframe [transforms and plots](doc/transforms.md) with `.|`, and Parquet saves with `.>`.
-* Support for querying LLMs with context derived from your schema using `/llm`.
+* [Polars](https://pola.rs) dataframe [transforms and plots](https://github.com/dbcli/mycli/blob/main/doc/transforms.md) with `.|`, and Parquet saves with `.>`.
+* Support for [querying LLMs](https://www.mycli.net/llm) with context derived from your schema using `/llm`.
 * Support for storing passwords in the system keyring.
 
 Mycli creates a config file `~/.myclirc` on the first run; you can use the
 options in that file to configure the above features, and more.
 
-Some features are only exposed as [key bindings](doc/key_bindings.rst).
+Some features are only exposed as [key bindings](https://github.com/dbcli/mycli/blob/main/doc/key_bindings.rst).
 
 
 Implementation

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,11 @@ Bugfixes
 * Downgrade `click` to v8.3.3, since v8.4.2 broke the pager on Windows.
 
 
+Documentation
+---------
+* Make all links in `README.md` absolute, so that they don't break on PyPi.
+
+
 2.11.0 (2026/08/07)
 ==============
 


### PR DESCRIPTION
## Description
Make links in `README.md` absolute, so that they behave better on PyPi.

Add a link to the LLM documentation on mycli.net.


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
