### PR TITLE
Hide timings after `/system clear`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Upcoming (TBD)
 Features
 --------
 * Add `/ping` special command.
+* Hide timings after `/system clear`.
 
 
 Documentation

--- a/mycli/packages/special/iocommands.py
+++ b/mycli/packages/special/iocommands.py
@@ -787,8 +787,9 @@ def execute_system_command(arg: str, **_) -> list[SQLResult]:
             completed_process = subprocess.run(command, check=False)
             if completed_process.returncode:
                 return [SQLResult(status=f'Command exited with return code {completed_process.returncode}')]
-            else:
-                return [SQLResult()]
+            if command[0].lower() == 'clear':
+                return []
+            return [SQLResult()]
         else:
             process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             try:

--- a/test/pytests/test_special_iocommands.py
+++ b/test/pytests/test_special_iocommands.py
@@ -1491,6 +1491,7 @@ def test_execute_system_command_usage_parse_and_cd(monkeypatch) -> None:
     [
         ('-r echo ok', 0, None),
         ('vim file.sql', 1, 'Command exited with return code 1'),
+        ('clear', 1, 'Command exited with return code 1'),
     ],
 )
 def test_execute_system_command_raw_modes(
@@ -1510,6 +1511,20 @@ def test_execute_system_command_raw_modes(
 
     assert calls
     assert result.status == expected_status
+
+
+@pytest.mark.parametrize('command', ['clear', 'CLEAR', '-r clear'])
+def test_execute_system_clear_returns_no_result(monkeypatch, command: str) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], check: bool = False) -> SimpleNamespace:
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(iocommands.subprocess, 'run', fake_run)
+
+    assert iocommands.execute_system_command(command) == []
+    assert calls == [[part for part in command.split() if part != '-r']]
 
 
 def test_execute_system_command_nonraw_paths(monkeypatch) -> None:


### PR DESCRIPTION

## Description
Special case `/system clear` to show no timing info.  When the user asks to clear the screen, they probably want to clear the screen, not "clear the screen except for some timing info".

Motivation: this is helpful when making screenshots.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
