### PR TITLE
Add `/system` special cases to TIPS

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Features
 Documentation
 --------
 * Minor edits to `README.md`.
+* Add `/system` special cases to TIPS.
 
 
 Internal

--- a/mycli/TIPS
+++ b/mycli/TIPS
@@ -106,6 +106,10 @@ use /tee or /notee to write/stop-writing results to a output file!
 
 use "/system <command>" to execute a shell command!
 
+use "/system cd" to change the working directory!
+
+use "/system clear" to clear the screen!
+
 /T or /tableformat changes the interactive table format!
 
 /u or /use changes to a new database!


### PR DESCRIPTION
## Description
`/system` special-cases two commands: `cd` and `clear`.  Add these to TIPS.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
