### PR TITLE
Use cache and turn off distro update for WSL tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,8 @@ jobs:
       - uses: vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
         with:
           distribution: Ubuntu-24.04
-          update: 'true'
+          use-cache: 'true'
+          update: 'false'
           additional-packages: |
             curl
             git

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -159,7 +159,8 @@ jobs:
     - uses: vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
       with:
         distribution: Ubuntu-24.04
-        update: 'true'
+        use-cache: 'true'
+        update: 'false'
         additional-packages: |
           curl
           git

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@ Internal
 * Upgrade `polars` dependency to v1.44.1.
 * Upgrade `sqlparse` dependency to v0.6.0.
 * Upgrade optional `pip` dependency to v26.2.1.
+* Use cache and turn off distro update for WSL tests in CI.
 
 
 2.18.5 (2026/08/31)


### PR DESCRIPTION
## Description
Use cache and turn off distro update for WSL tests in CI.

Motivation: performance.  The WSL test is always the last to finish.

Result: reduced runtime from 5 minutes to 3 minutes.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
