### PR TITLE
fix favorite query commands documented with a forward slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Features
     - `SELECT * FROM users WHERE <tab>` will only show column names.
 * Support for multiline queries.
 * Favorite queries with positional or named parameters using [Jinja](https://jinja.palletsprojects.com/en/stable/). Save a query using
-  `/fs <alias> <query>` and execute it with `/f <alias>` or `/f <alias> --key=value`.
+  `\fs <alias> <query>` and execute it with `\f <alias>` or `\f <alias> --key=value`.
 * Timing of sql statements and table rendering.
 * Log every query and its results to a file (disabled by default).
 * Pretty print tabular data (with colors!).

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,10 @@ Bug Fixes
 ---------
 * Lower Boundary tunnel stabilization pause to 0.15 sec.
 
+Documentation
+-------------
+* Fix favorite query commands shown with a forward slash instead of a backslash (`/fs` → `\fs`).
+
 
 2.14.0 (2026/08/15)
 ==============

--- a/mycli/packages/special/favoritequeries.py
+++ b/mycli/packages/special/favoritequeries.py
@@ -78,13 +78,13 @@ with a short name.
 Examples:
 
     # Save a new favorite query.
-    > /fs simple SELECT * FROM abc WHERE a IS NOT NULL;
+    > \fs simple SELECT * FROM abc WHERE a IS NOT NULL;
 
     # When multi-line mode is on, pressing Return twice is needed to save.
     # This supports multi-statement favorites.
 
     # List all favorite queries.
-    > /f
+    > \f
     ╒═══════════╤══════════════════════════════════════════════════╕
     │ Name      │ Query                                            │
     ╞═══════════╪══════════════════════════════════════════════════╡
@@ -93,7 +93,7 @@ Examples:
     ╘═══════════╧══════════════════════════════════════════════════╛
 
     # Run a favorite query.
-    > /f simple
+    > \f simple
     ╒════════╤════════╕
     │ a      │ b      │
     ╞════════╪════════╡
@@ -101,20 +101,20 @@ Examples:
     ╘════════╧════════╛
 
     # Run a favorite query containing {{ kv.name }} in the template.
-    > /f find_user --name=henry
-    > /f find_user --name henry
+    > \f find_user --name=henry
+    > \f find_user --name henry
 
     # Run a favorite query containing positional parameter $1 in the
     # template.
-    > /f find_user henry
+    > \f find_user henry
 
     # Use -- to disambiguate positional parameters such as $1, especially
     # if the positional value starts with a dash.
-    > /f query --key=value -- positional-value
-    > /f query -- --positional-value-which-looks-like-a-flag--
+    > \f query --key=value -- positional-value
+    > \f query -- --positional-value-which-looks-like-a-flag--
 
     # Delete a favorite query.
-    > /fd simple
+    > \fd simple
     simple: Deleted.
 """
 


### PR DESCRIPTION
Closes #2141.

The favorite query commands are registered as `\fs` / `\f` / `\fd` (backslash), but the
README and the `\fs`/`\f`/`\fd` help text showed them with a forward slash (`/fs`, `/f`,
`/fd`), so a user following the docs gets an SQL syntax error.

Changes:

- `README.md`: `/fs` → `\fs`, `/f` → `\f`.
- `mycli/packages/special/favoritequeries.py`: correct the `usage` examples
  (`/fs`, `/f`, `/fd` → `\fs`, `\f`, `\fd`).
- `changelog.md`: add a Documentation entry.

Verified against the actual registrations in `mycli/packages/special/iocommands.py`
(`"\\f"`, `"\\fs"`, `"\\fd"`). I left the `@special_command` usage strings there
untouched on purpose — they render the `/` prefix project-wide for every special
command, so changing just the favorite ones would be inconsistent. Say the word if
you'd rather normalize those too.

Docs-only, so no tests changed.
