### PR TITLE
Lower Boundary tunnel stabilization pause to 0.15s

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Bug Fixes
+---------
+* Lower Boundary tunnel stabilization pause to 0.15 sec.
+
+
 2.14.0 (2026/08/15)
 ==============
 

--- a/mycli/boundary_tunnel.py
+++ b/mycli/boundary_tunnel.py
@@ -15,7 +15,10 @@ from typing import IO
 
 from mycli.compat import WIN
 
-TUNNEL_STABILIZATION_PAUSE = 0.25
+# This should be as small as possible and yet still
+# ward off SSL errors at connection time.  We know
+# that 0.1 is too small on at least one Mac.
+TUNNEL_STABILIZATION_PAUSE = 0.15
 
 
 class BoundaryTunnelError(RuntimeError):
@@ -148,8 +151,6 @@ class BoundaryTunnel:
             self._raise_if_failed()
             if self._is_listening():
                 self._ready.set()
-                # todo: if this works to ward off SSL errors at connection time,
-                # try making the pause as small as possible
                 time.sleep(TUNNEL_STABILIZATION_PAUSE)
                 return
             time.sleep(0.05)


### PR DESCRIPTION
## Description
Lower Boundary tunnel stabilization pause to 0.15s, updating some commentary around it.

After testing, the connection errors have not happened yet at 0.15 seconds, but have happened at 0.1 seconds.  It is also possible that the threshold would differ on different machines.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
