### PR TITLE
Remove `pyproject.toml` llm library cooldown policy exceptions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Bug Fixes
 Internal
 ---------
 * Upgrade `sqlglot` to v30.17.0.
+* Remove `pyproject.toml` llm library cooldown policy exceptions.
 
 
 2.18.4 (2026/08/29)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     # TODO click 8.4.2 breaks the pager on Windows; check the next
     # version after 8.4.2 for https://github.com/pallets/click/pull/3739
     # which has been merged.  The click changelog predicts the next
-    # version to be 8.5.0.
+    # version to be 8.5.0, which can be merged around 2 Sep 2026.
     "click ~= 8.3.3",
     "clickdc ~= 0.1.1",
     "cryptography ~= 50.0.0",
@@ -102,8 +102,7 @@ include = ["mycli*"]
 
 [tool.uv]
 exclude-newer = '1 week'
-# TODO: should be able to remove llm and openai from the exceptions after 2026-08-29
-exclude-newer-package = { cli_helpers = false,  openai = false, llm = false }
+exclude-newer-package = { cli_helpers = false }
 
 [tool.ruff]
 target-version = 'py310'


### PR DESCRIPTION
## Description
Having exceptions to the policy was never a great idea, but it was needed because we were otherwise stuck.

Incidentally add a comment on the availability of `click` v8.5.0.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
