### PR TITLE
Upgrade `ruff` dev dependency to v0.16.5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Internal
 ---------
 * Upgrade `cryptography` dependency to v50.0.1.
 * Upgrade `rapidfuzz` dependency to v3.14.5.
+* Upgrade `ruff` dev dependency to v0.16.5.
 
 
 2.19.0 (2026/09/02)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ dev = [
     "pytest-random-order ~= 1.2.0",
     "tox ~= 4.35.0",
     "pdbpp ~= 0.11.7",
-    "ruff ~= 0.16.3",
+    "ruff ~= 0.16.5",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Description
Upgrade `ruff` dev dependency to v0.16.5.

No format/lint changes were needed.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
