### PR TITLE
Set `docker` output-type on ghcr.io images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -305,6 +305,9 @@ jobs:
       with:
         context: .
         file: docker/Dockerfile
+        # avoids pull error: unsupported media type application/vnd.oci.empty.v1+json
+        # by publishing a v2 mediaType
+        load: true
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,10 @@
-Upcoming (TBD)
+2.24.1 (2026/09/12)
 ==============
 
 Bug Fixes
 --------
 * Omitted completion-candidate methods are no longer applied at all.
+* Set `docker` output-type on ghcr.io images.
 
 
 2.24.0 (2026/09/12)


### PR DESCRIPTION
## Description
Set `docker` output-type on ghcr.io images, in an attempt to avoid the following error on `docker pull`:

    unsupported media type application/vnd.oci.empty.v1+json

which happens when copying the headlined GitHub instructions at

 * https://github.com/dbcli/mycli/pkgs/container/mycli

which pulls by SHA (rather than using our `README.md` which shows how to pull by tag).

Q: Could the problem also have to do with merge commits?

Incidentally update the changelog for release v2.24.1 .

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
