### PR TITLE
Update `llm` dependencies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Features
 Internal
 ---------
 * Upgrade `pygments` to v2.21.0, removing hacks for `set*` identifiers.
+* Upgrade `llm` dependency to v3.33, removing pin for `openai`.
 
 
 2.16.0 (2026/08/22)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,9 @@ build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
 llm = [
-    "llm ~= 0.31.1",
+    "llm ~= 0.33",
     "setuptools == 83.*",                   # Required by llm commands to install models
     "pip ~= 26.1.2",
-    "openai ~= 2.48.0",                     # openai v3.0.0 broke CI and would need work to support
 ]
 dataframe = [
     "polars ~= 1.42.1",
@@ -101,7 +100,8 @@ include = ["mycli*"]
 
 [tool.uv]
 exclude-newer = '1 week'
-exclude-newer-package = { cli_helpers = false,  pygments = false }
+# TODO: should be able to remove llm and openai from the exceptions after 2026-08-29
+exclude-newer-package = { cli_helpers = false,  openai = false, llm = false, pygments = false }
 
 [tool.ruff]
 target-version = 'py310'


### PR DESCRIPTION
## Description

Update `llm` dependencies

 * update `llm` to latest, v0.33
 * allow newer `llm` in policies
 * remove `openai` pin, allowing v3.3.1
 * allow newer `openai` in policies

It is annoying to evade the cooldown policies like this, but CI was broken without pinning to a 2.x version of `openai`, and `llm`+`openai` are tightly coupled.  We found one combination of the libraries which worked in CI, which unfortunately was newer than the cooldown period.

TODO comment included.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
