### PR TITLE
Add `docker run` example for ghcr.io in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,14 @@ Fedora has a package available for mycli; install it using dnf.  The `fzf` and
 sudo dnf install mycli fzf python-pygments
 ```
 
+### Docker
+
+The images on Dockerhub are out of date.  ghcr.io is preferred.  Example:
+
+```
+docker run -it ghcr.io/dbcli/mycli:latest mycli --help
+```
+
 ### Windows
 
 #### Option 1: Native Windows

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+2.21.1 (2026/09/07)
+==============
+
+Documentation
+--------
+* Show `docker run` example for ghcr.io in `README.md`.
+
+
 2.21.0 (2026/09/07)
 ==============
 


### PR DESCRIPTION
## Description
Add `docker run` example for ghcr.io in `README.md`, and update changelog for release.

Fixes #1048.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
