### PR TITLE
Trailing space for default split-line prompt

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Bug Fixes
+--------
+* Default split-line prompt was missing trailing space.
+
+
 2.17.0 (2026/08/25)
 ==============
 

--- a/mycli/client.py
+++ b/mycli/client.py
@@ -52,7 +52,7 @@ sqlparse.engine.grouping.MAX_GROUPING_TOKENS = None  # type: ignore[assignment]
 
 class MyCli(AppStateMixin, OutputMixin, ClientCommandsMixin, ClientConnectionMixin, ClientQueryMixin):
     default_prompt = DEFAULT_PROMPT
-    default_prompt_splitln = "\\u@\\h\\n(\\t):\\d>"
+    default_prompt_splitln = r'\u@\h\n(\t):\d>\_'
     max_len_prompt = 45
     prompt_lines: int
     sqlexecute: SQLExecute | None


### PR DESCRIPTION
## Description

Trailing space for default split-line prompt, just like the regular default prompt.

Fixes #2166 

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
