### PR TITLE
Upgrade optional `pip` dependency to v26.2.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ Internal
 ---------
 * Upgrade `polars` dependency to v1.44.1.
 * Upgrade `sqlparse` dependency to v0.6.0.
+* Upgrade optional `pip` dependency to v26.2.1.
 
 
 2.18.5 (2026/08/31)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ build-backend = "setuptools.build_meta"
 llm = [
     "llm ~= 0.33",
     "setuptools == 83.*",                   # Required by llm commands to install models
-    "pip ~= 26.1.2",
+    "pip ~= 26.2.1",
 ]
 dataframe = [
     "polars ~= 1.44.1",


### PR DESCRIPTION
## Description
Upgrade optional `pip` dependency to v26.2.1.

Motivation: `uv audit` now runs clean.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
