### PR TITLE
More robust read of JSON returned by boundary CLI tool

### DIFF
--- a/mycli/boundary_tunnel.py
+++ b/mycli/boundary_tunnel.py
@@ -90,8 +90,16 @@ class BoundaryTunnel:
             raise BoundaryTunnelError('Timed out waiting for Boundary tunnel process output.')
 
         connection_details = json.loads(self.stdout)
-        self.username = connection_details['credentials'][0]['secret']['decoded']['username']
-        self.password = connection_details['credentials'][0]['secret']['decoded']['password']
+
+        if 'status_code' in connection_details:
+            raise BoundaryTunnelError(f'Boundary tunnel CLI raised status code {connection_details["status_code"]}.')
+
+        try:
+            self.username = connection_details['credentials'][0]['secret']['decoded']['username']
+            self.password = connection_details['credentials'][0]['secret']['decoded']['password']
+        except (IndexError, KeyError):
+            raise BoundaryTunnelError('Boundary tunnel CLI did not return credentials.') from None
+
         expiry_raw = connection_details['expiration']
         expiry_utc = datetime.datetime.strptime(expiry_raw, '%Y-%m-%dT%H:%M:%S.%f%z')
         expiry_local = datetime.datetime.fromtimestamp(expiry_utc.timestamp())

--- a/test/pytests/test_boundary_tunnel.py
+++ b/test/pytests/test_boundary_tunnel.py
@@ -160,6 +160,41 @@ def test_boundary_tunnel_start_waits_for_process_to_start(monkeypatch: pytest.Mo
     assert sleeps == [0.05]
 
 
+def test_boundary_tunnel_start_reports_cli_status_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    tunnel = BoundaryTunnel(target_id='ttcp_123', local_port=4406)
+    tunnel.stdout = '{"status_code":403}'
+
+    def fake_run() -> None:
+        tunnel._started.set()
+        tunnel._output_ready.set()
+
+    monkeypatch.setattr(tunnel, '_run', fake_run)
+
+    with pytest.raises(BoundaryTunnelError, match='Boundary tunnel CLI raised status code 403'):
+        tunnel.start()
+
+
+@pytest.mark.parametrize(
+    'connection_details',
+    [
+        '{"credentials":[]}',
+        '{"credentials":[{}]}',
+    ],
+)
+def test_boundary_tunnel_start_reports_missing_credentials(monkeypatch: pytest.MonkeyPatch, connection_details: str) -> None:
+    tunnel = BoundaryTunnel(target_id='ttcp_123', local_port=4406)
+    tunnel.stdout = connection_details
+
+    def fake_run() -> None:
+        tunnel._started.set()
+        tunnel._output_ready.set()
+
+    monkeypatch.setattr(tunnel, '_run', fake_run)
+
+    with pytest.raises(BoundaryTunnelError, match='Boundary tunnel CLI did not return credentials'):
+        tunnel.start()
+
+
 def test_boundary_tunnel_start_reports_process_exit_before_ready(monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeStdout:
         def readline(self) -> bytes:


### PR DESCRIPTION
## Description

At the establishment of a tunnel

 * check for a `status_code` property in the emitted JSON and exit with its value if present
 * wrap access of credentials in a `try` block

It might be good to provide for overriding the user/pass with the usual values, in case Boundary is providing only a TCP connection.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
