### PR TITLE
Reduce warnings in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.14
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends --no-install-suggests -qq \
     fzf \
@@ -10,6 +12,6 @@ RUN apt-get update -qq && \
 
 COPY . /app
 
-RUN cd /app && pip install -e .[llm,dataframe]
+RUN cd /app && pip install --root-user-action -e .[llm,dataframe]
 
 CMD ["mycli", "--help"]


### PR DESCRIPTION
## Description
 * reduce warnings/retries from `apt-get` trying to use interactive frontends via environment variable
 * set `--root-user-action` to remove pip warning

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
