### PR TITLE
Upgrade mypy and ruff dev dependencies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,8 @@ Internal
 * Upgrade `pygments` to v2.21.0, removing hacks for `set*` identifiers.
 * Upgrade `llm` dependency to v3.33, removing pin for `openai`.
 * Remove `pygments` cooldown exception as no longer needed.
+* Upgrade `mypy` dev dependency to v2.3.1.
+* Upgrade `ruff` dev dependency to v0.16.3.
 
 
 2.16.0 (2026/08/22)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,10 @@ classifiers = [
 ]
 
 dependencies = [
-    # click 8.4.2 breaks the pager on Windows; check the next
-    # version for https://github.com/pallets/click/pull/3739
+    # TODO click 8.4.2 breaks the pager on Windows; check the next
+    # version after 8.4.2 for https://github.com/pallets/click/pull/3739
+    # which has been merged.  The click changelog predicts the next
+    # version to be 8.5.0.
     "click ~= 8.3.3",
     "clickdc ~= 0.1.1",
     "cryptography ~= 50.0.0",
@@ -79,14 +81,14 @@ all = [
 dev = [
     "behave ~= 1.3.3",
     "coverage ~= 7.13.4",
-    "mypy ~= 2.3.0",
+    "mypy ~= 2.3.1",
     "pexpect ~= 4.9.0",
     "pytest ~= 9.1.1",
     "pytest-cov ~= 7.0.0",
     "pytest-random-order ~= 1.2.0",
     "tox ~= 4.35.0",
     "pdbpp ~= 0.11.7",
-    "ruff ~= 0.15.0",
+    "ruff ~= 0.16.3",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Description
 * upgrade `mypy` dev dependency to v2.3.1
 * upgrade `ruff` dev dependency to v0.16.3

Incidentally, tweak a TODO comment.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
