### PR TITLE
Make badge colors match in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mycli
 
 [![Build Status](https://github.com/dbcli/mycli/workflows/mycli/badge.svg)](https://github.com/dbcli/mycli/actions?query=workflow%3Amycli)
-[![License](https://img.shields.io/github/license/dbcli/mycli.svg)](https://github.com/dbcli/mycli/blob/main/LICENSE.txt)
+[![License](https://img.shields.io/github/license/dbcli/mycli.svg?color=2FC745)](https://github.com/dbcli/mycli/blob/main/LICENSE.txt)
 
 Rich MySQL terminal client with auto-completion, syntax highlighting, and dataframes.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Documentation
+--------
+* Badge color nit in `README.md`.
+
+
 2.19.0 (2026/09/02)
 ==============
 


### PR DESCRIPTION
## Description
The two greens were just different enough to look weird together.


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
