### PR TITLE
Fix incomplete release of Boundary tunnels from beta

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Bug Fixes
+--------
+* Fix incomplete release of Boundary tunnels from beta.
+
+
 2.18.4 (2026/08/29)
 ==============
 

--- a/mycli/client_connection.py
+++ b/mycli/client_connection.py
@@ -132,12 +132,12 @@ class ClientConnectionMixin:
                 sys.exit(1)
         elif boundary_target_id:
             use_keyring = False
-            boundary_executable = self.config.get('boundary_beta', {}).get('boundary_executable', 'boundary') or 'boundary'
-            boundary_address = self.config.get('boundary_beta', {}).get('address') or None
-            boundary_auth_method_id = self.config.get('boundary_beta', {}).get('auth_method_id') or None
-            boundary_options = self.config.get('boundary_beta', {}).get('boundary_options') or None
-            boundary_test_command = self.config.get('boundary_beta', {}).get('boundary_test_command') or None
-            boundary_auth_command = self.config.get('boundary_beta', {}).get('boundary_auth_command') or None
+            boundary_executable = self.config.get('boundary', {}).get('boundary_executable', 'boundary') or 'boundary'
+            boundary_address = self.config.get('boundary', {}).get('address') or None
+            boundary_auth_method_id = self.config.get('boundary', {}).get('auth_method_id') or None
+            boundary_options = self.config.get('boundary', {}).get('boundary_options') or None
+            boundary_test_command = self.config.get('boundary', {}).get('boundary_test_command') or None
+            boundary_auth_command = self.config.get('boundary', {}).get('boundary_auth_command') or None
             try:
                 self.boundary_tunnel = BoundaryTunnel(
                     target_id=boundary_target_id,

--- a/test/pytests/test_client_connection.py
+++ b/test/pytests/test_client_connection.py
@@ -740,7 +740,7 @@ def test_connect_uses_boundary_tunnel(
     client = DummyClient(
         config={
             'main': {'password_sources': KNOWN_PASSWORD_SOURCES},
-            'boundary_beta': {
+            'boundary': {
                 'boundary_executable': '/opt/bin/boundary',
                 'address': 'https://boundary.example.com',
                 'auth_method_id': 'ampw_123',


### PR DESCRIPTION
## Description
The rename of the `[boundary_beta]` section of myclirc was not completed.

xref #2170

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
