### PR TITLE
Add `--pull=always` to documented `docker run` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ sudo dnf install mycli fzf python-pygments
 The images on Dockerhub are out of date.  ghcr.io is preferred.  Example:
 
 ```
-docker run -it ghcr.io/dbcli/mycli:latest mycli --help
+docker run --pull=always -it ghcr.io/dbcli/mycli:latest mycli --help
 ```
 
 ### Windows

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Documentation
+--------
+* Add `--pull=always` to documented `docker run` command.
+
+
 2.22.0 (2026/09/09)
 ==============
 


### PR DESCRIPTION
## Description
This will ensure that the user always runs the latest image.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
