### PR TITLE
Pygments cooldown exception is no longer needed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Internal
 ---------
 * Upgrade `pygments` to v2.21.0, removing hacks for `set*` identifiers.
 * Upgrade `llm` dependency to v3.33, removing pin for `openai`.
+* Remove `pygments` cooldown exception as no longer needed.
 
 
 2.16.0 (2026/08/22)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ include = ["mycli*"]
 [tool.uv]
 exclude-newer = '1 week'
 # TODO: should be able to remove llm and openai from the exceptions after 2026-08-29
-exclude-newer-package = { cli_helpers = false,  openai = false, llm = false, pygments = false }
+exclude-newer-package = { cli_helpers = false,  openai = false, llm = false }
 
 [tool.ruff]
 target-version = 'py310'


### PR DESCRIPTION
## Description

The `pygments` cooldown exception is no longer needed, since the desired release is older than one week on PyPi.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
