### PR TITLE
Reformat and linkify the server compatibility list in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,17 @@ Documentation: [https://mycli.net/docs](https://mycli.net/docs)
   <img alt="CompletionGif" src="https://raw.githubusercontent.com/dbcli/mycli/main/doc/screenshots/main.gif">
 </div>
 
-Mycli is compatible with MySQL, MariaDB, Percona, TiDB, and Apache Doris.
+Mycli is known to be compatible with
 
-Postgres Equivalent: [https://pgcli.com](https://pgcli.com)
+ * [MySQL](https://www.mysql.com/)
+ * [MariaDB](https://mariadb.org/)
+ * [Percona](https://www.percona.com/)
+ * [TiDB](https://www.pingcap.com/)
+ * [Apache Doris](https://doris.apache.org/)
+
+Postgres equivalent
+
+ * [pgcli](https://pgcli.com)
 
 # Release 2.x
 

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,11 @@ Bug Fixes
 * Fix pathname completions ignoring `~/` and `/` initial directories.
 
 
+Documentation
+--------
+* Add some links to `README.md` and format compatible servers with bullets.
+
+
 Internal
 ---------
 * Fix the zsh completion test harness when `PREFIX` is exported.


### PR DESCRIPTION
## Description
Reformat and linkify the server compatibility list in `README.md`, and format the link to pgcli similarly for readability.

We could mention somewhere lower down that we are "known to be compatible" with multiple servers but only tested against MySQL in CI.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
