### PR TITLE
Add Python 3.15 release candidate 1 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15.0-rc.1"]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15.0-rc.1"]
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,12 @@ Bug Fixes
 * Default split-line prompt was missing trailing space.
 
 
+Internal
+--------
+* Add Python 3.15 release candidate 1 to CI.
+* Pin `pydantic_core` LLM transitive dependency to 3.15-friendly 2.48.0.
+
+
 2.17.0 (2026/08/25)
 ==============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,9 @@ build-backend = "setuptools.build_meta"
 [project.optional-dependencies]
 llm = [
     "llm ~= 0.33",
-    "setuptools == 83.*",                   # Required by llm commands to install models
-    "pip ~= 26.1.2",
+    "setuptools == 83.*",              # Required by llm commands to install models
+    "pip ~= 26.1.2",                   # Required by llm commands to install models
+    "pydantic_core ~= 2.48.0",         # Force a version with 3.15 binary wheels for faster CI
 ]
 dataframe = [
     "polars ~= 1.42.1",
@@ -82,6 +83,7 @@ dev = [
     "behave ~= 1.3.3",
     "coverage ~= 7.13.4",
     "mypy ~= 2.3.1",
+    "ast-serialize ~= 0.8.0",         # Force a version with 3.15 binary wheels for faster CI
     "pexpect ~= 4.9.0",
     "pytest ~= 9.1.1",
     "pytest-cov ~= 7.0.0",


### PR DESCRIPTION
## Description
Add Python 3.15 release candidate 1 to CI.

Requires pinning some transitive dependencies to versions with binary wheels for 3.15, to keep from building the dependencies from scratch in CI (very slow).

 * pydantic_core to v2.48.0
 * ast-serialize to v0.8.0

Release will be in one month.  Time to start testing.

Note: RC2 is expected 2026-09-01.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
