### PR TITLE
Upgrade WSL OS to Ubuntu 26.04 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
     steps:
       - uses: vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
         with:
-          distribution: Ubuntu-24.04
+          distribution: Ubuntu-26.04
           use-cache: 'true'
           update: 'false'
           additional-packages: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -158,7 +158,7 @@ jobs:
     steps:
     - uses: vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
       with:
-        distribution: Ubuntu-24.04
+        distribution: Ubuntu-26.04
         use-cache: 'true'
         update: 'false'
         additional-packages: |

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ Internal
 * Upgrade `sqlparse` dependency to v0.6.0.
 * Upgrade optional `pip` dependency to v26.2.1.
 * Use cache and turn off distro update for WSL tests in CI.
+* Upgrade WSL OS to Ubuntu 26.04 in for tests in CI.
 
 
 2.18.5 (2026/08/31)


### PR DESCRIPTION
## Description
Upgrade WSL OS to Ubuntu 26.04 in CI, from Ubuntu 24.04.

Motivation: more users are probably on the latest OS.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
