### PR TITLE
Remove explicit `subject-digest` from ghcr.io publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -314,5 +314,4 @@ jobs:
       uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
       with:
         subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-        subject-digest: ${{ steps.push.outputs.digest }}
         push-to-registry: true

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+2.24.3 (2026/09/12)
+==============
+
+Bug Fixes
+--------
+* Remove explicit `subject-digest` from ghcr.io publish action.
+
+
 2.24.2 (2026/09/12)
 ==============
 


### PR DESCRIPTION
## Description
Remove explicit `subject-digest` from ghcr.io publish, and let it be computed implicitly by the Action.

This is an attempt to solve the `docker pull` error

    unsupported media type application/vnd.oci.empty.v1+json

Incidentally update the changelog for release v2.24.3 .


## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
