### PR TITLE
fix zsh completion test harness when PREFIX is exported

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ Bug Fixes
 * Raise Boundary tunnel stabilization pause to 0.2 sec.
 
 
+Internal
+---------
+* Fix the zsh completion test harness when `PREFIX` is exported.
+
+
 2.20.0 (2026/09/05)
 ==============
 

--- a/mycli/AUTHORS
+++ b/mycli/AUTHORS
@@ -119,6 +119,7 @@ Contributors:
   * Linuxdazhao
   * Puneet Dixit
   * Liu Zhenlong
+  * Chris Burr
 
 
 Created by:

--- a/test/pytests/test_zsh_completion.py
+++ b/test/pytests/test_zsh_completion.py
@@ -86,7 +86,7 @@ _path_files() {
 }
 
 typeset -a captured compset_calls path_file_calls
-typeset PREFIX IPREFIX used_unambiguous
+typeset PREFIX='' IPREFIX='' used_unambiguous=''
 compadd() {
     local array_name=''
     local candidate


### PR DESCRIPTION
## Description

When packaging for conda-forge `$PREFIX` is set as an environment variable. This ends up causing `test_zsh_completion_lists_dsn_aliases_in_supported_contexts` to fail due ot zsh's `typeset NAME` printing `NAME=value` when the parameter already exists, so with PREFIX exported the harness writes an extra line to stdout and the captured completion output no longer matches.

Setting it to `''` avoids this issue and makes things consistent.


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
