### PR TITLE
Pause before connecting over Boundary tunnels

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+2.13.1 (2026/08/11)
+==============
+
+Bugfixes
+---------
+* Pause before connecting over Boundary tunnels, to avoid SSL errors.
+
+
 2.13.0 (2026/08/11)
 ==============
 

--- a/mycli/boundary_tunnel.py
+++ b/mycli/boundary_tunnel.py
@@ -15,6 +15,8 @@ from typing import IO
 
 from mycli.compat import WIN
 
+TUNNEL_STABILIZATION_PAUSE = 0.25
+
 
 class BoundaryTunnelError(RuntimeError):
     pass
@@ -146,6 +148,9 @@ class BoundaryTunnel:
             self._raise_if_failed()
             if self._is_listening():
                 self._ready.set()
+                # todo: if this works to ward off SSL errors at connection time,
+                # try making the pause as small as possible
+                time.sleep(TUNNEL_STABILIZATION_PAUSE)
                 return
             time.sleep(0.05)
         self.close()

--- a/test/pytests/test_boundary_tunnel.py
+++ b/test/pytests/test_boundary_tunnel.py
@@ -12,7 +12,11 @@ from typing import Any, cast
 import pytest
 
 from mycli import boundary_tunnel
-from mycli.boundary_tunnel import BoundaryTunnel, BoundaryTunnelError
+from mycli.boundary_tunnel import (
+    TUNNEL_STABILIZATION_PAUSE,
+    BoundaryTunnel,
+    BoundaryTunnelError,
+)
 
 CONNECTION_DETAILS = (
     '{"address":"127.0.0.1","credentials":[{"secret":{"decoded":{"username":"1234","password":"5678"}}}],'
@@ -478,6 +482,7 @@ def test_boundary_tunnel_start_reads_stdout_in_worker_thread(monkeypatch: pytest
     monkeypatch.setattr(tunnel, '_read_stdout', fake_read_stdout)
     checks = iter([False, True])
     monkeypatch.setattr(tunnel, '_is_listening', lambda: next(checks))
+    monkeypatch.setattr(boundary_tunnel.time, 'sleep', lambda _seconds: None)
 
     tunnel.start()
 
@@ -504,6 +509,7 @@ def test_boundary_tunnel_start_authenticates_before_starting_worker(monkeypatch:
     monkeypatch.setattr(tunnel, '_authenticate_if_needed', fake_authenticate)
     monkeypatch.setattr(tunnel, '_run', fake_run)
     monkeypatch.setattr(tunnel, '_is_listening', lambda: True)
+    monkeypatch.setattr(boundary_tunnel.time, 'sleep', lambda _seconds: None)
 
     tunnel.start()
 
@@ -526,7 +532,7 @@ def test_boundary_tunnel_start_waits_for_process_to_start(monkeypatch: pytest.Mo
 
     tunnel.start()
 
-    assert sleeps == [0.05]
+    assert sleeps == [0.05, TUNNEL_STABILIZATION_PAUSE]
 
 
 def test_boundary_tunnel_start_reports_cli_status_code(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Description
The Boundary tunnels might not be quite ready at creation time, as there are some nondeterministic connection errors:

    $ mycli boundary_alias
    Connection to server lost. If this error persists, it may be a mismatch between the server and client SSL configuration. To troubleshoot the issue, try --ssl-mode=off or --ssl-mode=on.
    (2013, 'Lost connection to MySQL server during query')

    $ mycli boundary_alias
    (2003, "Can't connect to MySQL server on '127.0.0.1' ([Errno 22] Invalid argument)")

    $ mycli boundary_alias
    employees> /* worked! */

0.25 seconds might be too long to pause.  Having any pause at all is regrettable, especially for a user driving mycli in a script.

Incidentally update the changelog for a patch release.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
