### PR TITLE
Tokenize a leading slash or backslash as a symbol name

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ Features
 * Include a MariaDB server and example data in the Docker image.
 
 
+Bug Fixes
+--------
+* Tokenize leading `/` and `\` as symbol names for better highlighting.
+
+
 Documentation
 --------
 * Add `--pull=always` to documented `docker run` command.

--- a/mycli/lexer.py
+++ b/mycli/lexer.py
@@ -1,6 +1,6 @@
 from pygments.lexer import inherit
 from pygments.lexers.sql import MySqlLexer
-from pygments.token import Keyword
+from pygments.token import Keyword, Name
 
 
 class MyCliLexer(MySqlLexer):
@@ -8,6 +8,7 @@ class MyCliLexer(MySqlLexer):
 
     tokens = {
         "root": [
+            (r'^[/\\]', Name),
             (r"\brepair\b", Keyword),
             (r"\boffset\b", Keyword),
             inherit,


### PR DESCRIPTION
## Description
Tokenize a leading slash or backslash as a symbol name, so that in _eg_ `/help`, the characters should all be highly visible and have the same color.


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
