### PR TITLE
Add `artifact-metadata: write` publish permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -281,6 +281,7 @@ jobs:
       packages: write
       attestations: write
       id-token: write
+      artifact-metadata: write
 
     steps:
     - name: Checkout repository
@@ -305,9 +306,6 @@ jobs:
       with:
         context: .
         file: docker/Dockerfile
-        # avoids pull error: unsupported media type application/vnd.oci.empty.v1+json
-        # by publishing a v2 mediaType
-        load: true
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+2.24.2 (2026/09/12)
+==============
+
+Bug Fixes
+--------
+* Revert `docker` output-type on ghcr.io images.
+* Set `artifact-metadata: write` in `publish.yml`.
+
+
+
 2.24.1 (2026/09/12)
 ==============
 


### PR DESCRIPTION
## Description

Add `artifact-metadata: write` publish permissions, in an attempt to avoid the `docker pull` error

    unsupported media type application/vnd.oci.empty.v1+json

removing `load: true` which had no effect, and bumping the release version in the changelog.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
