### PR TITLE
Remove `continue-on-error` from release tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,6 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     needs: [docs]
-    continue-on-error: true
 
     strategy:
       matrix:

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+Upcoming (TBD)
+==============
+
+Internal
+--------
+* Remove `continue-on-error` from release tests.
+
+
 2.24.3 (2026/09/12)
 ==============
 


### PR DESCRIPTION
## Description
The tests are no longer so flaky as to warrant using continue-on-error.

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
