### PR TITLE
Harmonize GitHub description with `pyproject.toml`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ Features
 * Add beta support for HashiCorp Boundary tunnels.
 
 
+Documentation
+---------
+* Harmonize GitHub description and `pyproject.toml` description.
+
+
 Internal
 ---------
 * Remove CRLF line endings from fixture data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mycli"
 dynamic = ["version"]
-description = "CLI for MySQL Database. With auto-completion and syntax highlighting."
+description = "Rich terminal client for MySQL with autocompletion, syntax highlighting, and dataframes"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Description
Harmonize GitHub description with `pyproject.toml`, so that the description line shown on PyPi matches that of GitHub.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
