### PR TITLE
Remove artifact attestations from ghcr.io images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -308,9 +308,3 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-
-    - name: Generate artifact attestation
-      uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-      with:
-        subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-        push-to-registry: true

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
-Upcoming (TBD)
+2.24.4 (2026/09/12)
 ==============
+
+Bug Fixes
+--------
+* Remove artifact attestations from ghcr.io images, fixing package examples.
+
 
 Internal
 --------
@@ -21,7 +26,6 @@ Bug Fixes
 --------
 * Revert `docker` output-type on ghcr.io images.
 * Set `artifact-metadata: write` in `publish.yml`.
-
 
 
 2.24.1 (2026/09/12)


### PR DESCRIPTION
## Description
Artifact attestations are great, but this causes the headline suggestion at

 * https://github.com/dbcli/mycli/pkgs/container/mycli

to be a `docker pull` command which fails, giving

    unsupported media type application/vnd.oci.empty.v1+json

A number of fixes were tried in the v2.24.x series before giving up and removing attestations.

Some permissions could probably also be removed from `publish.yml`.

Incidentally update the changelog for release v2.24.4 .

## Checklist
<!--- We appreciate your help and want to give you credit. Place an `x` in the boxes below as you complete them. -->
- [x] I added this contribution to the `changelog.md` file.
- [x] I added my name to the `AUTHORS` file (or it's already there).
- [x] To lint and format the code, I ran
    ```bash
    uv run ruff check && uv run ruff format && uv run mypy --install-types .
    ```
