### PR TITLE
Upgrade `click` dependency to v8.5.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ Internal
 * Upgrade `sqlparse` dependency to v0.6.0.
 * Upgrade optional `pip` dependency to v26.2.1.
 * Use cache and turn off distro update for WSL tests in CI.
+* Upgrade `click` dependency to v8.5.0.
 
 
 2.18.5 (2026/08/31)

--- a/mycli/main_modes/batch.py
+++ b/mycli/main_modes/batch.py
@@ -214,9 +214,8 @@ def main_batch_without_progress_bar(mycli: 'MyCli', cli_args: 'CliArgs') -> int:
 
 
 def main_batch_from_stdin(mycli: 'MyCli', cli_args: 'CliArgs') -> int:
-    batch_h = click.get_text_stream('stdin')
     try:
-        for statement, counter in statements_from_filehandle(batch_h):
+        for statement, counter in statements_from_filehandle(sys.stdin):
             dispatch_batch_statements(mycli, cli_args, statement, counter)
     except (ValueError, StopIteration, IOError, OSError, pymysql.err.Error) as e:
         click.secho(str(e), err=True, fg='red')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,7 @@ classifiers = [
 ]
 
 dependencies = [
-    # TODO click 8.4.2 breaks the pager on Windows; check the next
-    # version after 8.4.2 for https://github.com/pallets/click/pull/3739
-    # which has been merged.  The click changelog predicts the next
-    # version to be 8.5.0, which can be merged around 2 Sep 2026.
-    "click ~= 8.3.3",
+    "click ~= 8.5.0",
     "clickdc ~= 0.1.1",
     "cryptography ~= 50.0.0",
     "Pygments ~= 2.21.0",

--- a/test/pytests/test_main_modes_batch.py
+++ b/test/pytests/test_main_modes_batch.py
@@ -798,9 +798,7 @@ def test_main_batch_without_progress_bar_returns_error_when_iteration_fails(monk
 
 def test_main_batch_from_stdin_processes_statements(monkeypatch) -> None:
     dispatch_calls: list[tuple[str, int]] = []
-    batch_handle = object()
 
-    monkeypatch.setattr(batch_mode.click, 'get_text_stream', lambda _name: batch_handle)
     monkeypatch.setattr(batch_mode, 'statements_from_filehandle', lambda _handle: iter([('select 1;', 0), ('select 2;', 1)]))
     monkeypatch.setattr(
         batch_mode,
@@ -817,7 +815,6 @@ def test_main_batch_from_stdin_processes_statements(monkeypatch) -> None:
 def test_main_batch_from_stdin_returns_error_for_value_errors(monkeypatch) -> None:
     messages: list[tuple[str, bool, str]] = []
 
-    monkeypatch.setattr(batch_mode.click, 'get_text_stream', lambda _name: object())
     monkeypatch.setattr(batch_mode, 'statements_from_filehandle', lambda _handle: (_ for _ in ()).throw(ValueError('bad stdin')))
     monkeypatch.setattr(batch_mode.click, 'secho', lambda message, err, fg: messages.append((message, err, fg)))
 


### PR DESCRIPTION
## Description

This should include a Windows pager fix which had kept us on v8.3.3.

Requires avoiding a deprecated method `get_text_stream()`.

xref #2100

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
