### PR TITLE
Quoting nit in `client_commands.py`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,11 @@ Documentation
 * Make all links in `README.md` absolute, so that they don't break on PyPi.
 
 
+Internal
+---------
+* Tiny change to quoting in `client_commands.py`.
+
+
 2.11.0 (2026/08/07)
 ==============
 

--- a/mycli/client_commands.py
+++ b/mycli/client_commands.py
@@ -303,7 +303,7 @@ class ClientCommandsMixin:
         if not arg:
             return [SQLResult(status=f'Prompt format: "{self.prompt_format}"')]
 
-        if len(arg) >= 2 and arg[0] == arg[-1] and arg[0] in {'\'', '"'}:
+        if len(arg) >= 2 and arg[0] == arg[-1] and arg[0] in {"'", '"'}:
             arg = arg[1:-1]
 
         self.prompt_format = arg


### PR DESCRIPTION
## Description
Quoting with the alternate character is easier to read than backslashes (for both myself and my editor).


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
