### PR TITLE
Add line breaks between `README.md` screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Documentation: [https://mycli.net/docs](https://mycli.net/docs)
 
 <div align="center">
   <img alt="Completion" src="https://raw.githubusercontent.com/dbcli/mycli/main/doc/screenshots/tables.png">
+  </br>
+  </br>
   <img alt="CompletionGif" src="https://raw.githubusercontent.com/dbcli/mycli/main/doc/screenshots/main.gif">
 </div>
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Documentation
+--------
+* Add line breaks between `README.md` screenshots.
+
+
 2.18.0 (2026/08/29)
 ==============
 


### PR DESCRIPTION
## Description

Add line breaks between `README.md` screenshots.

The README spacing looks particularly bad on PyPi.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
