### PR TITLE
Fix CI by pinning the `openai` library to v2.48.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Internal
+---------
+* Fix CI by pinning the `openai` library to v2.48.0.
+
+
 2.13.1 (2026/08/11)
 ==============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ llm = [
     "llm ~= 0.31.1",
     "setuptools == 83.*",                   # Required by llm commands to install models
     "pip ~= 26.1.2",
+    "openai ~= 2.48.0",                     # openai v3.0.0 broke CI and would need work to support
 ]
 dataframe = [
     "polars ~= 1.42.1",
@@ -100,7 +101,7 @@ include = ["mycli*"]
 
 [tool.uv]
 exclude-newer = '1 week'
-exclude-newer-package = { cli_helpers = false, openai = false, cryptography = false }
+exclude-newer-package = { cli_helpers = false,  cryptography = false }
 
 [tool.ruff]
 target-version = 'py310'


### PR DESCRIPTION
## Description
It looks like additional work would be needed to support `openai` 3.x, (which should be done at some point).  3.x may be importing `httpx`, which is not available.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
