### PR TITLE
Update `coverage`/`pytest-cov` dev dependencies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,8 @@ Internal
 * Upgrade `cryptography` dependency to v50.0.1.
 * Upgrade `rapidfuzz` dependency to v3.14.5.
 * Upgrade `ruff` dev dependency to v0.16.5.
+* Upgrade `coverage` dev dependency to v7.15.4.
+* Upgrade `pytest-cov` dev dependency to v7.1.0.
 
 
 2.19.0 (2026/09/02)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,11 +76,11 @@ all = [
 ]
 dev = [
     "behave ~= 1.3.3",
-    "coverage ~= 7.13.4",
+    "coverage ~= 7.15.4",
     "mypy ~= 2.3.1",
     "pexpect ~= 4.9.0",
     "pytest ~= 9.1.1",
-    "pytest-cov ~= 7.0.0",
+    "pytest-cov ~= 7.1.0",
     "pytest-random-order ~= 1.2.0",
     "tox ~= 4.35.0",
     "pdbpp ~= 0.11.7",


### PR DESCRIPTION
## Description
* Upgrade `coverage` dev dependency to v7.15.4.
* Upgrade `pytest-cov` dev dependency to v7.1.0.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
