### PR TITLE
Raise Boundary tunnel stabilization pause to 0.2s

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Bug Fixes
+--------
+* Raise Boundary tunnel stabilization pause to 0.2 sec.
+
+
 2.20.0 (2026/09/05)
 ==============
 

--- a/mycli/boundary_tunnel.py
+++ b/mycli/boundary_tunnel.py
@@ -17,8 +17,8 @@ from mycli.compat import WIN
 
 # This should be as small as possible and yet still
 # ward off SSL errors at connection time.  We know
-# that 0.1 is too small on at least one Mac.
-TUNNEL_STABILIZATION_PAUSE = 0.15
+# that 0.15 is too small on at least one Mac.
+TUNNEL_STABILIZATION_PAUSE = 0.20
 
 
 class BoundaryTunnelError(RuntimeError):


### PR DESCRIPTION
## Description
Raise Boundary tunnel stabilization pause to 0.2s, after observing one transient connection failure.

This value was previously 0.25 with no observed failures, so the new value of 0.2 is probably right.


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
